### PR TITLE
UPBGE: Add a new method to setUniformTexture in KX_2DFilter

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -18,3 +18,14 @@ base class --- :class:`BL_Shader`
       :type index: integer
       :arg bindCode: The texture bind code/Id.
       :type bindCode: integer
+
+   .. method:: setUniformTexture(textureName, textureBindCode, index)
+
+      Set uniform sampler2D textureName in the 2D Filter fragment shader.
+
+      :arg name: Uniform sampler2D name in the 2D Filter.
+      :type name: string
+      :arg bindCode: The bind code/Id of the texture we want to bind.
+      :type bindCode: integer
+      :arg index: The emplacement in range 0 to 7 included where we want to assign the texture (optional argument).
+      :type index: integer

--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -242,8 +242,7 @@ GPUBlendMode GPU_material_alpha_blend(GPUMaterial *material, float obcol[4]);
 /* High level functions to create and use GPU materials */
 GPUMaterial *GPU_material_world(struct Scene *scene, struct World *wo);
 
-GPUMaterial *GPU_material_from_blender(struct Scene *scene, struct Material *ma, bool use_opensubdiv);
-GPUMaterial *GPU_material_instancing_from_blender(struct Scene *scene, struct Material *ma);
+GPUMaterial *GPU_material_from_blender(struct Scene *scene, struct Material *ma, bool use_opensubdiv, bool is_instancing);
 GPUMaterial *GPU_material_matcap(struct Scene *scene, struct Material *ma, bool use_opensubdiv);
 void GPU_material_free(struct ListBase *gpumaterial);
 

--- a/source/blender/gpu/intern/gpu_codegen.c
+++ b/source/blender/gpu/intern/gpu_codegen.c
@@ -1705,6 +1705,7 @@ GPUPass *GPU_generate_pass(
 	fragmentcode = code_generate_fragment(nodes, outlink->output);
 	vertexcode = code_generate_vertex(nodes, type);
 	geometrycode = code_generate_geometry(nodes, use_opensubdiv);
+	printf("%s\n", fragmentcode);
 
 	int flags = GPU_SHADER_FLAGS_NONE;
 	if (use_opensubdiv) {

--- a/source/blender/gpu/intern/gpu_draw.c
+++ b/source/blender/gpu/intern/gpu_draw.c
@@ -1815,7 +1815,7 @@ void GPU_begin_object_materials(
 
 			if (glsl) {
 				GMS.gmatbuf[0] = &defmaterial;
-				GPU_material_from_blender(GMS.gscene, &defmaterial, GMS.is_opensubdiv);
+				GPU_material_from_blender(GMS.gscene, &defmaterial, GMS.is_opensubdiv, false);
 			}
 
 			GMS.alphablend[0] = GPU_BLEND_SOLID;
@@ -1829,7 +1829,7 @@ void GPU_begin_object_materials(
 			if (ma == NULL) ma = &defmaterial;
 
 			/* create glsl material if requested */
-			gpumat = glsl ? GPU_material_from_blender(GMS.gscene, ma, GMS.is_opensubdiv) : NULL;
+			gpumat = glsl ? GPU_material_from_blender(GMS.gscene, ma, GMS.is_opensubdiv, false) : NULL;
 
 			if (gpumat) {
 				/* do glsl only if creating it succeed, else fallback */
@@ -1928,7 +1928,7 @@ int GPU_object_material_bind(int nr, void *attribs)
 	/* unbind glsl material */
 	if (GMS.gboundmat) {
 		if (GMS.is_alpha_pass) glDepthMask(0);
-		GPU_material_unbind(GPU_material_from_blender(GMS.gscene, GMS.gboundmat, GMS.is_opensubdiv));
+		GPU_material_unbind(GPU_material_from_blender(GMS.gscene, GMS.gboundmat, GMS.is_opensubdiv, false));
 		GMS.gboundmat = NULL;
 	}
 
@@ -1955,7 +1955,7 @@ int GPU_object_material_bind(int nr, void *attribs)
 
 			float auto_bump_scale;
 
-			GPUMaterial *gpumat = GPU_material_from_blender(GMS.gscene, mat, GMS.is_opensubdiv);
+			GPUMaterial *gpumat = GPU_material_from_blender(GMS.gscene, mat, GMS.is_opensubdiv, false);
 			GPU_material_vertex_attributes(gpumat, gattribs);
 
 			if (GMS.dob)
@@ -2053,7 +2053,7 @@ void GPU_object_material_unbind(void)
 			glDisable(GL_CULL_FACE);
 
 		if (GMS.is_alpha_pass) glDepthMask(0);
-		GPU_material_unbind(GPU_material_from_blender(GMS.gscene, GMS.gboundmat, GMS.is_opensubdiv));
+		GPU_material_unbind(GPU_material_from_blender(GMS.gscene, GMS.gboundmat, GMS.is_opensubdiv, false));
 		GMS.gboundmat = NULL;
 	}
 	else
@@ -2350,7 +2350,8 @@ void GPU_draw_update_fvar_offset(DerivedMesh *dm)
 
 		gpu_material = GPU_material_from_blender(GMS.gscene,
 		                                         material,
-		                                         GMS.is_opensubdiv);
+		                                         GMS.is_opensubdiv,
+												 false);
 
 		GPU_material_update_fvar_offset(gpu_material, dm);
 	}

--- a/source/gameengine/Ketsji/BL_BlenderShader.cpp
+++ b/source/gameengine/Ketsji/BL_BlenderShader.cpp
@@ -94,11 +94,7 @@ void BL_BlenderShader::ParseAttribs(STR_String uvsname[RAS_Texture::MaxUnits])
 
 void BL_BlenderShader::ReloadMaterial()
 {
-	m_GPUMat = (m_mat) ? 
-		(UseInstancing() ?
-		GPU_material_instancing_from_blender(m_blenderScene, m_mat) :
-		GPU_material_from_blender(m_blenderScene, m_mat, false)) :
-		NULL;
+	m_GPUMat = (m_mat) ? GPU_material_from_blender(m_blenderScene, m_mat, false, UseInstancing()) : NULL;
 }
 
 void BL_BlenderShader::SetProg(bool enable, double time, RAS_IRasterizer *rasty)

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -66,6 +66,7 @@ PyTypeObject KX_2DFilter::Type = {
 
 PyMethodDef KX_2DFilter::Methods[] = {
 	KX_PYMETHODTABLE(KX_2DFilter, setTexture),
+	KX_PYMETHODTABLE(KX_2DFilter, setUniformTexture),
 	{NULL, NULL} // Sentinel
 };
 
@@ -93,5 +94,47 @@ KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode)")
 	}
 
 	m_textures[index] = bindCode;
+	Py_RETURN_NONE;
+}
+
+KX_PYMETHODDEF_DOC(KX_2DFilter, setUniformTexture, "setUniformTexture(textureName, texturebindCode, index)")
+{
+	const char *uniform;
+	int bindCode = 0;
+	int index = -99;
+
+	if (!PyArg_ParseTuple(args, "si|i:setTexture", &uniform, &bindCode, &index)) {
+		PyErr_SetString(PyExc_ValueError, "setUniformTexture(name, bindCode, index(from 0 to 7)): KX_2DFilter, invalid textureName, textureBindCode or index");
+		return NULL;
+	}
+	if ((index < 0 && index != -99) || index >= RAS_Texture::MaxUnits) {
+		PyErr_SetString(PyExc_ValueError, "setUniformTexture(name, bindCode, index): KX_2DFilter, index out of range [0, 7]");
+		return NULL;
+	}
+
+	if (!RAS_Texture::CheckBindCode(bindCode)) {
+		PyErr_Format(PyExc_ValueError, "setUniformTexture(name, bindCode, index): KX_2DFilter, bindCode (%i) invalid", bindCode);
+		return NULL;
+	}
+
+	if (index != -99) {
+		int loc = GetUniformLocation(uniform);
+		SetUniformiv(loc, RAS_Uniform::UNI_INT, &index, (sizeof(int)), 1);
+		m_textures[index] = bindCode;
+	}
+	else {
+		for (int i = 0; i < RAS_Texture::MaxUnits; i++) {
+			if (m_textures[i] == 0) {
+				int loc = GetUniformLocation(uniform);
+				SetUniformiv(loc, RAS_Uniform::UNI_INT, &i, (sizeof(int)), 1);
+				m_textures[i] = bindCode;
+				if (i == RAS_Texture::MaxUnits && m_textures[i] != 0) {
+					printf("warning: All textures slots available are already used.\n");
+					printf("Please use optionnal setUniformTexture(name, bindCode, index) index argument to overwrite an emplacement.\n");
+				}
+				break;
+			}
+		}
+	}
 	Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -42,6 +42,7 @@ public:
 #ifdef WITH_PYTHON
 
 	KX_PYMETHOD_DOC(KX_2DFilter, setTexture);
+	KX_PYMETHOD_DOC(KX_2DFilter, setUniformTexture);
 
 #endif
 };

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1013,7 +1013,7 @@ void RAS_OpenGLRasterizer::DrawDerivedMesh(RAS_MeshSlot *ms)
 		Material* blmat = current_polymat->GetBlenderMaterial();
 		Scene* blscene = current_polymat->GetBlenderScene();
 		if (!current_wireframe && blscene && blmat)
-			GPU_material_vertex_attributes(GPU_material_from_blender(blscene, blmat, false), &current_gpu_attribs);
+			GPU_material_vertex_attributes(GPU_material_from_blender(blscene, blmat, false, current_polymat->UseInstancing()), &current_gpu_attribs);
 		else
 			memset(&current_gpu_attribs, 0, sizeof(current_gpu_attribs));
 		// DM draw can mess up blending mode, restore at the end

--- a/source/gameengine/VideoTexture/Texture.h
+++ b/source/gameengine/VideoTexture/Texture.h
@@ -57,6 +57,8 @@ struct Texture
 	unsigned int m_actTex;
 	// original texture bind code
 	unsigned int m_orgTex;
+	// original image bind code
+	unsigned int m_orgImg;
 	// original texture saved
 	bool m_orgSaved;
 


### PR DESCRIPTION
I think the system with setTexture then setSampler is too complex to
understand for the user. But as setTexture method could be used to assign
a bindcode to m_texture[index] without having to setSampler, I propose to
add another method in KX_2DFilter to set uniform as we did usually in
BL_Shader methods: setUniform...(name, value). I think this is more
understandable for the end user.
The setUniformTexture(textureName, textureBindCode, index) method sets
uniform sampler2D texturename with the bindcode of the texture we want to
bind in the 2D Filter. Index argument is optional: It allows the user to
choose at which emplacement of m_textures list he wants to bind his
texture. Like that, if all the emplacement in m_textures list are already
filled, the user can choose to overwrite an existing emplacement with his
texture bindcode.
If all emplacements in m_textures list are already filled, the user can't
bind additional texture in his 2D filter. A warning message inform him
that all the available m_textures slots are already filled with a
bindcode, so that he has to use optional index argument to overwrite
m_textures[index] with his bindcode.

test file: http://www.pasteall.org/blend/41949