### PR TITLE
recalculating normals patch

### DIFF
--- a/source/gameengine/Ketsji/KX_MeshProxy.h
+++ b/source/gameengine/Ketsji/KX_MeshProxy.h
@@ -79,6 +79,7 @@ public:
 	KX_PYMETHOD(KX_MeshProxy, GetPolygon);
 	KX_PYMETHOD(KX_MeshProxy, Transform);
 	KX_PYMETHOD(KX_MeshProxy, TransformUV);
+	KX_PYMETHOD(KX_MeshProxy, RecalculateNormals);
 
 	static PyObject *pyattr_get_materials(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_numMaterials(void *self, const KX_PYATTRIBUTE_DEF *attrdef);


### PR DESCRIPTION
After moving a mesh's vertices with python (like when generating terrain) you have to recalculate the mesh's normals with python, which can be painfully slow. This adds recalculateNormals(material_ID) to KX_MeshProxy to speed things up. 