### PR TITLE
UPBGE: Implement vehicle constraint ray cast mask.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_VehicleWrapper.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_VehicleWrapper.rst
@@ -164,3 +164,8 @@ base class --- :class:`PyObjectPlus`
       :arg wheelIndex: the wheel index
       :type wheelIndex: integer
 
+   .. attribute:: rayMask
+
+      Set ray cast mask.
+
+      :type: bitfield

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.h
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.h
@@ -51,6 +51,10 @@ public:
 	KX_PYMETHOD_VARARGS(KX_VehicleWrapper,SetSuspensionCompression);
 	
 	KX_PYMETHOD_VARARGS(KX_VehicleWrapper,SetRollInfluence);
+
+	static PyObject *pyattr_get_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
 #endif  /* WITH_PYTHON */
 
 private:

--- a/source/gameengine/Physics/Common/PHY_IVehicle.h
+++ b/source/gameengine/Physics/Common/PHY_IVehicle.h
@@ -60,6 +60,9 @@ public:
 
 	virtual void SetCoordinateSystem(int rightIndex, int upIndex, int forwardIndex) = 0;
 
+	virtual void SetRayCastMask(short mask) = 0;
+	virtual short GetRayCastMask() const = 0;
+
 #ifdef WITH_CXX_GUARDEDALLOC
 	MEM_CXX_CLASS_ALLOC_FUNCS("GE:PHY_IVehicle")
 #endif


### PR DESCRIPTION
Previously it was impossible to allow the wheel to use a physics controller
because its shape was frequently hit by the ray.

To support it the btVehicleRaycaster is inherited to BlenderVehicleRaycaster
which use a m_mask attribute checked with a & operator to the hit object
collision group.

From the python API a new attribute is introduced : KX_VehicleWrapper.rayMask.


@DCubix, @youle31, @lordloki, @AkiraSan : Qestions:
wrapper.mask/rayMask/rayCastMask