### PR TITLE
Implementation of KX_Filter proxy to set uniforms

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -11,9 +11,9 @@ base class --- :class:`PyObjectPlus`
 
    TODO - Description
 
-   .. attribute:: enable
+   .. attribute:: enabled
 
-      Enable/Disable shader.
+      Set shader enabled to use.
 
       :type: boolean
 

--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -11,6 +11,12 @@ base class --- :class:`PyObjectPlus`
 
    TODO - Description
 
+   .. attribute:: enabled
+
+      Set shader enabled to use.
+
+      :type: boolean
+
    .. method:: setUniformfv(name, fList)
 
       Set a uniform with a list of float values

--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -11,9 +11,9 @@ base class --- :class:`PyObjectPlus`
 
    TODO - Description
 
-   .. attribute:: enabled
+   .. attribute:: enable
 
-      Set shader enabled to use.
+      Enable/Disable shader.
 
       :type: boolean
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -1,0 +1,20 @@
+KX_2DFilter(BL_Shader)
+======================
+
+.. module:: bge.types
+
+base class --- :class:`BL_Shader`
+
+.. class:: KX_2DFilter(BL_Shader)
+
+   2D filter shader object. Can be alterate with :class:`BL_Shader`'s functions.
+
+   .. method:: setTexture(index, bindCode)
+
+      Set specified texture bind code :data:`bindCode` in specified slot :data:`index`. Any call to :data:`setTexture`
+      should be followed by a call to :data:`BL_Shader.setSampler` with the same :data:`index`.
+
+      :arg index: The texture slot.
+      :type index: integer
+      :arg bindCode: The texture bind code/Id.
+      :type bindCode: integer

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilterManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilterManager.rst
@@ -1,0 +1,50 @@
+KX_2DFilterManager(PyObjectPlus)
+================================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_2DFilterManager(PyObjectPlus)
+
+   2D filter manager used to add, remove and find filters in a scene.
+
+   .. method:: addFilter(index, type, fragmentProgram)
+
+      Add a filter to the pass index :data:`index`, type :data:`type` and fragment program if custom filter.
+
+      :arg index: The filter pass index.
+      :type index: integer
+      :arg type: The filter type, one of:
+
+         * :data:`bge.logic.RAS_2DFILTER_BLUR`
+         * :data:`bge.logic.RAS_2DFILTER_DILATION`
+         * :data:`bge.logic.RAS_2DFILTER_EROSION`
+         * :data:`bge.logic.RAS_2DFILTER_SHARPEN`
+         * :data:`bge.logic.RAS_2DFILTER_LAPLACIAN`
+         * :data:`bge.logic.RAS_2DFILTER_PREWITT`
+         * :data:`bge.logic.RAS_2DFILTER_SOBEL`
+         * :data:`bge.logic.RAS_2DFILTER_GRAYSCALE`
+         * :data:`bge.logic.RAS_2DFILTER_SEPIA`
+         * :data:`bge.logic.RAS_2DFILTER_CUSTOMFILTER`
+
+      :type type: integer
+      :arg fragmentProgram: The filter shader fragment program.
+      Specified only if :data:`type` is :data:`bge.logic.RAS_2DFILTER_CUSTOMFILTER`. (optional)
+      :type fragmentProgram: string
+
+   .. method:: removeFilter(index)
+
+      Remove filter to the pass index :data:`index`.
+
+      :arg index: The filter pass index.
+      :type index: integer
+
+   .. method:: getFilter(index)
+
+      Return filter to the pass index :data:`index`.
+
+      :arg index: The filter pass index.
+      :type index: integer
+      :return: The filter in the specified pass index or None.
+      :rtype: :class:`KX_2DFilter` or None

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -89,6 +89,12 @@ base class --- :class:`PyObjectPlus`
 
       :type: :class:`KX_WorldInfo`
 
+   .. attribute:: filterManager
+
+      The scene's 2D filter manager, (read-only).
+
+      :type: :class:`KX_2DFilterManager`
+
    .. attribute:: suspended
 
       True if the scene is suspended, (read-only).

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -68,7 +68,7 @@ PyMethodDef BL_Shader::Methods[] = {
 };
 
 PyAttributeDef BL_Shader::Attributes[] = {
-	KX_PYATTRIBUTE_RW_FUNCTION("enabled", BL_Shader, pyattr_get_enabled, pyattr_set_enabled),
+	KX_PYATTRIBUTE_RW_FUNCTION("enable", BL_Shader, pyattr_get_enable, pyattr_set_enable),
 	{NULL} //Sentinel
 };
 
@@ -94,13 +94,13 @@ PyTypeObject BL_Shader::Type = {
 	py_base_new
 };
 
-PyObject *BL_Shader::pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *BL_Shader::pyattr_get_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	BL_Shader* self = static_cast<BL_Shader*>(self_v);
 	return PyBool_FromLong(self->GetEnabled());
 }
 
-int BL_Shader::pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+int BL_Shader::pyattr_set_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
 {
 	BL_Shader* self = static_cast<BL_Shader*>(self_v);
 	int param = PyObject_IsTrue(value);

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -68,7 +68,7 @@ PyMethodDef BL_Shader::Methods[] = {
 };
 
 PyAttributeDef BL_Shader::Attributes[] = {
-	KX_PYATTRIBUTE_RW_FUNCTION("enable", BL_Shader, pyattr_get_enable, pyattr_set_enable),
+	KX_PYATTRIBUTE_RW_FUNCTION("enabled", BL_Shader, pyattr_get_enabled, pyattr_set_enabled),
 	{NULL} //Sentinel
 };
 
@@ -94,13 +94,13 @@ PyTypeObject BL_Shader::Type = {
 	py_base_new
 };
 
-PyObject *BL_Shader::pyattr_get_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *BL_Shader::pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	BL_Shader* self = static_cast<BL_Shader*>(self_v);
 	return PyBool_FromLong(self->GetEnabled());
 }
 
-int BL_Shader::pyattr_set_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+int BL_Shader::pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
 {
 	BL_Shader* self = static_cast<BL_Shader*>(self_v);
 	int param = PyObject_IsTrue(value);

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -68,6 +68,7 @@ PyMethodDef BL_Shader::Methods[] = {
 };
 
 PyAttributeDef BL_Shader::Attributes[] = {
+	KX_PYATTRIBUTE_RW_FUNCTION("enabled", BL_Shader, pyattr_get_enabled, pyattr_set_enabled),
 	{NULL} //Sentinel
 };
 
@@ -92,6 +93,25 @@ PyTypeObject BL_Shader::Type = {
 	0, 0, 0, 0, 0, 0,
 	py_base_new
 };
+
+PyObject *BL_Shader::pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	BL_Shader* self = static_cast<BL_Shader*>(self_v);
+	return PyBool_FromLong(self->GetEnabled());
+}
+
+int BL_Shader::pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	BL_Shader* self = static_cast<BL_Shader*>(self_v);
+	int param = PyObject_IsTrue(value);
+	if (param == -1) {
+		PyErr_SetString(PyExc_AttributeError, "shader.enabled = bool: BL_Shader, expected True or False");
+		return PY_SET_ATTR_FAIL;
+	}
+
+	self->SetEnabled(param);
+	return PY_SET_ATTR_SUCCESS;
+}
 
 KX_PYMETHODDEF_DOC(BL_Shader, setSource, " setSource(vertexProgram, fragmentProgram)")
 {

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -23,8 +23,8 @@ public:
 		return PyUnicode_FromFormat("BL_Shader\n\tvertex shader:%s\n\n\tfragment shader%s\n\n", m_vertProg.ReadPtr(), m_fragProg.ReadPtr());
 	}
 
-	static PyObject *pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -9,7 +9,7 @@
 #include "EXP_PyObjectPlus.h"
 #include "RAS_Shader.h"
 
-class BL_Shader : public PyObjectPlus, public RAS_Shader
+class BL_Shader : public PyObjectPlus, public virtual RAS_Shader
 {
 	Py_Header
 public:
@@ -22,6 +22,9 @@ public:
 	{
 		return PyUnicode_FromFormat("BL_Shader\n\tvertex shader:%s\n\n\tfragment shader%s\n\n", m_vertProg.ReadPtr(), m_fragProg.ReadPtr());
 	}
+
+	static PyObject *pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -23,8 +23,8 @@ public:
 		return PyUnicode_FromFormat("BL_Shader\n\tvertex shader:%s\n\n\tfragment shader%s\n\n", m_vertProg.ReadPtr(), m_fragProg.ReadPtr());
 	}
 
-	static PyObject *pyattr_get_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int pyattr_set_enable(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -67,6 +67,8 @@ set(SRC
 	BL_BlenderShader.cpp
 	BL_Shader.cpp
 	BL_Texture.cpp
+	KX_2DFilter.cpp
+	KX_2DFilterManager.cpp
 	KX_ArmatureSensor.cpp
 	KX_BlenderMaterial.cpp
 	KX_Camera.cpp
@@ -141,6 +143,8 @@ set(SRC
 	BL_BlenderShader.h
 	BL_Shader.h
 	BL_Texture.h
+	KX_2DFilter.h
+	KX_2DFilterManager.h
 	KX_ArmatureSensor.h
 	KX_BlenderMaterial.h
 	KX_Camera.h

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -30,6 +30,7 @@
 */
 
 #include "KX_2DFilter.h"
+#include "BL_Texture.h" // for BL_Texture::MaxUnits
 
 KX_2DFilter::KX_2DFilter(RAS_2DFilterData& data)
 	:RAS_2DFilter(data)
@@ -63,9 +64,28 @@ PyTypeObject KX_2DFilter::Type = {
 };
 
 PyMethodDef KX_2DFilter::Methods[] = {
+	KX_PYMETHODTABLE(KX_2DFilter, setTexture),
 	{NULL, NULL} // Sentinel
 };
 
 PyAttributeDef KX_2DFilter::Attributes[] = {
 	{NULL} // Sentinel
 };
+
+
+KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindcode)")
+{
+	int index = 0;
+	int bindcode = 0;
+
+	if (!PyArg_ParseTuple(args, "ii:setTexture", &index, &bindcode)) {
+		return NULL;
+	}
+	if (index < 0 || index >= BL_Texture::MaxUnits) {
+		PyErr_SetString(PyExc_TypeError, "setTexture(index, bindcode): KX_2DFilter. index out of range [0, 7]");
+		return NULL;
+	}
+
+	m_textures[index] = bindcode;
+	Py_RETURN_NONE;
+}

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -30,7 +30,7 @@
 */
 
 #include "KX_2DFilter.h"
-#include "BL_Texture.h" // for BL_Texture::MaxUnits
+#include "RAS_Texture.h" // for RAS_Texture::MaxUnits
 
 KX_2DFilter::KX_2DFilter(RAS_2DFilterData& data)
 	:RAS_2DFilter(data)
@@ -79,19 +79,24 @@ PyAttributeDef KX_2DFilter::Attributes[] = {
 };
 
 
-KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindcode)")
+KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode)")
 {
 	int index = 0;
-	int bindcode = 0;
+	int bindCode = 0;
 
-	if (!PyArg_ParseTuple(args, "ii:setTexture", &index, &bindcode)) {
+	if (!PyArg_ParseTuple(args, "ii:setTexture", &index, &bindCode)) {
 		return NULL;
 	}
-	if (index < 0 || index >= BL_Texture::MaxUnits) {
-		PyErr_SetString(PyExc_TypeError, "setTexture(index, bindcode): KX_2DFilter. index out of range [0, 7]");
+	if (index < 0 || index >= RAS_Texture::MaxUnits) {
+		PyErr_SetString(PyExc_ValueError, "setTexture(index, bindCode): KX_2DFilter, index out of range [0, 7]");
 		return NULL;
 	}
 
-	m_textures[index] = bindcode;
+	if (!RAS_Texture::CheckBindCode(bindCode)) {
+		PyErr_Format(PyExc_ValueError, "setTexture(index, bindCode): KX_2DFilter, bindCode (%i) invalid", bindCode);
+		return NULL;
+	}
+
+	m_textures[index] = bindCode;
 	Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -41,6 +41,12 @@ KX_2DFilter::~KX_2DFilter()
 {
 }
 
+bool KX_2DFilter::LinkProgram()
+{
+	return RAS_2DFilter::LinkProgram();
+}
+
+
 PyTypeObject KX_2DFilter::Type = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"KX_2DFilter",

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -1,0 +1,71 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+* All rights reserved.
+*
+* The Original Code is: all of this file.
+*
+* Contributor(s): none yet.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+/** \file gameengine/Ketsji/KX_2DFilter.cpp
+*  \ingroup ketsji
+*/
+
+#include "KX_2DFilter.h"
+
+KX_2DFilter::KX_2DFilter(RAS_2DFilterData& data)
+	:RAS_2DFilter(data)
+{
+}
+
+KX_2DFilter::~KX_2DFilter()
+{
+}
+
+PyTypeObject KX_2DFilter::Type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"KX_2DFilter",
+	sizeof(PyObjectPlus_Proxy),
+	0,
+	py_base_dealloc,
+	0,
+	0,
+	0,
+	0,
+	py_base_repr,
+	0, 0, 0, 0, 0, 0, 0, 0, 0,
+	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	0, 0, 0, 0, 0, 0, 0,
+	Methods,
+	0,
+	0,
+	&BL_Shader::Type,
+	0, 0, 0, 0, 0, 0,
+	py_base_new
+};
+
+PyMethodDef KX_2DFilter::Methods[] = {
+	{NULL, NULL} // Sentinel
+};
+
+PyAttributeDef KX_2DFilter::Attributes[] = {
+	{NULL} // Sentinel
+};

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -1,0 +1,48 @@
+//This class is a subclass of RAS_2DFilter, it contains only the pytohn proxy and it is created only in the KX_2DFilterManager class which is also a subclass of RAS_2DFilterManager.
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+* All rights reserved.
+*
+* The Original Code is: all of this file.
+*
+* Contributor(s): none yet.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+/** \file KX_2DFilter.h
+*  \ingroup ketsji
+*/
+
+#ifndef __KX_2DFILTER_H__
+#define __KX_2DFILTER_H__
+
+#include "RAS_2DFilter.h"
+#include "BL_Shader.h"
+#include "MT_Matrix4x4.h"
+
+class KX_2DFilter : public RAS_2DFilter, BL_Shader
+{
+	Py_Header
+public:
+	KX_2DFilter(RAS_2DFilterData& data);
+	virtual ~KX_2DFilter();
+};
+
+#endif  // __KX_2DFILTER_H__

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -43,6 +43,12 @@ class KX_2DFilter : public RAS_2DFilter, public BL_Shader
 public:
 	KX_2DFilter(RAS_2DFilterData& data);
 	virtual ~KX_2DFilter();
+
+#ifdef WITH_PYTHON
+
+	KX_PYMETHOD_DOC(KX_2DFilter, setTexture);
+
+#endif
 };
 
 #endif  // __KX_2DFILTER_H__

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -44,6 +44,8 @@ public:
 	KX_2DFilter(RAS_2DFilterData& data);
 	virtual ~KX_2DFilter();
 
+	virtual bool LinkProgram();
+
 #ifdef WITH_PYTHON
 
 	KX_PYMETHOD_DOC(KX_2DFilter, setTexture);

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -37,7 +37,7 @@
 #include "BL_Shader.h"
 #include "MT_Matrix4x4.h"
 
-class KX_2DFilter : public RAS_2DFilter, BL_Shader
+class KX_2DFilter : public RAS_2DFilter, public BL_Shader
 {
 	Py_Header
 public:

--- a/source/gameengine/Ketsji/KX_2DFilterManager.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilterManager.cpp
@@ -97,8 +97,37 @@ KX_PYMETHODDEF_DOC(KX_2DFilterManager, getFilter, " getFilter(index)")
 	Py_RETURN_NONE;
 }
 
-KX_PYMETHODDEF_DOC(KX_2DFilterManager, addFilter, " addFilter(index)")
+KX_PYMETHODDEF_DOC(KX_2DFilterManager, addFilter, " addFilter(index, type, fragmentProgram)")
 {
+	int index = 0;
+	int type = 0;
+	const char *frag = "";
+
+	if (!PyArg_ParseTuple(args, "ii|s:addFilter", &index, &type, &frag)) {
+		return NULL;
+	}
+
+	if (GetFilterPass(index)) {
+		PyErr_Format(PyExc_ValueError, "filterManager.addFilter(index, type, fragmentProgram): KX_2DFilterManager, found exisiting filter in index (%i)", index);
+		return NULL;
+	}
+
+	if (type < FILTER_BLUR || type > FILTER_CUSTOMFILTER) {
+		PyErr_SetString(PyExc_ValueError, "filterManager.addFilter(index, type, fragmentProgram): KX_2DFilterManager, type invalid");
+		return NULL;
+	}
+
+	if (strlen(frag) > 0 && type != FILTER_CUSTOMFILTER) {
+		std::cout << "filterManager.addFilter(index, type, fragmentProgram): KX_2DFilterManager, Warning non-empty fragment program with non-custom filter type" << std::endl;
+	}
+
+	RAS_2DFilterData data;
+	data.filterPassIndex = index;
+	data.filterMode = type;
+	data.shaderText = STR_String(frag);
+
+	AddFilter(data);
+
 	Py_RETURN_NONE;
 }
 

--- a/source/gameengine/Ketsji/KX_2DFilterManager.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilterManager.cpp
@@ -44,3 +44,75 @@ RAS_2DFilter *KX_2DFilterManager::NewFilter(RAS_2DFilterData& filterData)
 {
 	return new KX_2DFilter(filterData);
 }
+
+#ifdef WITH_PYTHON
+PyMethodDef KX_2DFilterManager::Methods[] = {
+	// creation
+	KX_PYMETHODTABLE(KX_2DFilterManager, getFilter),
+	KX_PYMETHODTABLE(KX_2DFilterManager, addFilter),
+	KX_PYMETHODTABLE(KX_2DFilterManager, removeFilter),
+	{NULL, NULL} //Sentinel
+};
+
+PyAttributeDef KX_2DFilterManager::Attributes[] = {
+	{NULL} //Sentinel
+};
+
+PyTypeObject KX_2DFilterManager::Type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"KX_2DFilterManager",
+	sizeof(PyObjectPlus_Proxy),
+	0,
+	py_base_dealloc,
+	0,
+	0,
+	0,
+	0,
+	py_base_repr,
+	0, 0, 0, 0, 0, 0, 0, 0, 0,
+	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	0, 0, 0, 0, 0, 0, 0,
+	Methods,
+	0,
+	0,
+	&PyObjectPlus::Type,
+	0, 0, 0, 0, 0, 0,
+	py_base_new
+};
+
+
+KX_PYMETHODDEF_DOC(KX_2DFilterManager, getFilter, " getFilter(index)")
+{
+	int index = 0;
+
+	if (!PyArg_ParseTuple(args, "i:getFilter", &index)) {
+		return NULL;
+	}
+
+	KX_2DFilter *filter = (KX_2DFilter*)GetFilterPass(index);
+
+	if (filter) {
+		return filter->GetProxy();
+	}
+	Py_RETURN_NONE;
+}
+
+KX_PYMETHODDEF_DOC(KX_2DFilterManager, addFilter, " addFilter(index)")
+{
+	Py_RETURN_NONE;
+}
+
+KX_PYMETHODDEF_DOC(KX_2DFilterManager, removeFilter, " removeFilter(index)")
+{
+	int index = 0;
+
+	if (!PyArg_ParseTuple(args, "i:removeFilter", &index)) {
+		return NULL;
+	}
+
+	RemoveFilterPass(index);
+
+	Py_RETURN_NONE;
+}
+
+#endif  // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_2DFilterManager.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilterManager.cpp
@@ -1,0 +1,46 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+* All rights reserved.
+*
+* The Original Code is: all of this file.
+*
+* Contributor(s): none yet.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+/** \file KX_2DFilterManager.cpp
+*  \ingroup ketsji
+*/
+
+#include "KX_2DFilterManager.h"
+#include "KX_2DFilter.h"
+
+KX_2DFilterManager::KX_2DFilterManager()
+{
+}
+
+KX_2DFilterManager::~KX_2DFilterManager()
+{
+}
+
+RAS_2DFilter *KX_2DFilterManager::NewFilter(RAS_2DFilterData& filterData)
+{
+	return new KX_2DFilter(filterData);
+}

--- a/source/gameengine/Ketsji/KX_2DFilterManager.h
+++ b/source/gameengine/Ketsji/KX_2DFilterManager.h
@@ -33,16 +33,24 @@
 #define __KX_2DFILTER_MANAGER_H__
 
 #include "RAS_2DFilterManager.h"
+#include "EXP_PyObjectPlus.h"
 
-class KX_2DFilterManager : public RAS_2DFilterManager
+class KX_2DFilterManager : public RAS_2DFilterManager, public PyObjectPlus
 {
-private:
-
+	Py_Header
 public:
 	KX_2DFilterManager();
 	virtual ~KX_2DFilterManager();
 
 	virtual RAS_2DFilter *NewFilter(RAS_2DFilterData& filterData);
+
+#ifdef WITH_PYTHON
+
+	KX_PYMETHOD_DOC(KX_2DFilterManager, getFilter);
+	KX_PYMETHOD_DOC(KX_2DFilterManager, addFilter);
+	KX_PYMETHOD_DOC(KX_2DFilterManager, removeFilter);
+
+#endif  // WITH_PYTHON
 };
 
 #endif // __KX_2DFILTER_MANAGER_H__

--- a/source/gameengine/Ketsji/KX_2DFilterManager.h
+++ b/source/gameengine/Ketsji/KX_2DFilterManager.h
@@ -1,0 +1,48 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+* All rights reserved.
+*
+* The Original Code is: all of this file.
+*
+* Contributor(s): none yet.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+/** \file KX_2DFilterManager.h
+*  \ingroup ketsji
+*/
+
+#ifndef __KX_2DFILTER_MANAGER_H__
+#define __KX_2DFILTER_MANAGER_H__
+
+#include "RAS_2DFilterManager.h"
+
+class KX_2DFilterManager : public RAS_2DFilterManager
+{
+private:
+
+public:
+	KX_2DFilterManager();
+	virtual ~KX_2DFilterManager();
+
+	virtual RAS_2DFilter *NewFilter(RAS_2DFilterData& filterData);
+};
+
+#endif // __KX_2DFILTER_MANAGER_H__

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -75,7 +75,6 @@ extern "C" {
 //python physics binding
 #include "KX_PyConstraintBinding.h"
 
-#include "KX_2DFilter.h"
 #include "KX_KetsjiEngine.h"
 #include "KX_RadarSensor.h"
 #include "KX_RaySensor.h"
@@ -648,21 +647,7 @@ static PyObject *gPyGetInactiveSceneNames(PyObject *self)
 	return list->NewProxy(true);
 }
 
-PyDoc_STRVAR(gPyGetFilters_doc,
-	"filters()\n"
-	"Return a list of 2D Filters."
-	);
-static PyObject *gPyGetFilters(PyObject *self)
-{
-	int i = 0;
-	RAS_PassTo2DFilter filters = KX_GetActiveScene()->Get2DFilterManager()->GetFilters();
-	PyObject *filterlist = PyList_New(filters.size());
-	for (RAS_PassTo2DFilter::iterator it = filters.begin(), end = filters.end(); it != end; ++it) {
-		KX_2DFilter *filter = (KX_2DFilter *)it->second;
-		PyList_SET_ITEM(filterlist, i++, filter->GetProxy());
-	}
-	return filterlist;
-}
+
 
 static PyObject *pyPrintStats(PyObject *,PyObject *,PyObject *)
 {
@@ -858,7 +843,6 @@ static struct PyMethodDef game_methods[] = {
 	{"getCurrentScene", (PyCFunction) gPyGetCurrentScene, METH_NOARGS, gPyGetCurrentScene_doc},
 	{"getInactiveSceneNames", (PyCFunction)gPyGetInactiveSceneNames, METH_NOARGS, (const char *)gPyGetInactiveSceneNames_doc},
 	{"getSceneList", (PyCFunction) gPyGetSceneList, METH_NOARGS, (const char *)gPyGetSceneList_doc},
-	{"filters", (PyCFunction)gPyGetFilters, METH_NOARGS, (const char *)gPyGetFilters_doc},
 	{"addScene", (PyCFunction)gPyAddScene, METH_VARARGS, (const char *)gPyAddScene_doc},
 	{"getRandomFloat",(PyCFunction) gPyGetRandomFloat, METH_NOARGS, (const char *)gPyGetRandomFloat_doc},
 	{"setGravity",(PyCFunction) gPySetGravity, METH_O, (const char *)"set Gravitation"},

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -75,6 +75,7 @@ extern "C" {
 //python physics binding
 #include "KX_PyConstraintBinding.h"
 
+#include "KX_2DFilter.h"
 #include "KX_KetsjiEngine.h"
 #include "KX_RadarSensor.h"
 #include "KX_RaySensor.h"
@@ -647,7 +648,21 @@ static PyObject *gPyGetInactiveSceneNames(PyObject *self)
 	return list->NewProxy(true);
 }
 
-
+PyDoc_STRVAR(gPyGetFilters_doc,
+	"filters()\n"
+	"Return a list of 2D Filters."
+	);
+static PyObject *gPyGetFilters(PyObject *self)
+{
+	int i = 0;
+	RAS_PassTo2DFilter filters = KX_GetActiveScene()->Get2DFilterManager()->GetFilters();
+	PyObject *filterlist = PyList_New(filters.size());
+	for (RAS_PassTo2DFilter::iterator it = filters.begin(), end = filters.end(); it != end; ++it) {
+		KX_2DFilter *filter = (KX_2DFilter *)it->second;
+		PyList_SET_ITEM(filterlist, i++, filter->GetProxy());
+	}
+	return filterlist;
+}
 
 static PyObject *pyPrintStats(PyObject *,PyObject *,PyObject *)
 {
@@ -843,6 +858,7 @@ static struct PyMethodDef game_methods[] = {
 	{"getCurrentScene", (PyCFunction) gPyGetCurrentScene, METH_NOARGS, gPyGetCurrentScene_doc},
 	{"getInactiveSceneNames", (PyCFunction)gPyGetInactiveSceneNames, METH_NOARGS, (const char *)gPyGetInactiveSceneNames_doc},
 	{"getSceneList", (PyCFunction) gPyGetSceneList, METH_NOARGS, (const char *)gPyGetSceneList_doc},
+	{"filters", (PyCFunction)gPyGetFilters, METH_NOARGS, (const char *)gPyGetFilters_doc},
 	{"addScene", (PyCFunction)gPyAddScene, METH_VARARGS, (const char *)gPyAddScene_doc},
 	{"getRandomFloat",(PyCFunction) gPyGetRandomFloat, METH_NOARGS, (const char *)gPyGetRandomFloat_doc},
 	{"setGravity",(PyCFunction) gPySetGravity, METH_O, (const char *)"set Gravitation"},

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -42,6 +42,7 @@
 #include "BL_ArmatureObject.h"
 #include "BL_ArmatureChannel.h"
 #include "BL_Texture.h"
+#include "KX_2DFilter.h"
 #include "KX_WorldInfo.h"
 #include "KX_ArmatureSensor.h"
 #include "KX_BlenderMaterial.h"
@@ -210,6 +211,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, CListValue, init_getset);
 		PyType_Ready_Attr(dict, CListWrapper, init_getset);
 		PyType_Ready_Attr(dict, CValue, init_getset);
+		PyType_Ready_Attr(dict, KX_2DFilter, init_getset);
 		PyType_Ready_Attr(dict, KX_ArmatureSensor, init_getset);
 		PyType_Ready_Attr(dict, KX_BlenderMaterial, init_getset);
 		PyType_Ready_Attr(dict, KX_Camera, init_getset);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -43,6 +43,7 @@
 #include "BL_ArmatureChannel.h"
 #include "BL_Texture.h"
 #include "KX_2DFilter.h"
+#include "KX_2DFilterManager.h"
 #include "KX_WorldInfo.h"
 #include "KX_ArmatureSensor.h"
 #include "KX_BlenderMaterial.h"
@@ -212,6 +213,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, CListWrapper, init_getset);
 		PyType_Ready_Attr(dict, CValue, init_getset);
 		PyType_Ready_Attr(dict, KX_2DFilter, init_getset);
+		PyType_Ready_Attr(dict, KX_2DFilterManager, init_getset);
 		PyType_Ready_Attr(dict, KX_ArmatureSensor, init_getset);
 		PyType_Ready_Attr(dict, KX_BlenderMaterial, init_getset);
 		PyType_Ready_Attr(dict, KX_Camera, init_getset);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -63,7 +63,7 @@
 #include "RAS_IRasterizer.h"
 #include "RAS_ICanvas.h"
 #include "RAS_2DFilterData.h"
-#include "RAS_2DFilterManager.h"
+#include "KX_2DFilterManager.h"
 #include "RAS_BucketManager.h"
 
 #include "EXP_FloatValue.h"
@@ -171,7 +171,7 @@ KX_Scene::KX_Scene(class SCA_IInputDevice* keyboarddevice,
 	m_euthanasyobjects = new CListValue();
 	m_animatedlist = new CListValue();
 
-	m_filterManager = new RAS_2DFilterManager();
+	m_filterManager = new KX_2DFilterManager();
 	m_logicmgr = new SCA_LogicManager();
 	
 	m_timemgr = new SCA_TimeEventManager(m_logicmgr);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2334,6 +2334,14 @@ PyObject *KX_Scene::pyattr_get_lights(void *self_v, const KX_PYATTRIBUTE_DEF *at
 	return self->GetLightList()->GetProxy();
 }
 
+PyObject *KX_Scene::pyattr_get_filter_manager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_Scene *self = static_cast<KX_Scene*>(self_v);
+	KX_2DFilterManager *filterManager = (KX_2DFilterManager *)self->Get2DFilterManager();
+
+	return filterManager->GetProxy();
+}
+
 PyObject *KX_Scene::pyattr_get_world(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_Scene* self = static_cast<KX_Scene*>(self_v);
@@ -2497,6 +2505,7 @@ PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("objectsInactive",	KX_Scene, pyattr_get_objects_inactive),
 	KX_PYATTRIBUTE_RO_FUNCTION("lights",			KX_Scene, pyattr_get_lights),
 	KX_PYATTRIBUTE_RO_FUNCTION("cameras",			KX_Scene, pyattr_get_cameras),
+	KX_PYATTRIBUTE_RO_FUNCTION("filterManager", KX_Scene, pyattr_get_filter_manager),
 	KX_PYATTRIBUTE_RO_FUNCTION("world",				KX_Scene, pyattr_get_world),
 	KX_PYATTRIBUTE_RW_FUNCTION("active_camera",		KX_Scene, pyattr_get_active_camera, pyattr_set_active_camera),
 	KX_PYATTRIBUTE_RW_FUNCTION("pre_draw",			KX_Scene, pyattr_get_drawing_callback_pre, pyattr_set_drawing_callback_pre),

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -635,6 +635,7 @@ public:
 	static PyObject*	pyattr_get_objects_inactive(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_lights(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_cameras(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject*	pyattr_get_filter_manager(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_world(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_active_camera(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_active_camera(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -79,6 +79,7 @@ class RAS_IPolyMaterial;
 class RAS_IRasterizer;
 class RAS_IRenderTools;
 class RAS_2DFilterManager;
+class KX_2DFilterManager;
 class SCA_JoystickManager;
 class btCollisionShape;
 class KX_BlenderSceneConverter;
@@ -286,7 +287,7 @@ protected:
 
 	struct Scene* m_blenderScene;
 
-	RAS_2DFilterManager *m_filterManager;
+	KX_2DFilterManager *m_filterManager;
 
 	KX_ObstacleSimulation* m_obstacleSimulation;
 

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -204,7 +204,12 @@ void KX_WorldInfo::RenderBackground(RAS_IRasterizer *rasty)
 		static float texcofac[4] = {0.0f, 0.0f, 1.0f, 1.0f};
 		GPU_material_bind(gpumat, 0xFFFFFFFF, m_scene->lay, 1.0f, false, viewmat, invviewmat, texcofac, false);
 
-		rasty->RenderBackground();
+		rasty->Enable(RAS_IRasterizer::RAS_DEPTH_TEST);
+		rasty->SetDepthFunc(RAS_IRasterizer::RAS_ALWAYS);
+
+		rasty->DrawOverlayPlane();
+
+		rasty->SetDepthFunc(RAS_IRasterizer::RAS_LEQUAL);
 
 		GPU_material_unbind(gpumat);
 	}

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -349,25 +349,7 @@ void RAS_2DFilter::DrawOverlayPlane(RAS_IRasterizer *rasty, RAS_ICanvas *canvas)
 	rasty->PushMatrix();
 	rasty->LoadIdentity();
 
-	glBegin(GL_QUADS);
-	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-
-	glTexCoord2f(1.0f, 1.0f);
-	glMultiTexCoord2fARB(GL_TEXTURE3_ARB, 1.0f, 1.0f);
-	glVertex2f(1.0f, 1.0f);
-
-	glTexCoord2f(0.0f, 1.0f);
-	glMultiTexCoord2fARB(GL_TEXTURE3_ARB, -1.0f, 1.0f);
-	glVertex2f(-1.0f, 1.0f);
-
-	glTexCoord2f(0.0f, 0.0f);
-	glMultiTexCoord2fARB(GL_TEXTURE3_ARB, -1.0f, -1.0f);
-	glVertex2f(-1.0f, -1.0f);
-
-	glTexCoord2f(1.0f, 0.0f);
-	glMultiTexCoord2fARB(GL_TEXTURE3_ARB, 1.0f, -1.0f);
-	glVertex2f(1.0f, -1.0f);
-	glEnd();
+	rasty->DrawOverlayPlane();
 
 	rasty->PopMatrix();
 	rasty->SetMatrixMode(RAS_IRasterizer::RAS_MODELVIEW);

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -60,6 +60,8 @@ RAS_2DFilter::RAS_2DFilter(RAS_2DFilterData& data)
 
 	m_vertProg = STR_String(VertexShader);
 	m_fragProg = data.shaderText;
+
+	mUse = true;
 }
 
 void RAS_2DFilter::ReleaseTextures()
@@ -75,12 +77,6 @@ void RAS_2DFilter::ReleaseTextures()
 RAS_2DFilter::~RAS_2DFilter()
 {
 	ReleaseTextures();
-}
-
-void RAS_2DFilter::SetEnabled(bool enabled)
-{
-	// reuse mUse variable to use the Ok() function.
-	mUse = enabled;
 }
 
 void RAS_2DFilter::Initialize(RAS_ICanvas *canvas)

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -43,8 +43,7 @@ static char predefinedUniformsName[RAS_2DFilter::MAX_PREDEFINED_UNIFORM_TYPE][40
 
 RAS_2DFilter::RAS_2DFilter(RAS_2DFilterData& data)
 	:m_properties(data.propertyNames),
-	m_gameObject(data.gameObject),
-	m_passIndex(data.filterPassIndex)
+	m_gameObject(data.gameObject)
 {
 	for(unsigned int i = 0; i < TEXTURE_OFFSETS_SIZE; i++) {
 		m_textureOffsets[i] = 0;
@@ -89,11 +88,6 @@ void RAS_2DFilter::Initialize(RAS_ICanvas *canvas)
 		InitializeTextures(canvas);
 		ComputeTextureOffsets(canvas);
 	}
-}
-
-int RAS_2DFilter::GetPassIndex()
-{
-	return m_passIndex;
 }
 
 void RAS_2DFilter::Start(RAS_IRasterizer *rasty, RAS_ICanvas *canvas)

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -162,7 +162,7 @@ void RAS_2DFilter::InitializeTextures(RAS_ICanvas *canvas)
 	const unsigned int textureheight = canvas->GetHeight() + 1;
 
 	for (unsigned int i = 0; i < MAX_RENDERED_TEXTURE_TYPE; ++i) {
-		m_renderedTextures[i];
+		m_renderedTextures[i] = 0;
 	}
 
 	if (m_predefinedUniforms[RENDERED_TEXTURE_UNIFORM] != -1 && m_renderedTextures[RENDERED_TEXTURE] == 0) {

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -26,6 +26,8 @@
 #include "RAS_ICanvas.h"
 #include "RAS_Rect.h"
 
+#include "BLI_utildefines.h" // for STRINGIFY
+
 #include "RAS_OpenGLFilters/RAS_VertexShader2DFilter.h"
 
 #include "EXP_Value.h"

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -112,7 +112,7 @@ void RAS_2DFilter::Start(RAS_IRasterizer *rasty, RAS_ICanvas *canvas)
 		mat.setIdentity();
 		Update(rasty, mat);
 		ApplyShader();
-		DrawOverlayPlane(canvas);
+		DrawOverlayPlane(rasty, canvas);
 		UnbindTextures();
 	}
 }
@@ -327,27 +327,27 @@ void RAS_2DFilter::BindUniforms(RAS_ICanvas *canvas)
 	}
 }
 
-void RAS_2DFilter::DrawOverlayPlane(RAS_ICanvas *canvas)
+void RAS_2DFilter::DrawOverlayPlane(RAS_IRasterizer *rasty, RAS_ICanvas *canvas)
 {
 	RAS_Rect scissor_rect = canvas->GetDisplayArea();
-	glScissor(scissor_rect.GetLeft() + canvas->GetViewPort()[0], 
+	rasty->SetScissor(scissor_rect.GetLeft() + canvas->GetViewPort()[0], 
 			  scissor_rect.GetBottom() + canvas->GetViewPort()[1],
 			  scissor_rect.GetWidth() + 1,
 			  scissor_rect.GetHeight() + 1);
 
-	glDisable(GL_DEPTH_TEST);
-	glDisable(GL_BLEND);
-	glDisable(GL_ALPHA_TEST);
+	rasty->Disable(RAS_IRasterizer::RAS_DEPTH_TEST);
+	rasty->Disable(RAS_IRasterizer::RAS_BLEND);
+	rasty->Disable(RAS_IRasterizer::RAS_ALPHA_TEST);
 
-	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	rasty->SetLines(false);
 
-	glPushMatrix();
-	glLoadIdentity();
-	glMatrixMode(GL_TEXTURE);
-	glLoadIdentity();
-	glMatrixMode(GL_PROJECTION);
-	glPushMatrix();
-	glLoadIdentity();
+	rasty->PushMatrix();
+	rasty->LoadIdentity();
+	rasty->SetMatrixMode(RAS_IRasterizer::RAS_TEXTURE);
+	rasty->LoadIdentity();
+	rasty->SetMatrixMode(RAS_IRasterizer::RAS_PROJECTION);
+	rasty->PushMatrix();
+	rasty->LoadIdentity();
 
 	glBegin(GL_QUADS);
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
@@ -369,9 +369,9 @@ void RAS_2DFilter::DrawOverlayPlane(RAS_ICanvas *canvas)
 	glVertex2f(1.0f, -1.0f);
 	glEnd();
 
-	glPopMatrix();
-	glMatrixMode(GL_MODELVIEW);
-	glPopMatrix();
+	rasty->PopMatrix();
+	rasty->SetMatrixMode(RAS_IRasterizer::RAS_MODELVIEW);
+	rasty->PopMatrix();
 
-	glEnable(GL_DEPTH_TEST);
+	rasty->Enable(RAS_IRasterizer::RAS_DEPTH_TEST);
 }

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -51,7 +51,7 @@ public:
 		MAX_RENDERED_TEXTURE_TYPE
 	};
 
-private:
+protected:
 	int m_predefinedUniforms[MAX_PREDEFINED_UNIFORM_TYPE];
 	unsigned int m_renderedTextures[MAX_RENDERED_TEXTURE_TYPE];
 
@@ -65,12 +65,16 @@ private:
 	/** A set of vec2 coordinates that the shaders use to sample nearby pixels from incoming textures.
 	The computation should be left to the glsl shader, I keep it for backward compatibility. */
 	static const int TEXTURE_OFFSETS_SIZE = 18; //9 vec2 entries
-	float m_textureOffsets[TEXTURE_OFFSETS_SIZE]; 
+	float m_textureOffsets[TEXTURE_OFFSETS_SIZE];
+
+	unsigned int m_textures[8];
 
 	virtual bool LinkProgram();
 	void ParseShaderProgram();
 	void InitializeTextures(RAS_ICanvas *canvas);
 	void BindUniforms(RAS_ICanvas *canvas);
+	void BindTextures(RAS_ICanvas *canvas);
+	void UnbindTextures();
 	void DrawOverlayPlane(RAS_ICanvas *canvas);
 	void ComputeTextureOffsets(RAS_ICanvas *canvas);
 	void ReleaseTextures();

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -59,11 +59,15 @@ private:
 	std::vector<unsigned int> m_propertiesLoc;
 	CValue *m_gameObject;
 
+	/// True if the uniform are updated with the current shader program/script.
+	bool m_uniformInitialized;
+
 	/** A set of vec2 coordinates that the shaders use to sample nearby pixels from incoming textures.
 	The computation should be left to the glsl shader, I keep it for backward compatibility. */
 	static const int TEXTURE_OFFSETS_SIZE = 18; //9 vec2 entries
 	float m_textureOffsets[TEXTURE_OFFSETS_SIZE]; 
 
+	virtual bool LinkProgram();
 	void ParseShaderProgram();
 	void InitializeTextures(RAS_ICanvas *canvas);
 	void BindUniforms(RAS_ICanvas *canvas);

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -75,7 +75,7 @@ protected:
 	void BindUniforms(RAS_ICanvas *canvas);
 	void BindTextures(RAS_ICanvas *canvas);
 	void UnbindTextures();
-	void DrawOverlayPlane(RAS_ICanvas *canvas);
+	void DrawOverlayPlane(RAS_IRasterizer *rasty, RAS_ICanvas *canvas);
 	void ComputeTextureOffsets(RAS_ICanvas *canvas);
 	void ReleaseTextures();
 

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -74,7 +74,7 @@ private:
 
 public:
 	RAS_2DFilter(RAS_2DFilterData& data);
-	~RAS_2DFilter();
+	virtual ~RAS_2DFilter();
 
 	/// Called by the filter manager when it has informations like the display size, a gl context...
 	void Initialize(RAS_ICanvas *canvas);

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -63,7 +63,6 @@ private:
 	The computation should be left to the glsl shader, I keep it for backward compatibility. */
 	static const int TEXTURE_OFFSETS_SIZE = 18; //9 vec2 entries
 	float m_textureOffsets[TEXTURE_OFFSETS_SIZE]; 
-	int m_passIndex;
 
 	void ParseShaderProgram();
 	void InitializeTextures(RAS_ICanvas *canvas);
@@ -84,9 +83,6 @@ public:
 
 	/// Finalizes the execution stage of the filter.
 	void End();
-
-	/// The pass index determines the precedence of this filter over other filters in the same context.
-	int GetPassIndex();
 };
 
 #endif // __RAS_2DFILTER_H__

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -31,7 +31,7 @@ class RAS_IRasterizer;
 class RAS_ICanvas;
 class CValue;
 
-class RAS_2DFilter : public RAS_Shader
+class RAS_2DFilter : public virtual RAS_Shader
 {
 public:
 	enum PredefinedUniformType {
@@ -87,9 +87,6 @@ public:
 
 	/// The pass index determines the precedence of this filter over other filters in the same context.
 	int GetPassIndex();
-
-	/// Enables / disables this filter. A disabled filter has no effect on the rendering.
-	void SetEnabled(bool enabled);
 };
 
 #endif // __RAS_2DFILTER_H__

--- a/source/gameengine/Rasterizer/RAS_2DFilterData.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterData.cpp
@@ -25,9 +25,7 @@
 RAS_2DFilterData::RAS_2DFilterData()
 	:gameObject(NULL),
 	filterMode(-1),
-	filterPassIndex(-1),
-	outputBufferWidth(0),
-	outputBufferHeight(0)
+	filterPassIndex(-1)
 {
 }
 

--- a/source/gameengine/Rasterizer/RAS_2DFilterData.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilterData.h
@@ -49,10 +49,6 @@ public:
 	unsigned int filterPassIndex;
 	/// This is the shader program source code IF the filter is not a predefined one.
 	STR_String shaderText;
-	/// If > 0 tells that the filter wants an offscreen buffer to render into (possibly smaller than the viewport, for performance reasons).
-	int outputBufferWidth;
-	/// If > 0 tells that the filter wants... actually a tuple2 might have been a better idea.
-	int outputBufferHeight;
 };
 
 #endif // __RAS_2DFILTERDATA__

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
@@ -85,8 +85,6 @@ RAS_2DFilter *RAS_2DFilterManager::AddFilter(RAS_2DFilterData& filterData)
 	RAS_2DFilter *filter = CreateFilter(filterData);
 
 	m_filters[filterData.filterPassIndex] = filter;
-	// By default enable the filter.
-	filter->SetEnabled(true);
 
 	return filter;
 }

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
@@ -151,7 +151,7 @@ RAS_2DFilter *RAS_2DFilterManager::CreateFilter(RAS_2DFilterData& filterData)
 	}
 	if (!shaderSource) {
 		if(filterData.filterMode == RAS_2DFilterManager::FILTER_CUSTOMFILTER) {
-			result = new RAS_2DFilter(filterData);
+			result = NewFilter(filterData);
 		}
 		else {
 			std::cout << "Cannot create filter for mode: " << filterData.filterMode << "." << std::endl;
@@ -159,7 +159,12 @@ RAS_2DFilter *RAS_2DFilterManager::CreateFilter(RAS_2DFilterData& filterData)
 	}
 	else {
 		filterData.shaderText = shaderSource;
-		result = new RAS_2DFilter(filterData);
+		result = NewFilter(filterData);
 	}
 	return result;
+}
+
+RAS_2DFilter *RAS_2DFilterManager::NewFilter(RAS_2DFilterData& filterData)
+{
+	return new RAS_2DFilter(filterData);
 }

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
@@ -27,11 +27,13 @@
 #include "RAS_ICanvas.h"
 #include "RAS_2DFilterManager.h"
 #include "RAS_2DFilter.h"
+
+#include "BLI_utildefines.h" // for STRINGIFY
+
 #include <iostream>
 
 #include "glew-mx.h"
 
-#define STRINGIFY(A) #A
 #include "RAS_OpenGLFilters/RAS_Blur2DFilter.h"
 #include "RAS_OpenGLFilters/RAS_Sharpen2DFilter.h"
 #include "RAS_OpenGLFilters/RAS_Dilation2DFilter.h"

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
@@ -56,30 +56,6 @@ RAS_2DFilterManager::~RAS_2DFilterManager()
 	}
 }
 
-void RAS_2DFilterManager::PrintShaderError(unsigned int shaderUid, const char *title, const char *shaderCode, unsigned int passindex)
-{
-	std::cout << "2D Filter GLSL Shader: " << title << " error." << std::endl;
-
-	// Copied value from BL_Shader MAX_LOG_LEN.
-	const int MAX_LOG_CHAR_COUNT = 262144;
-	GLint logSize = 0;
-	glGetShaderiv(shaderUid, GL_INFO_LOG_LENGTH, &logSize);
-
-	if(logSize != 0) {
-		GLsizei infoLogRetSize = 0;
-		if (logSize > MAX_LOG_CHAR_COUNT) {
-			logSize = MAX_LOG_CHAR_COUNT;
-		}
-		char *logCharBuffer = (char *)malloc(sizeof(char) * logSize);
-
-		glGetInfoLogARB(shaderUid, logSize, &infoLogRetSize, logCharBuffer);
-		std::cout << logCharBuffer << std::endl;
-		m_filters[passindex]->SetEnabled(false);
-
-		free(logCharBuffer);
-	}
-}
-
 RAS_2DFilter *RAS_2DFilterManager::AddFilter(RAS_2DFilterData& filterData)
 {
 	RAS_2DFilter *filter = CreateFilter(filterData);

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.h
@@ -77,6 +77,8 @@ public:
 
 	RAS_ICanvas *GetCanvas();
 
+	RAS_PassTo2DFilter GetFilters() { return m_filters; }
+
 private:
 	RAS_PassTo2DFilter m_filters;
 
@@ -84,6 +86,8 @@ private:
 	 * filter can be created with such information.
 	 */
 	RAS_2DFilter *CreateFilter(RAS_2DFilterData& filterData);
+	/// Only return a new instanced filter.
+	virtual RAS_2DFilter *NewFilter(RAS_2DFilterData& filterData);
 };
 
 #endif // __RAS_2DFILTERMANAGER_H__

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.h
@@ -61,8 +61,6 @@ public:
 	RAS_2DFilterManager();
 	virtual ~RAS_2DFilterManager();
 
-	void PrintShaderError(unsigned int shaderUid, const char *title, const char *shaderCode, unsigned int passindex);
-
 	/// Applies the filters to the scene.
 	void RenderFilters(RAS_IRasterizer *rasty, RAS_ICanvas *canvas);
 

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -268,9 +268,9 @@ public:
 	virtual void Exit() = 0;
 
 	/**
-	 * Draw world background according to world material
+	 * Draw screen overlay plane with basic uv coordinates.
 	 */
-	virtual void RenderBackground() = 0;
+	virtual void DrawOverlayPlane() = 0;
 
 	/**
 	 * BeginFrame is called at the start of each frame.

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -585,6 +585,9 @@ public:
 	virtual void PushMatrix() = 0;
 	virtual void PopMatrix() = 0;
 	virtual void MultMatrix(const float mat[16]) = 0;
+	virtual void SetMatrixMode(MatrixMode mode) = 0;
+	virtual void LoadMatrix(const float mat[16]) = 0;
+	virtual void LoadIdentity() = 0;
 
 	virtual RAS_ILightObject *CreateLight() = 0;
 

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -317,24 +317,32 @@ void RAS_OpenGLRasterizer::Exit()
 	EndFrame();
 }
 
-void RAS_OpenGLRasterizer::RenderBackground()
+void RAS_OpenGLRasterizer::DrawOverlayPlane()
 {
-	Enable(RAS_DEPTH_TEST);
-	SetDepthFunc(RAS_ALWAYS);
-
-	float vertices[] = {
+	static const float vertices[] = {
 		-1.0f, -1.0f, 1.0f,
 		 1.0f, -1.0f, 1.0f,
 		-1.0f,  1.0f, 1.0f,
 		 1.0f,  1.0f, 1.0f
 	};
 
-	glEnableClientState(GL_VERTEX_ARRAY);
-	glVertexPointer(3, GL_FLOAT, 0, vertices);
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-	glDisableClientState(GL_VERTEX_ARRAY);
+	static const float uvs[] = {
+		0.0f, 0.0f,
+		1.0f, 0.0f,
+		0.0f, 1.0f,
+		1.0f, 1.0f
+	};
 
-	SetDepthFunc(RAS_LEQUAL);
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+	glVertexPointer(3, GL_FLOAT, 0, vertices);
+	glTexCoordPointer(2, GL_FLOAT, 0, uvs);
+
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 }
 
 bool RAS_OpenGLRasterizer::BeginFrame(double time)

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -151,10 +151,6 @@ protected:
 	RAS_IStorage *m_storage;
 	int m_storageInfo;
 
-	void SetMatrixMode(RAS_IRasterizer::MatrixMode mode);
-	void LoadMatrix(const float mat[16]);
-	void LoadIdentity();
-
 public:
 	double GetTime();
 	RAS_OpenGLRasterizer(RAS_STORAGE_TYPE storage, int storageInfo);
@@ -343,9 +339,12 @@ public:
 
 	virtual void GetTransform(float *origmat, int objectdrawmode, float mat[16]);
 
-	void PushMatrix();
-	void PopMatrix();
-	void MultMatrix(const float mat[16]);
+	virtual void PushMatrix();
+	virtual void PopMatrix();
+	virtual void MultMatrix(const float mat[16]);
+	virtual void SetMatrixMode(RAS_IRasterizer::MatrixMode mode);
+	virtual void LoadMatrix(const float mat[16]);
+	virtual void LoadIdentity();
 
 	/// \see KX_RayCast
 	bool RayHit(struct KX_ClientObjectInfo *client, class KX_RayCast *result, RayCastTranform *raytransform);

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -168,7 +168,7 @@ public:
 
 	virtual bool Init();
 	virtual void Exit();
-	virtual void RenderBackground();
+	virtual void DrawOverlayPlane();
 	virtual bool BeginFrame(double time);
 	virtual void Clear(int clearbit);
 	virtual void SetClearColor(float r, float g, float b, float a=1.0f);

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -559,13 +559,11 @@ void RAS_Shader::Update(RAS_IRasterizer *rasty, const MT_Matrix4x4 model)
 				}
 				case VIEWMATRIX_INVERSE:
 				{
-					MT_Matrix4x4 viewinv = view;
 					SetUniform(uni->mLoc, view.inverse());
 					break;
 				}
 				case VIEWMATRIX_INVERSETRANSPOSE:
 				{
-					MT_Matrix4x4 viewinv = view;
 					SetUniform(uni->mLoc, view.inverse(), true);
 					break;
 				}

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -470,6 +470,15 @@ void RAS_Shader::SetProg(bool enable)
 	}
 }
 
+void RAS_Shader::SetEnabled(bool enabled)
+{
+	mUse = enabled;
+}
+
+bool RAS_Shader::GetEnabled() const
+{
+	return mUse;
+}
 
 void RAS_Shader::Update(RAS_IRasterizer *rasty, const MT_Matrix4x4 model)
 {

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -149,6 +149,8 @@ public:
 	bool Ok() const;
 	unsigned int GetProg();
 	void SetProg(bool enable);
+	void SetEnabled(bool enabled);
+	bool GetEnabled() const;
 	int GetAttribute();
 
 	// Apply methods : sets colected uniforms

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -108,7 +108,7 @@ protected:
 	RAS_UniformVecDef mPreDef;
 
 	// Compiles and links the shader
-	bool LinkProgram();
+	virtual bool LinkProgram();
 	void ValidateProgram();
 
 	// search by location


### PR DESCRIPTION
This is a prototype:

- Problem to get the name of the filter (we have to find 2D filter
  actuator name). For the moment the name is "0" for all filters.
- setSampler doesn't work neither setUniform1i("tex", texBindcode)... we
  have to investigate on this. A texture can't be bound to the 2D filter
  for the moment.
- I just tested for setUniform1f but I guess it works for 2f, 1i etc...
- I copied all the methods from BL_Shader but this means we have all in
  double. It's not very esthetic. But the methods used in KX_2DFilter use
  glUseProgramARB to update uniforms so this methods are not exactly the
  same as in BL_Shader. But maybe a better way could be found.
- I didn't add setUniformDef for the moment, I don't know if it's needed...
- Neither setAttrib...
- I didn't add #ifdef WITH_PYTHON for the moment so to compile you have to select WITH_PYTHON_INSTALL
- We have to move bge.logic.filters() (KX_PythonInit.cpp) to KX_Scene.filters
- Maybe some cleanups could be done in #includes because of inheritance.

Needs tests and to solve some issues but I'm not experienced enough to
solve it alone...

Test file for setUniform1f: http://www.pasteall.org/blend/41667