### PR TITLE
Ge object timer

### DIFF
--- a/source/gameengine/Expressions/EXP_IntValue.h
+++ b/source/gameengine/Expressions/EXP_IntValue.h
@@ -34,6 +34,7 @@ public:
 	virtual int				GetValueType();
 	
 	cInt GetInt();
+	void SetInt(int i);
 	CIntValue();
 	CIntValue(cInt innie);
 	CIntValue(cInt innie,

--- a/source/gameengine/Expressions/intern/IntValue.cpp
+++ b/source/gameengine/Expressions/intern/IntValue.cpp
@@ -282,6 +282,12 @@ CValue* CIntValue::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *v
 }
 
 
+void CIntValue::SetInt(int i)
+{
+	m_int = (cInt) i;
+}
+
+
 /**
  * pre:
  * ret: the cInt stored in the object

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2381,11 +2381,10 @@ PyObject *KX_GameObject::pyattr_get_life(void *self_v, const KX_PYATTRIBUTE_DEF 
 {
 	KX_GameObject* self = static_cast<KX_GameObject*>(self_v);
 
-	CValue *life = self->GetProperty("::timebomb");
+	CIntValue *life = (CIntValue*) self->GetProperty("::timebomb");
 	if (life)
-		// this convert the timebomb seconds to frames, hard coded 50.0f (assuming 50fps)
-		// value hardcoded in KX_Scene::AddReplicaObject()
-		return PyFloat_FromDouble(life->GetNumber() * 50.0);
+		// Set in KX_Scene::AddReplicaObject()
+		return PyLong_FromLongLong(life->GetInt());
 	else
 		Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -905,13 +905,11 @@ SCA_IObject* KX_Scene::AddReplicaObject(class CValue* originalobject,
 	// lifespan of zero means 'this object lives forever'
 	if (lifespan > 0)
 	{
-		// for now, convert between so called frames and realtime
 		m_tempObjectList->Add(replica->AddRef());
-		// this convert the life from frames to sort-of seconds, hard coded 0.02 that assumes we have 50 frames per second
 		// if you change this value, make sure you change it in KX_GameObject::pyattr_get_life property too
-		CValue *fval = new CFloatValue(lifespan*0.02f);
-		replica->SetProperty("::timebomb",fval);
-		fval->Release();
+		CValue *ival = new CIntValue(lifespan);
+		replica->SetProperty("::timebomb",ival);
+		ival->Release();
 	}
 
 	// add to 'rootparent' list (this is the list of top hierarchy objects, updated each frame)
@@ -1557,15 +1555,15 @@ void KX_Scene::LogicBeginFrame(double curtime)
 	for (int i = lastobj; i >= 0; i--)
 	{
 		CValue* objval = m_tempObjectList->GetValue(i);
-		CFloatValue* propval = (CFloatValue*) objval->GetProperty("::timebomb");
+		CIntValue* propval = (CIntValue*) objval->GetProperty("::timebomb");
 		
 		if (propval)
 		{
-			float timeleft = (float)(propval->GetNumber() - 1.0/KX_KetsjiEngine::GetTicRate());
+			int timeleft = propval->GetInt() - 1;
 			
 			if (timeleft > 0)
 			{
-				propval->SetFloat(timeleft);
+				propval->SetInt(timeleft);
 			}
 			else
 			{


### PR DESCRIPTION
Makes the add object timer count frames as advertised.  Before, it was converting frames to seconds at a hard-coded rate of 50fps, which sometimes resulted in unexpected behavior.
Resolves #68