### PR TITLE
Fix screenshot crash

### DIFF
--- a/source/gameengine/Rasterizer/RAS_ICanvas.cpp
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.cpp
@@ -92,14 +92,12 @@ void save_screenshot_thread_func(TaskPool *__restrict UNUSED(pool), void *taskda
 	ibuf->rect = task->dumprect;
 	
 	BKE_imbuf_write_as(ibuf, task->path, task->im_format, false);
+	MEM_freeN(task->path);
 	task->path = NULL;
 	ibuf->rect = NULL;
 	task->im_format = NULL;
 	task->dumprect = NULL;
 	IMB_freeImBuf(ibuf);
-	//MEM_freeN(task->dumprect);
-	//MEM_freeN(task->path);
-	//MEM_freeN(task->im_format);
 }
 
 

--- a/source/gameengine/Rasterizer/RAS_ICanvas.cpp
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.cpp
@@ -90,14 +90,16 @@ void save_screenshot_thread_func(TaskPool *__restrict UNUSED(pool), void *taskda
 	/* create and save imbuf */
 	ImBuf *ibuf = IMB_allocImBuf(task->dumpsx, task->dumpsy, 24, 0);
 	ibuf->rect = task->dumprect;
-
+	
 	BKE_imbuf_write_as(ibuf, task->path, task->im_format, false);
-
+	task->path = NULL;
 	ibuf->rect = NULL;
+	task->im_format = NULL;
+	task->dumprect = NULL;
 	IMB_freeImBuf(ibuf);
-	MEM_freeN(task->dumprect);
-	MEM_freeN(task->path);
-	MEM_freeN(task->im_format);
+	//MEM_freeN(task->dumprect);
+	//MEM_freeN(task->path);
+	//MEM_freeN(task->im_format);
 }
 
 


### PR DESCRIPTION
since openGL refactor, crash when screenshot.
I don't understand why, but this patch seems to fix the issue.
task->dumprect, path, im_format freed in another function and save
screenshot_thread_func try to access a NULL pointer with MEM_freeN?

test file: http://www.pasteall.org/blend/41545