### PR TITLE
UPBGE: Reload GPU textures when were invalidated.

### DIFF
--- a/source/blender/gpu/GPU_texture.h
+++ b/source/blender/gpu/GPU_texture.h
@@ -81,6 +81,7 @@ void GPU_invalid_tex_free(void);
 void GPU_texture_free(GPUTexture *tex);
 
 void GPU_texture_ref(GPUTexture *tex);
+int GPU_texture_ref_count(GPUTexture *tex);
 
 void GPU_texture_bind(GPUTexture *tex, int number);
 void GPU_texture_unbind(GPUTexture *tex);

--- a/source/blender/gpu/intern/gpu_texture.c
+++ b/source/blender/gpu/intern/gpu_texture.c
@@ -726,6 +726,11 @@ void GPU_texture_ref(GPUTexture *tex)
 	tex->refcount++;
 }
 
+int GPU_texture_ref_count(GPUTexture *tex)
+{
+	return tex->refcount;
+}
+
 int GPU_texture_target(const GPUTexture *tex)
 {
 	return tex->target;

--- a/source/gameengine/Ketsji/BL_Texture.h
+++ b/source/gameengine/Ketsji/BL_Texture.h
@@ -36,6 +36,7 @@ class BL_Texture : public CValue, public RAS_Texture
 {
 	Py_Header
 private:
+	bool m_cubeMap;
 	MTex *m_mtex;
 	GPUTexture *m_gpuTex;
 
@@ -55,6 +56,8 @@ private:
 		float lodbias;
 	} m_savedData;
 
+	GPUTexture *GetGPUTexture();
+
 public:
 	BL_Texture(MTex *mtex, bool cubemap);
 	virtual ~BL_Texture();
@@ -73,7 +76,7 @@ public:
 	virtual MTex *GetMTex();
 	virtual Image *GetImage();
 
-	virtual unsigned int GetTextureType() const;
+	virtual unsigned int GetTextureType();
 
 	enum {MaxUnits = 8};
 

--- a/source/gameengine/Rasterizer/RAS_Texture.h
+++ b/source/gameengine/Rasterizer/RAS_Texture.h
@@ -46,7 +46,7 @@ public:
 	virtual Image *GetImage() = 0;
 	STR_String& GetName();
 
-	virtual unsigned int GetTextureType() const = 0;
+	virtual unsigned int GetTextureType() = 0;
 
 	/// Return GL_TEXTURE_2D
 	static int GetCubeMapTextureType();


### PR DESCRIPTION
Previosuly any call to GPU_set_anisotropic or GPU_set_gpu_mipmapping was
freeing all gpu textures, but BL_Texture was still using the old pointer
to this freed texture. This was not causing segfault but the bind code
was just invalid.

To solve this we first ensure that the gpu texture we will not be freed
by calling GPu_texture_ref in BL_Texture which has as effect to increment
the user counter in the gpu texture. But it's not enought since even if we
have a valid texture the material is already using the a new copy of the
gpu texture (which is cooresponding to the needs by GPU_set_anisotropic
and GPU_set_gpu_mipmapping). To get a pointer of the used texture in BL_Texture
we use a new function GetGPUTexture.
This function returns always the updated gpu texture. Internally of this
function we can detect that a texture is only owned by us by caling
GPU_texture_ref_count, if it returns 1 then it means that no anymore materials
are using it and that only the BL_Texture keep it alive (by the previous
call to GPU_texture_ref). Then we free the texture by freeing it in the
image and get the current used gpu texture with GPU_texture_from_blender.
The new gpu texture pointer is copied in m_gpuTex.
The GetGPUTexture function is called everytime we need to use the gpu
texture and must replace any direct use of m_gpuTex other than in the
BL_Texture constructor.

Add the BL_Texture destructor if there a gpu texture we release the user
counter by calling GPU_texture_free.