### PR TITLE
Refactor KX_Lod to implement python API for lod levels (and eventually lodManager)

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
@@ -29,7 +29,9 @@ base class --- :class:`KX_GameObject`
 
    .. attribute:: lodFactor
 
-      The camera's level of detail factor value.
+      The factor to multiply distance to camera to ajust levels of detail.
+      A float < 1.0f will make the distance to camera used to compute
+      levels of detail decrease.
 
       :type: float
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
@@ -27,7 +27,7 @@ base class --- :class:`KX_GameObject`
 
       :type: float
 
-   .. attribute:: lodFactor
+   .. attribute:: lodDistanceFactor
 
       The factor to multiply distance to camera to ajust levels of detail.
       A float < 1.0f will make the distance to camera used to compute

--- a/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
@@ -27,6 +27,12 @@ base class --- :class:`KX_GameObject`
 
       :type: float
 
+   .. attribute:: lodFactor
+
+      The camera's level of detail factor value.
+
+      :type: float
+
    .. attribute:: fov
 
       The camera's field of view value.

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -498,12 +498,10 @@ base class --- :class:`SCA_IObject`
 
    .. attribute:: lodManager
 
-      Return the :class:`KX_LodManager` of this KX_GameObject.
-      We need to access lodManager to set attributes of levels of detail
-      for this KX_GameObject. Example:
-      KX_GameObject.lodManager.lodLevel[0].distance = 25.0.
+      Return the lod manager of this KX_GameObject.
+      Needed to access to lod manager to set attributes of levels of detail of this object.
 
-      :type: :class:`KX_LodManager` (read-only)
+      :type: :class:`KX_LodManager`
 
    .. method:: endObject()
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -498,7 +498,7 @@ base class --- :class:`SCA_IObject`
 
    .. attribute:: lodManager
 
-      Return the lod manager of this KX_GameObject.
+      Return the lod manager of this object.
       Needed to access to lod manager to set attributes of levels of detail of this object.
 
       :type: :class:`KX_LodManager`

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -496,6 +496,15 @@ base class --- :class:`SCA_IObject`
 
       :type: int
 
+   .. attribute:: lodManager
+
+      Return the :class:`KX_LodManager` of this KX_GameObject.
+      We need to access lodManager to set attributes of levels of detail
+      for this KX_GameObject. Example:
+      KX_GameObject.lodManager.lodLevel[0].distance = 25.0.
+
+      :type: :class:`KX_LodManager` (read-only)
+
    .. method:: endObject()
 
       Delete this object, can be used in place of the EndObject Actuator.

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -17,7 +17,7 @@ base class --- :class:`PyObjectPlus`
 
    .. attribute:: level
 
-      The id of the lod level. (read only)
+      The number of the lod level. (read only)
 
       :type: integer
 
@@ -41,7 +41,7 @@ base class --- :class:`PyObjectPlus`
 
    .. attribute:: useMaterial
 
-      Return True if the lod level uses a diferent mesh than the original object mesh material. (read only)
+      Return True if the lod level uses a different material than the original object mesh material. (read only)
 
       :type: boolean
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -1,0 +1,34 @@
+KX_LodLevel(PyObjectPlus)
+=========================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_LodLevel(PyObjectPlus)
+
+   A single Lod Level for a KX_GameObject.
+
+   .. attribute:: meshName
+
+      The name of the mesh used at this lod level.
+
+      :type: string (read only)
+
+   .. attribute:: useHysteresis
+
+      return true is this lod level use hysteresis override and false if not.
+
+      :type: boolean (read only)
+
+   .. attribute:: distance
+
+      Distance to begin using this level of detail.
+
+      :type: float (0.0 to 99999999.0)
+
+   .. attribute:: hysteresis
+
+      Minimum distance change required to transition to the previous level of detail.
+
+      :type: float (0.0 to 100.0 (percents))

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -9,11 +9,29 @@ base class --- :class:`PyObjectPlus`
 
    A single Lod Level for a KX_GameObject.
 
-   .. attribute:: meshName
+   .. attribute:: mesh
 
-      The name of the mesh used at this lod level.
+      The mesh used at this lod level.
 
-      :type: string (read only)
+      :type: :class:`RAS_MeshObject`(read only)
+
+   .. attribute:: level
+
+      The id of the KX_LodLevel.
+
+      :type: integer(read only)
+
+   .. attribute:: useMesh
+
+      Return True if this KX_LodLevel has a mesh, False if not.
+
+      :type: boolean(read only)
+
+   .. attribute:: useMaterial
+
+      Return True if this KX_LodLevel has a mesh with at least one material, False if not.
+
+      :type: boolean(read only)
 
    .. attribute:: useHysteresis
 
@@ -25,7 +43,7 @@ base class --- :class:`PyObjectPlus`
 
       Distance to begin using this level of detail.
 
-      :type: float (0.0 to 99999999.0)
+      :type: float (0.0 to infinite)
 
    .. attribute:: hysteresis
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -7,46 +7,46 @@ base class --- :class:`PyObjectPlus`
 
 .. class:: KX_LodLevel(PyObjectPlus)
 
-   A single Lod Level for a KX_GameObject.
+   A single lod level for a game object lod manager.
 
    .. attribute:: mesh
 
-      The mesh used at this lod level.
+      The mesh used for this lod level. (read only)
 
-      :type: :class:`RAS_MeshObject`(read only)
+      :type: :class:`RAS_MeshObject`
 
    .. attribute:: level
 
-      The id of the KX_LodLevel.
+      The id of the lod level. (read only)
 
-      :type: integer(read only)
-
-   .. attribute:: useMesh
-
-      Return True if this KX_LodLevel has a mesh, False if not.
-
-      :type: boolean(read only)
-
-   .. attribute:: useMaterial
-
-      Return True if this KX_LodLevel has a mesh with at least one material, False if not.
-
-      :type: boolean(read only)
-
-   .. attribute:: useHysteresis
-
-      return true is this lod level use hysteresis override and false if not.
-
-      :type: boolean (read only)
+      :type: integer
 
    .. attribute:: distance
 
-      Distance to begin using this level of detail.
+      Distance to begin using this level of detail. (read only)
 
       :type: float (0.0 to infinite)
 
    .. attribute:: hysteresis
 
-      Minimum distance change required to transition to the previous level of detail.
+      Minimum distance factor change required to transition to the previous level of detail in percent. (read only)
 
-      :type: float (0.0 to 100.0 (percents))
+      :type: float [0.0 to 100.0]
+
+   .. attribute:: useMesh
+
+      Return True if the lod level uses a different mesh than the original object mesh. (read only)
+
+      :type: boolean
+
+   .. attribute:: useMaterial
+
+      Return True if the lod level uses a diferent mesh than the original object mesh material. (read only)
+
+      :type: boolean
+
+   .. attribute:: useHysteresis
+
+      Return true if the lod level uses hysteresis override. (read only)
+
+      :type: boolean

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
@@ -9,7 +9,7 @@ base class --- :class:`PyObjectPlus`
 
    This class contains a list of all levels of detail for a KX_GameObject.
 
-   .. attribute:: lodLevel
+   .. attribute:: levels
 
       Return the list of all levels of detail of the KX_GameObject.
       To select one level (:class:`KX_LodLevel`), you can do:
@@ -18,11 +18,8 @@ base class --- :class:`PyObjectPlus`
 
       :type: list (read only)
 
-   .. attribute:: lodLevelScale
+   .. attribute:: distanceFactor
 
-      Method to set the distance of all levels of detail for a game object at the same time.
-      For example, if a KX_GameObject has a lod1 with a distance = 25.0 and a lod2 with
-      a distance = 50.0 and you set the lodLevelScale to 2.0, lod1.distance will be equal to 50.0
-      and lod2 will be equal to 100.0.
+      Method to multiply the distance to the camera.
 
       :type: float

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
@@ -1,0 +1,28 @@
+KX_LodManager(PyObjectPlus)
+===========================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_LodManager(PyObjectPlus)
+
+   This class contains a list of all levels of detail for a KX_GameObject.
+
+   .. attribute:: lodLevel
+
+      Return the list of all levels of detail of the KX_GameObject.
+      To select one level (:class:`KX_LodLevel`), you can do:
+      KX_GameObject.lodManager.lodLevel[index] and then you can set
+      individual attributes for this level of detail.
+
+      :type: list (read only)
+
+   .. attribute:: lodLevelScale
+
+      Method to set the distance of all levels of detail for a game object at the same time.
+      For example, if a KX_GameObject has a lod1 with a distance = 25.0 and a lod2 with
+      a distance = 50.0 and you set the lodLevelScale to 2.0, lod1.distance will be equal to 50.0
+      and lod2 will be equal to 100.0.
+
+      :type: float

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
@@ -7,16 +7,13 @@ base class --- :class:`PyObjectPlus`
 
 .. class:: KX_LodManager(PyObjectPlus)
 
-   This class contains a list of all levels of detail for a KX_GameObject.
+   This class contains a list of all levels of detail used by a game object.
 
    .. attribute:: levels
 
-      Return the list of all levels of detail of the KX_GameObject.
-      To select one level (:class:`KX_LodLevel`), you can do:
-      KX_GameObject.lodManager.lodLevel[index] and then you can set
-      individual attributes for this level of detail.
+      Return the list of all levels of detail of the lod manager.
 
-      :type: list (read only)
+      :type: list of :class:`KX_LodLevel`
 
    .. attribute:: distanceFactor
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,6 +143,12 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
+   .. attribute:: lodGlobalScale
+
+      All the scene objects with level of detail LOD scale.
+
+      :type: float
+
    .. method:: addObject(object, reference, time=0.0)
 
       Adds an object to the scene like the Add Object Actuator would.

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,17 +143,6 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
-   .. method:: setLodScale(pythonObjectList, scale)
-
-      Set LOD scale for all objects with LOD in the pythonObjectList.
-
-      :arg pythonObjectList: list of KX_GameObject with LOD to set 
-      :type: list
-      :arg scale: factor to scale initial LOD distance. If the initial distance of a
-      KX_GameObject in the list is 25.0 and the scale is 2.0, the LOD distance for
-      this KX_GameObject will become 50.0.
-      :type: float
-
    .. method:: addObject(object, reference, time=0.0)
 
       Adds an object to the scene like the Add Object Actuator would.

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,10 +143,15 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
-   .. attribute:: lodGlobalScale
+   .. method:: setLodScale(pythonObjectList, scale)
 
-      All the scene objects with level of detail LOD scale.
+      Set LOD scale for all objects with LOD in the pythonObjectList.
 
+      :arg pythonObjectList: list of KX_GameObject with LOD to set 
+      :type: list
+      :arg scale: factor to scale initial LOD distance. If the initial distance of a
+      KX_GameObject in the list is 25.0 and the scale is 2.0, the LOD distance for
+      this KX_GameObject will become 50.0.
       :type: float
 
    .. method:: addObject(object, reference, time=0.0)

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -76,6 +76,7 @@
 #include "KX_Camera.h"
 #include "KX_EmptyObject.h"
 #include "KX_FontObject.h"
+#include "KX_LodManager.h"
 
 #include "RAS_ICanvas.h"
 #include "RAS_Polygon.h"
@@ -176,8 +177,6 @@ extern Material defmaterial;	/* material.c */
 
 #include "KX_NavMeshObject.h"
 #include "KX_ObstacleSimulation.h"
-
-#include "KX_Lod.h"
 
 #include "BLI_threads.h"
 
@@ -952,9 +951,9 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 	}
 }
 
-static KX_LodList *lodlist_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
+static KX_LodManager *lodlist_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
 {
-	KX_LodList *lodList = new KX_LodList(ob, scene, converter, libloading);
+	KX_LodManager *lodList = new KX_LodManager(ob, scene, converter, libloading);
 	if (lodList->Empty()) {
 		lodList->Release();
 		return NULL;
@@ -1085,8 +1084,8 @@ static KX_GameObject *gameobject_from_blenderobject(
 		gameobj->AddMesh(meshobj);
 
 		// gather levels of detail
-		KX_LodList *lodList = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
-		gameobj->SetLodList(lodList);
+		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
+		gameobj->SetLodManager(lodManager);
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1086,6 +1086,10 @@ static KX_GameObject *gameobject_from_blenderobject(
 		// gather levels of detail
 		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
+		if (gameobj->GetLodManager()) {
+			KX_Scene *kxscene = gameobj->GetScene();
+			kxscene->LodObjectListAppend(gameobj);
+		}
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -951,15 +951,15 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 	}
 }
 
-static KX_LodManager *lodlist_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
+static KX_LodManager *lodmanager_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
 {
-	KX_LodManager *lodList = new KX_LodManager(ob, scene, converter, libloading);
-	if (lodList->Empty()) {
-		lodList->Release();
+	KX_LodManager *lodManager = new KX_LodManager(ob, scene, converter, libloading);
+	if (lodManager->Empty()) {
+		lodManager->Release();
 		return NULL;
 	}
 
-	return lodList;
+	return lodManager;
 }
 
 static KX_LightObject *gamelight_from_blamp(Object *ob, Lamp *la, unsigned int layerflag, KX_Scene *kxscene, RAS_IRasterizer *rasterizer, KX_BlenderSceneConverter *converter)
@@ -1084,7 +1084,7 @@ static KX_GameObject *gameobject_from_blenderobject(
 		gameobj->AddMesh(meshobj);
 
 		// gather levels of detail
-		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
+		KX_LodManager *lodManager = lodmanager_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
 
 		// for all objects: check whether they want to

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -953,8 +953,13 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 
 static KX_LodManager *lodmanager_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
 {
+	if (BLI_listbase_count_ex(&ob->lodlevels, 2) <= 1) {
+		return NULL;
+	}
+
 	KX_LodManager *lodManager = new KX_LodManager(ob, scene, converter, libloading);
-	if (lodManager->Empty()) {
+	// The lod manager is useless ?
+	if (lodManager->GetLevelCount() == 0) {
 		lodManager->Release();
 		return NULL;
 	}

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1086,10 +1086,6 @@ static KX_GameObject *gameobject_from_blenderobject(
 		// gather levels of detail
 		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
-		if (gameobj->GetLodManager()) {
-			KX_Scene *kxscene = gameobj->GetScene();
-			kxscene->LodObjectListAppend(gameobj);
-		}
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -88,7 +88,8 @@ set(SRC
 	KX_KetsjiEngine.cpp
 	KX_Light.cpp
 	KX_LightIpoSGController.cpp
-	KX_Lod.cpp
+	KX_LodLevel.cpp
+	KX_LodManager.cpp
 	KX_MaterialIpoController.cpp
 	KX_MeshProxy.cpp
 	KX_MotionState.cpp
@@ -170,7 +171,8 @@ set(SRC
 	KX_KetsjiEngine.h
 	KX_Light.h
 	KX_LightIpoSGController.h
-	KX_Lod.h
+	KX_LodLevel.h
+	KX_LodManager.h
 	KX_MaterialIpoController.h
 	KX_MeshProxy.h
 	KX_MotionState.h

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -54,7 +54,7 @@ KX_Camera::KX_Camera(void* sgReplicationInfo,
       m_set_projection_matrix(false),
       m_set_frustum_center(false),
       m_delete_node(delete_node),
-	  m_lodFactor(1.0f)
+	  m_lodDistanceFactor(1.0f)
 {
 	// setting a name would be nice...
 	m_name = "cam";
@@ -265,14 +265,14 @@ RAS_CameraData*	KX_Camera::GetCameraData()
 	return &m_camdata; 
 }
 
-float KX_Camera::GetLodFactor() const
+float KX_Camera::GetLodDistanceFactor() const
 {
-	return m_lodFactor;
+	return m_lodDistanceFactor;
 }
 
-void KX_Camera::SetLodFactor(float lodfactor)
+void KX_Camera::SetLodDistanceFactor(float lodfactor)
 {
-	m_lodFactor = lodfactor;
+	m_lodDistanceFactor = lodfactor;
 }
 
 void KX_Camera::ExtractClipPlanes()
@@ -558,7 +558,7 @@ PyAttributeDef KX_Camera::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("far",	KX_Camera,	pyattr_get_far,  pyattr_set_far),
 	KX_PYATTRIBUTE_RW_FUNCTION("shift_x",	KX_Camera,	pyattr_get_shift_x, pyattr_set_shift_x),
 	KX_PYATTRIBUTE_RW_FUNCTION("shift_y",	KX_Camera,	pyattr_get_shift_y,  pyattr_set_shift_y),
-	KX_PYATTRIBUTE_FLOAT_RW("lodFactor", 0.0f, FLT_MAX, KX_Camera, m_lodFactor),
+	KX_PYATTRIBUTE_FLOAT_RW("lodDistanceFactor", 0.0f, FLT_MAX, KX_Camera, m_lodDistanceFactor),
 
 	KX_PYATTRIBUTE_RW_FUNCTION("useViewport",	KX_Camera,	pyattr_get_use_viewport,  pyattr_set_use_viewport),
 	

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -53,7 +53,8 @@ KX_Camera::KX_Camera(void* sgReplicationInfo,
       m_frustum_culling(frustum_culling),
       m_set_projection_matrix(false),
       m_set_frustum_center(false),
-      m_delete_node(delete_node)
+      m_delete_node(delete_node),
+	  m_lodFactor(1.0f)
 {
 	// setting a name would be nice...
 	m_name = "cam";
@@ -262,6 +263,16 @@ float KX_Camera::GetFocalLength() const
 RAS_CameraData*	KX_Camera::GetCameraData()
 {
 	return &m_camdata; 
+}
+
+float KX_Camera::GetLodFactor() const
+{
+	return m_lodFactor;
+}
+
+void KX_Camera::SetLodFactor(float lodfactor)
+{
+	m_lodFactor = lodfactor;
 }
 
 void KX_Camera::ExtractClipPlanes()
@@ -547,6 +558,7 @@ PyAttributeDef KX_Camera::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("far",	KX_Camera,	pyattr_get_far,  pyattr_set_far),
 	KX_PYATTRIBUTE_RW_FUNCTION("shift_x",	KX_Camera,	pyattr_get_shift_x, pyattr_set_shift_x),
 	KX_PYATTRIBUTE_RW_FUNCTION("shift_y",	KX_Camera,	pyattr_get_shift_y,  pyattr_set_shift_y),
+	KX_PYATTRIBUTE_FLOAT_RW("lodFactor", 0.0f, FLT_MAX, KX_Camera, m_lodFactor),
 
 	KX_PYATTRIBUTE_RW_FUNCTION("useViewport",	KX_Camera,	pyattr_get_use_viewport,  pyattr_set_use_viewport),
 	
@@ -920,7 +932,6 @@ int KX_Camera::pyattr_set_use_viewport(void *self_v, const KX_PYATTRIBUTE_DEF *a
 	self->EnableViewport((bool)param);
 	return PY_SET_ATTR_SUCCESS;
 }
-
 
 PyObject *KX_Camera::pyattr_get_projection_matrix(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -82,7 +82,7 @@ protected:
 	 * Storage for the modelview matrix that is passed to the
 	 * rasterizer. */
 	MT_Matrix4x4 m_modelview_matrix;
-	
+
 	/**
 	 * true if the view frustum (modelview/projection matrix)
 	 * has changed - the clip planes (m_planes) will have to be
@@ -121,6 +121,10 @@ protected:
 	 * whether the camera should delete the node itself (only for shadow camera)
 	 */
 	bool         m_delete_node;
+
+
+	/** Factor for level of detail*/
+	float m_lodFactor;
 
 	/**
 	 * Extracts the camera clip frames from the projection and world-to-camera matrices.
@@ -218,6 +222,11 @@ public:
 	float				GetFocalLength() const;
 	/** Gets all camera data. */
 	RAS_CameraData*		GetCameraData();
+
+	/** Get level of detail factor */
+	float GetLodFactor() const;
+	/** Set level of detail factor */
+	void SetLodFactor(float lodfactor);
 	
 	/**
 	 * Tests if the given sphere is inside this camera's view frustum.

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -123,7 +123,7 @@ protected:
 	bool         m_delete_node;
 
 
-	/** Disance factor for level of detail*/
+	/** Distance factor for level of detail*/
 	float m_lodDistanceFactor;
 
 	/**
@@ -223,9 +223,9 @@ public:
 	/** Gets all camera data. */
 	RAS_CameraData*		GetCameraData();
 
-	/** Get level of detail factor */
+	/** Get level of detail distance factor */
 	float GetLodDistanceFactor() const;
-	/** Set level of detail factor */
+	/** Set level of detail distance factor */
 	void SetLodDistanceFactor(float lodfactor);
 	
 	/**

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -123,8 +123,8 @@ protected:
 	bool         m_delete_node;
 
 
-	/** Factor for level of detail*/
-	float m_lodFactor;
+	/** Disance factor for level of detail*/
+	float m_lodDistanceFactor;
 
 	/**
 	 * Extracts the camera clip frames from the projection and world-to-camera matrices.
@@ -224,9 +224,9 @@ public:
 	RAS_CameraData*		GetCameraData();
 
 	/** Get level of detail factor */
-	float GetLodFactor() const;
+	float GetLodDistanceFactor() const;
 	/** Set level of detail factor */
-	void SetLodFactor(float lodfactor);
+	void SetLodDistanceFactor(float lodfactor);
 	
 	/**
 	 * Tests if the given sphere is inside this camera's view frustum.

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2055,6 +2055,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("debug",	KX_GameObject, pyattr_get_debug, pyattr_set_debug),
 	KX_PYATTRIBUTE_RO_FUNCTION("components", KX_GameObject, pyattr_get_components),
 	KX_PYATTRIBUTE_RW_FUNCTION("debugRecursive",	KX_GameObject, pyattr_get_debugRecursive, pyattr_set_debugRecursive),
+	KX_PYATTRIBUTE_RO_FUNCTION("lod", KX_GameObject, pyattr_get_lodlist),
 	
 	/* experimental, don't rely on these yet */
 	KX_PYATTRIBUTE_RO_FUNCTION("sensors",		KX_GameObject, pyattr_get_sensors),
@@ -3273,6 +3274,17 @@ int KX_GameObject::pyattr_set_debugRecursive(void *self_v, const KX_PYATTRIBUTE_
 	self->SetUseDebugProperties(param, true);
 
 	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_GameObject *self = static_cast<KX_GameObject*>(self_v);
+	if (!self->m_lodList) {
+		PyErr_SetString(PyExc_ValueError, "KX_GameObject.lod: there is no lod levels for this gameobject");
+		return NULL;
+	}
+
+	return self->m_lodList->GetProxy();
 }
 
 PyObject *KX_GameObject::PyApplyForce(PyObject *args)

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -796,15 +796,14 @@ void KX_GameObject::RemoveMeshes()
 	m_meshes.clear();
 }
 
-void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos)
+void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos, float lodfactor)
 {
 	if (!m_lodManager) {
 		return;
 	}
 
 	KX_Scene *scene = GetScene();
-	float distance2 = NodeGetWorldPosition().distance2(cam_pos);
-
+	const float distance2 = NodeGetWorldPosition().distance2(cam_pos) * (lodfactor * lodfactor);
 	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, distance2);
 	const unsigned short level = lodLevel->GetLevel();
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -801,6 +801,14 @@ void KX_GameObject::SetLodManager(KX_LodManager *lodManager)
 	// Reset lod level to avoid bugs on KX_LodManager::GetLevel.
 	m_previousLodLevel = 0;
 	m_currentLodLevel = 0;
+
+	// Restore object original mesh.
+	if (!lodManager && m_lodManager && m_lodManager->GetLevelCount() > 0) {
+		KX_Scene *scene = GetScene();
+		RAS_MeshObject *origmesh = m_lodManager->GetLevel(0)->GetMesh();
+		scene->ReplaceMesh(this, origmesh, true, false);
+	}
+
 	m_lodManager = lodManager;
 }
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -62,6 +62,7 @@
 #include "KX_NetworkMessageScene.h" //Needed for sendMessage()
 #include "KX_ObstacleSimulation.h"
 #include "KX_Scene.h"
+#include "KX_LodLevel.h"
 #include "KX_LodManager.h"
 #include "KX_CollisionContactPoints.h"
 

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -797,18 +797,10 @@ public:
 	}
 
 
-	/**
-	 * Set library of lod meshes
-	 */
-	void SetLodManager(KX_LodManager *lodManager)
-	{
-		m_lodManager = lodManager;
-	}
-
-	KX_LodManager *GetLodManager()
-	{
-		return m_lodManager;
-	}
+	/// Set library of lod meshes.
+	void SetLodManager(KX_LodManager *lodManager);
+	/// Get library of lod meshes.
+	KX_LodManager *GetLodManager() const;
 
 	/**
 	 * Updates the current lod level based on distance from camera.
@@ -1114,7 +1106,8 @@ public:
 	static int			pyattr_set_linearDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_lodmanager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject*	pyattr_get_lodManager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int			pyattr_set_lodManager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	/* Experimental! */
 	static PyObject*	pyattr_get_sensors(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -797,9 +797,11 @@ public:
 	}
 
 
-	/// Set library of lod meshes.
+	/** Set current lod manager, can be NULL.
+	 * If NULL the object's mesh backs to the original mesh.
+	 */
 	void SetLodManager(KX_LodManager *lodManager);
-	/// Get library of lod meshes.
+	/// Get current lod manager.
 	KX_LodManager *GetLodManager() const;
 
 	/**

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -813,7 +813,7 @@ public:
 	/**
 	 * Updates the current lod level based on distance from camera.
 	 */
-	void UpdateLod(const MT_Vector3& cam_pos);
+	void UpdateLod(const MT_Vector3& cam_pos, float lodfactor);
 
 	/**
 	 * Pick out a mesh associated with the integer 'num'.

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -54,7 +54,7 @@
 //Forward declarations.
 struct KX_ClientObjectInfo;
 class KX_RayCast;
-class KX_LodList;
+class KX_LodManager;
 class RAS_MeshObject;
 class RAS_MeshUser;
 class PHY_IGraphicController;
@@ -89,7 +89,7 @@ protected:
 	STR_String							m_text;
 	int									m_layer;
 	std::vector<RAS_MeshObject*>		m_meshes;
-	KX_LodList							*m_lodList;
+	KX_LodManager						*m_lodManager;
 	int                                 m_currentLodLevel;
 	short								m_previousLodLevel;
 	RAS_MeshUser						*m_meshUser;
@@ -800,14 +800,14 @@ public:
 	/**
 	 * Set library of lod meshes
 	 */
-	void SetLodList(KX_LodList *lodList)
+	void SetLodManager(KX_LodManager *lodManager)
 	{
-		m_lodList = lodList;
+		m_lodManager = lodManager;
 	}
 
-	KX_LodList *GetLodList()
+	KX_LodManager *GetLodManager()
 	{
-		return m_lodList;
+		return m_lodManager;
 	}
 
 	/**
@@ -1114,7 +1114,7 @@ public:
 	static int			pyattr_set_linearDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject*	pyattr_get_lodmanager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
 	/* Experimental! */
 	static PyObject*	pyattr_get_sensors(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -1114,6 +1114,7 @@ public:
 	static int			pyattr_set_linearDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
 	/* Experimental! */
 	static PyObject*	pyattr_get_sensors(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_Lod.h
+++ b/source/gameengine/Ketsji/KX_Lod.h
@@ -21,15 +21,16 @@
  */
 
 #include "EXP_Value.h"
+#include "RAS_MeshObject.h"
 #include <vector>
 
-class RAS_MeshObject;
 class KX_Scene;
 class KX_BlenderSceneConverter;
 struct Object;
 
-class KX_LodList
+class KX_LodList: public CValue
 {
+	Py_Header
 public:
 	struct Level
 	{
@@ -56,9 +57,29 @@ private:
 
 	int m_refcount;
 
+	STR_String m_lodListName;
+
 public:
 	KX_LodList(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodList();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
+
+#ifdef WITH_PYTHON
+
+	//static PyObject *pyattr_get_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
+	KX_PYMETHOD_DOC(KX_LodList, getLevelMeshName);
+
+#endif //WITH_PYTHON
 
 	/** Get lod level cooresponding to distance and previous level.
 	 * \param scene Scene used to get default hysteresis.

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -1,0 +1,117 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* Contributor(s): Porteries Tristan.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+#include "KX_LodLevel.h"
+
+KX_LodLevel::KX_LodLevel()
+{
+}
+
+KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag)
+	:m_distance(distance),
+	m_hysteresis(hysteresis),
+	m_level(level),
+	m_meshobj(meshobj),
+	m_flags(flag)
+{
+}
+
+KX_LodLevel::~KX_LodLevel()
+{
+}
+
+// stuff for cvalue related things
+CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+const STR_String &KX_LodLevel::GetText()
+{
+	return GetName();
+}
+
+double KX_LodLevel::GetNumber()
+{
+	return -1.0;
+}
+
+STR_String &KX_LodLevel::GetName()
+{
+	return m_meshobj->GetName();
+}
+
+void KX_LodLevel::SetName(const char *name)
+{
+}
+
+CValue *KX_LodLevel::GetReplica()
+{
+	return NULL;
+}
+
+#ifdef WITH_PYTHON
+
+PyTypeObject KX_LodLevel::Type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"KX_LodLevel",
+	sizeof(PyObjectPlus_Proxy),
+	0,
+	py_base_dealloc,
+	0,
+	0,
+	0,
+	0,
+	py_base_repr,
+	0, 0, 0, 0, 0, 0, 0, 0, 0,
+	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	0, 0, 0, 0, 0, 0, 0,
+	Methods,
+	0,
+	0,
+	&CValue::Type,
+	0, 0, 0, 0, 0, 0,
+	py_base_new
+};
+
+PyMethodDef KX_LodLevel::Methods[] = {
+	//KX_PYMETHODTABLE(KX_LodLevel, getLevelMeshName),
+	{ NULL, NULL } //Sentinel
+};
+
+PyAttributeDef KX_LodLevel::Attributes[] = {
+	KX_PYATTRIBUTE_RO_FUNCTION("meshName", KX_LodLevel, pyattr_get_mesh_name),
+	{ NULL }    //Sentinel
+};
+
+PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	return PyUnicode_FromString(self->GetName());
+}
+
+#endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -30,14 +30,38 @@ KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level,
 	:m_distance(distance),
 	m_hysteresis(hysteresis),
 	m_level(level),
-	m_meshobj(meshobj),
-	m_flags(flag)
+	m_flags(flag),
+	m_meshobj(meshobj)
 {
-	m_initialDistance = distance;
 }
 
 KX_LodLevel::~KX_LodLevel()
 {
+}
+
+float KX_LodLevel::GetDistance() const
+{
+	return m_distance;
+}
+
+float KX_LodLevel::GetHysteresis() const
+{
+	return m_hysteresis;
+}
+
+unsigned short KX_LodLevel::GetLevel() const
+{
+	return m_level;
+}
+
+unsigned short KX_LodLevel::GetFlag() const
+{
+	return m_flags;
+}
+
+RAS_MeshObject *KX_LodLevel::GetMesh() const
+{
+	return m_meshobj;
 }
 
 #ifdef WITH_PYTHON
@@ -65,29 +89,42 @@ PyTypeObject KX_LodLevel::Type = {
 };
 
 PyMethodDef KX_LodLevel::Methods[] = {
-	//KX_PYMETHODTABLE(KX_LodLevel, getLevelMeshName),
-	{ NULL, NULL } //Sentinel
+	{NULL, NULL} // Sentinel
 };
 
 PyAttributeDef KX_LodLevel::Attributes[] = {
-	KX_PYATTRIBUTE_RO_FUNCTION("meshName", KX_LodLevel, pyattr_get_mesh_name),
+	KX_PYATTRIBUTE_RO_FUNCTION("mesh", KX_LodLevel, pyattr_get_mesh),
+	KX_PYATTRIBUTE_SHORT_RO("level", KX_LodLevel, m_level),
+	KX_PYATTRIBUTE_FLOAT_RO("distance", KX_LodLevel, m_distance),
+	KX_PYATTRIBUTE_FLOAT_RO("hysteresis", KX_LodLevel, m_hysteresis),
 	KX_PYATTRIBUTE_RO_FUNCTION("useHysteresis", KX_LodLevel, pyattr_get_use_hysteresis),
-	KX_PYATTRIBUTE_FLOAT_RW("distance", 0.0f, 99999999.0f, KX_LodLevel, m_distance),
-	KX_PYATTRIBUTE_FLOAT_RW("hysteresis", 0.0f, 100.0f, KX_LodLevel, m_hysteresis),
-	{ NULL }    //Sentinel
+	KX_PYATTRIBUTE_RO_FUNCTION("useMesh", KX_LodLevel, pyattr_get_mesh),
+	KX_PYATTRIBUTE_RO_FUNCTION("useMaterial", KX_LodLevel, pyattr_get_use_material),
+	{NULL} // Sentinel
 };
 
-PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *KX_LodLevel::pyattr_get_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return PyUnicode_FromString(self->m_meshobj->GetName());
+	return self->m_meshobj->GetProxy();
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	int useHysteresis = self->GetFlag();
-	return PyBool_FromLong(useHysteresis);
+	return PyBool_FromLong(self->GetFlag() & KX_LodLevel::USE_HYSTERESIS);
+}
+
+PyObject *KX_LodLevel::pyattr_get_use_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	return PyBool_FromLong(self->GetFlag() & KX_LodLevel::USE_MESH);
+}
+
+PyObject *KX_LodLevel::pyattr_get_use_material(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	return PyBool_FromLong(self->GetFlag() & KX_LodLevel::USE_MATERIAL);
 }
 
 #endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -33,6 +33,7 @@ KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level,
 	m_meshobj(meshobj),
 	m_flags(flag)
 {
+	m_initialDistance = distance;
 }
 
 KX_LodLevel::~KX_LodLevel()

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -105,6 +105,9 @@ PyMethodDef KX_LodLevel::Methods[] = {
 
 PyAttributeDef KX_LodLevel::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("meshName", KX_LodLevel, pyattr_get_mesh_name),
+	KX_PYATTRIBUTE_RO_FUNCTION("useHysteresis", KX_LodLevel, pyattr_get_use_hysteresis),
+	KX_PYATTRIBUTE_FLOAT_RW("distance", 0.0f, 99999999.0f, KX_LodLevel, m_distance),
+	KX_PYATTRIBUTE_FLOAT_RW("hysteresis", 0.0f, 100.0f, KX_LodLevel, m_hysteresis),
 	{ NULL }    //Sentinel
 };
 
@@ -112,6 +115,13 @@ PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_D
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
 	return PyUnicode_FromString(self->GetName());
+}
+
+PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	int useHysteresis = self->GetFlag();
+	return PyBool_FromLong(useHysteresis);
 }
 
 #endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -99,7 +99,7 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 	KX_PYATTRIBUTE_FLOAT_RO("distance", KX_LodLevel, m_distance),
 	KX_PYATTRIBUTE_FLOAT_RO("hysteresis", KX_LodLevel, m_hysteresis),
 	KX_PYATTRIBUTE_RO_FUNCTION("useHysteresis", KX_LodLevel, pyattr_get_use_hysteresis),
-	KX_PYATTRIBUTE_RO_FUNCTION("useMesh", KX_LodLevel, pyattr_get_mesh),
+	KX_PYATTRIBUTE_RO_FUNCTION("useMesh", KX_LodLevel, pyattr_get_use_mesh),
 	KX_PYATTRIBUTE_RO_FUNCTION("useMaterial", KX_LodLevel, pyattr_get_use_material),
 	{NULL} // Sentinel
 };

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -15,16 +15,17 @@
 * along with this program; if not, write to the Free Software Foundation,
 * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 *
-* Contributor(s): Porteries Tristan.
+* Contributor(s): Ulysse Martin, Tristan Porteries.
 *
 * ***** END GPL LICENSE BLOCK *****
 */
 
-#include "KX_LodLevel.h"
+/** \file gameengine/Ketsji/KX_LodLevel.cpp
+ *  \ingroup ketsji
+ */
 
-KX_LodLevel::KX_LodLevel()
-{
-}
+#include "KX_LodLevel.h"
+#include "KX_MeshProxy.h"
 
 KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag)
 	:m_distance(distance),
@@ -106,7 +107,8 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 PyObject *KX_LodLevel::pyattr_get_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return self->m_meshobj->GetProxy();
+	KX_MeshProxy *meshproxy = new KX_MeshProxy(self->GetMesh());
+	return meshproxy->NewProxy(true);
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -40,6 +40,41 @@ KX_LodLevel::~KX_LodLevel()
 {
 }
 
+// stuff for cvalue related things
+CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+const STR_String &KX_LodLevel::GetText()
+{
+	return GetName();
+}
+
+double KX_LodLevel::GetNumber()
+{
+	return -1.0;
+}
+
+STR_String &KX_LodLevel::GetName()
+{
+	return m_meshobj->GetName();
+}
+
+void KX_LodLevel::SetName(const char *name)
+{
+}
+
+CValue *KX_LodLevel::GetReplica()
+{
+	return NULL;
+}
+
 #ifdef WITH_PYTHON
 
 PyTypeObject KX_LodLevel::Type = {
@@ -80,7 +115,7 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return PyUnicode_FromString(self->m_meshobj->GetName());
+	return PyUnicode_FromString(self->GetName());
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -40,41 +40,6 @@ KX_LodLevel::~KX_LodLevel()
 {
 }
 
-// stuff for cvalue related things
-CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
-{
-	return NULL;
-}
-
-CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
-{
-	return NULL;
-}
-
-const STR_String &KX_LodLevel::GetText()
-{
-	return GetName();
-}
-
-double KX_LodLevel::GetNumber()
-{
-	return -1.0;
-}
-
-STR_String &KX_LodLevel::GetName()
-{
-	return m_meshobj->GetName();
-}
-
-void KX_LodLevel::SetName(const char *name)
-{
-}
-
-CValue *KX_LodLevel::GetReplica()
-{
-	return NULL;
-}
-
 #ifdef WITH_PYTHON
 
 PyTypeObject KX_LodLevel::Type = {
@@ -115,7 +80,7 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return PyUnicode_FromString(self->GetName());
+	return PyUnicode_FromString(self->m_meshobj->GetName());
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -1,0 +1,81 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* Contributor(s): Porteries Tristan.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+#include "EXP_Value.h"
+#include "RAS_MeshObject.h"
+
+class KX_LodLevel : public CValue
+{
+	Py_Header
+
+private:
+
+	float m_distance;
+	float m_hysteresis;
+	unsigned short m_level;
+	unsigned short m_flags;
+	RAS_MeshObject *m_meshobj;
+
+public:
+	KX_LodLevel();
+	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
+	virtual ~KX_LodLevel();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
+
+	float GetDistance() {
+		return m_distance;
+	}
+	float GetHysteresis() {
+		return m_hysteresis;
+	}
+	unsigned short GetLevel() {
+		return m_level;
+	}
+	unsigned short GetFlag() {
+		return m_flags;
+	}
+	RAS_MeshObject *GetMesh() {
+		return m_meshobj;
+	}
+	enum {
+		// Use custom hysteresis for this level.
+		USE_HYST = (1 << 0),
+	};
+
+#ifdef WITH_PYTHON
+
+	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
+	//KX_PYMETHOD_DOC(KX_LodLevel, getMeshName);
+
+#endif //WITH_PYTHON
+
+};

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -30,6 +30,7 @@ class KX_LodLevel : public CValue
 private:
 
 	float m_distance;
+	float m_initialDistance;
 	float m_hysteresis;
 	unsigned short m_level;
 	unsigned short m_flags;
@@ -51,6 +52,12 @@ public:
 
 	float GetDistance() {
 		return m_distance;
+	}
+	void SetDistance(float dist) {
+		m_distance = dist;
+	}
+	float GetInitialDistance() {
+		return m_initialDistance;
 	}
 	float GetHysteresis() {
 		return m_hysteresis;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public PyObjectPlus
+class KX_LodLevel : public CValue
 {
 	Py_Header
 
@@ -40,6 +40,15 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public CValue
+class KX_LodLevel : public PyObjectPlus
 {
 	Py_Header
 
@@ -40,15 +40,6 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -30,9 +30,8 @@ class KX_LodLevel : public PyObjectPlus
 private:
 
 	float m_distance;
-	float m_initialDistance;
 	float m_hysteresis;
-	unsigned short m_level;
+	short m_level;
 	unsigned short m_flags;
 	RAS_MeshObject *m_meshobj;
 
@@ -41,30 +40,19 @@ public:
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
 
-	float GetDistance() {
-		return m_distance;
-	}
-	void SetDistance(float dist) {
-		m_distance = dist;
-	}
-	float GetInitialDistance() {
-		return m_initialDistance;
-	}
-	float GetHysteresis() {
-		return m_hysteresis;
-	}
-	unsigned short GetLevel() {
-		return m_level;
-	}
-	unsigned short GetFlag() {
-		return m_flags;
-	}
-	RAS_MeshObject *GetMesh() {
-		return m_meshobj;
-	}
+	float GetDistance() const;
+	float GetHysteresis() const;
+	unsigned short GetLevel() const;
+	unsigned short GetFlag() const;
+	RAS_MeshObject *GetMesh() const;
+
 	enum {
-		// Use custom hysteresis for this level.
-		USE_HYST = (1 << 0),
+		/// Use custom hysteresis for this level.
+		USE_HYSTERESIS = (1 << 0),
+		/// Use a different mesh than original.
+		USE_MESH = (1 << 1),
+		/// Use a different material than original mesh.
+		USE_MATERIAL = (1 << 2)
 	};
 
 #ifdef WITH_PYTHON
@@ -74,10 +62,10 @@ public:
 		return PyUnicode_FromString(m_meshobj->GetName());
 	}
 
-	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-
-	//KX_PYMETHOD_DOC(KX_LodLevel, ...);
+	static PyObject *pyattr_get_use_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_use_material(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
 #endif //WITH_PYTHON
 

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -15,20 +15,25 @@
 * along with this program; if not, write to the Free Software Foundation,
 * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 *
-* Contributor(s): Porteries Tristan.
+* Contributor(s): Ulysse Martin, Tristan Porteries.
 *
 * ***** END GPL LICENSE BLOCK *****
 */
 
-#include "EXP_Value.h"
+/** \file KX_LodLevel.h
+ *  \ingroup ketsji
+ */
+
+#ifndef __KX_LOD_LEVEL_H__
+#define __KX_LOD_LEVEL_H__
+
+#include "EXP_PyObjectPlus.h"
 #include "RAS_MeshObject.h"
 
 class KX_LodLevel : public PyObjectPlus
 {
 	Py_Header
-
 private:
-
 	float m_distance;
 	float m_hysteresis;
 	short m_level;
@@ -36,7 +41,6 @@ private:
 	RAS_MeshObject *m_meshobj;
 
 public:
-	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
 
@@ -67,6 +71,8 @@ public:
 	static PyObject *pyattr_get_use_mesh(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_use_material(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
-#endif //WITH_PYTHON
+#endif // WITH_PYTHON
 
 };
+
+#endif  // __KX_LOD_LEVEL_H__

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -72,9 +72,9 @@ public:
 #ifdef WITH_PYTHON
 
 	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
-	//KX_PYMETHOD_DOC(KX_LodLevel, getMeshName);
+	//KX_PYMETHOD_DOC(KX_LodLevel, ...);
 
 #endif //WITH_PYTHON
 

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public CValue
+class KX_LodLevel : public PyObjectPlus
 {
 	Py_Header
 
@@ -40,15 +40,6 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;
@@ -77,6 +68,11 @@ public:
 	};
 
 #ifdef WITH_PYTHON
+
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString(m_meshobj->GetName());
+	}
 
 	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -30,7 +30,7 @@
 
 KX_LodManager::KX_LodManager(Object *ob, KX_Scene* scene, KX_BlenderSceneConverter* converter, bool libloading)
 	:m_refcount(1),
-	m_lodLevelsScale(1.0f)
+	m_distanceFactor(1.0f)
 {
 	if (BLI_listbase_count_ex(&ob->lodlevels, 2) > 1) {
 		LodLevel *lod = (LodLevel*)ob->lodlevels.first;
@@ -93,6 +93,8 @@ KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod
 {
 	unsigned short level = 0;
 	unsigned short count = m_lodLevelList.size();
+	distance2 *= (m_distanceFactor * m_distanceFactor);
+
 	while (level < count) {
 		if (level == (count - 1)) {
 			break;
@@ -114,15 +116,6 @@ KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod
 		++level;
 	}
 	return m_lodLevelList[level];
-}
-
-void KX_LodManager::SetScale(float scale)
-{
-	for (int i = 0; i < m_lodLevelList.size(); i++) {
-		float val = max_ff(m_lodLevelList[i]->GetInitialDistance() * scale, 0.0f);
-		m_lodLevelList[i]->SetDistance(val);
-		m_lodLevelsScale = val;
-	}
 }
 
 #ifdef WITH_PYTHON
@@ -156,7 +149,7 @@ PyMethodDef KX_LodManager::Methods[] = {
 
 PyAttributeDef KX_LodManager::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("lodLevel", KX_LodManager, pyattr_get_lodlevels),
-	KX_PYATTRIBUTE_RW_FUNCTION("lodLevelScale", KX_LodManager, pyattr_get_lod_levels_scale, pyattr_set_lod_levels_scale),
+	KX_PYATTRIBUTE_FLOAT_RW("distanceFactor", 0.0f, FLT_MAX, KX_LodManager, m_distanceFactor),
 	{ NULL }    //Sentinel
 };
 
@@ -171,26 +164,6 @@ PyObject *KX_LodManager::pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE
 	}
 
 	return levelList;
-}
-
-PyObject *KX_LodManager::pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
-{
-	KX_LodManager* self = static_cast<KX_LodManager*>(self_v);
-	return PyFloat_FromDouble(self->m_lodLevelsScale);
-}
-
-int KX_LodManager::pyattr_set_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
-{
-	KX_LodManager* self = static_cast<KX_LodManager*>(self_v);
-	float scale = PyFloat_AsDouble(value);
-	if (scale == -1.0f && PyErr_Occurred()) {
-		PyErr_SetString(PyExc_ValueError, "KX_LodManager.lodLevelsScale: KX_LodManager expected a float");
-		return NULL;
-	}
-	
-	self->SetScale(scale);
-
-	return PY_SET_ATTR_SUCCESS;
 }
 
 #endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -162,7 +162,7 @@ PyMethodDef KX_LodManager::Methods[] = {
 };
 
 PyAttributeDef KX_LodManager::Attributes[] = {
-	KX_PYATTRIBUTE_RO_FUNCTION("Level", KX_LodManager, pyattr_get_levels),
+	KX_PYATTRIBUTE_RO_FUNCTION("levels", KX_LodManager, pyattr_get_levels),
 	KX_PYATTRIBUTE_FLOAT_RW("distanceFactor", 0.0f, FLT_MAX, KX_LodManager, m_distanceFactor),
 	{NULL} //Sentinel
 };

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -15,9 +15,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Contributor(s): Porteries Tristan.
+ * Contributor(s): Ulysse Martin, Tristan Porteries.
  *
  * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file gameengine/Ketsji/KX_LodManager.cpp
+ *  \ingroup ketsji
  */
 
 #include "KX_LodManager.h"
@@ -65,10 +69,8 @@ KX_LodManager::KX_LodManager(Object *ob, KX_Scene* scene, KX_BlenderSceneConvert
 
 KX_LodManager::~KX_LodManager()
 {
-	for (int i = 0; i < m_levels.size(); i++) {
-		if (m_levels[i]) {
-			delete m_levels[i];
-		}
+	for (std::vector<KX_LodLevel *>::iterator it = m_levels.begin(), end = m_levels.end(); it != end; ++it) {
+		delete *it;
 	}
 }
 
@@ -90,6 +92,16 @@ float KX_LodManager::GetHysteresis(KX_Scene *scene, unsigned short level)
 		hysteresis = scene->GetLodHysteresisValue() / 100.0f;
 	}
 	return MT_abs(lodnext->GetDistance() - lod->GetDistance()) * hysteresis;
+}
+
+unsigned int KX_LodManager::GetLevelCount() const
+{
+	return m_levels.size();
+}
+
+KX_LodLevel *KX_LodManager::GetLevel(unsigned int index) const
+{
+	return m_levels[index];
 }
 
 KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2)

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "KX_LodManager.h"
+#include "KX_LodLevel.h"
 #include "KX_Scene.h"
 #include "BL_BlenderDataConversion.h"
 #include "DNA_object_types.h"

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -85,4 +85,5 @@ public:
 		}
 		return this;
 	}
+	void SetScale(float scale);
 };

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -44,7 +44,8 @@ private:
 
 	int m_refcount;
 
-	float m_lodLevelsScale;
+	/// Factor applied to the distance from the camera to the object.
+	float m_distanceFactor;
 
 public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
@@ -59,8 +60,6 @@ public:
 
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int pyattr_set_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 #endif //WITH_PYTHON
 
@@ -69,7 +68,7 @@ public:
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
-	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
+	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance);
 
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const
@@ -90,5 +89,4 @@ public:
 		}
 		return this;
 	}
-	void SetScale(float scale);
 };

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -15,12 +15,19 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Contributor(s): Porteries Tristan.
+ * Contributor(s): Ulysse Martin, Tristan Porteries.
  *
  * ***** END GPL LICENSE BLOCK *****
  */
 
-#include "EXP_Value.h"
+/** \file KX_LodManager.h
+ *  \ingroup ketsji
+ */
+
+#ifndef __KX_LOD_MANAGER_H__
+#define __KX_LOD_MANAGER_H__
+
+#include "EXP_PyObjectPlus.h"
 #include <vector>
 
 class KX_Scene;
@@ -31,8 +38,6 @@ struct Object;
 class KX_LodManager: public PyObjectPlus
 {
 	Py_Header
-public:
-
 private:
 	std::vector<KX_LodLevel *> m_levels;
 
@@ -51,18 +56,20 @@ public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodManager();
 
+	/// Return number of lod levels.
+	unsigned int GetLevelCount() const;
+
+	/** Get lod level by index.
+	 * \param index The lod level index.
+	 */
+	KX_LodLevel *GetLevel(unsigned int index) const;
+
 	/** Get lod level cooresponding to distance and previous level.
 	 * \param scene Scene used to get default hysteresis.
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
 	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance);
-
-	/// If it returns true, then the lod is useless then.
-	inline bool Empty() const
-	{
-		return m_levels.empty();
-	}
 
 	KX_LodManager *AddRef()
 	{
@@ -96,3 +103,5 @@ public:
 bool ConvertPythonToLodManager(PyObject *value, KX_LodManager **object, bool py_none_ok, const char *error_prefix);
 
 #endif  // WITH_PYTHON
+
+#endif  // __KX_LOD_MANAGER_H__

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -44,6 +44,8 @@ private:
 
 	int m_refcount;
 
+	float m_lodLevelsScale;
+
 public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodManager();
@@ -52,6 +54,8 @@ public:
 
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 #endif //WITH_PYTHON
 

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -51,18 +51,6 @@ public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodManager();
 
-#ifdef WITH_PYTHON
-
-	virtual PyObject *py_repr()
-	{
-		return PyUnicode_FromString("KX_LodManager");
-	}
-
-	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-
-#endif //WITH_PYTHON
-
 	/** Get lod level cooresponding to distance and previous level.
 	 * \param scene Scene used to get default hysteresis.
 	 * \param previouslod Previous lod computed by this function before.
@@ -89,4 +77,22 @@ public:
 		}
 		return this;
 	}
+
+#ifdef WITH_PYTHON
+
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString("KX_LodManager");
+	}
+
+	static PyObject *pyattr_get_levels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+
+#endif //WITH_PYTHON
 };
+
+#ifdef WITH_PYTHON
+
+/// Utility python conversion function.
+bool ConvertPythonToLodManager(PyObject *value, KX_LodManager **object, bool py_none_ok, const char *error_prefix);
+
+#endif  // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -21,33 +21,20 @@
  */
 
 #include "EXP_Value.h"
-#include "RAS_MeshObject.h"
+#include "KX_LodLevel.h"
 #include <vector>
 
 class KX_Scene;
 class KX_BlenderSceneConverter;
 struct Object;
 
-class KX_LodList: public CValue
+class KX_LodManager: public PyObjectPlus
 {
 	Py_Header
 public:
-	struct Level
-	{
-		float distance;
-		float hysteresis;
-		unsigned short level;
-		unsigned short flags;
-		RAS_MeshObject *meshobj;
-
-		enum {
-			// Use custom hysteresis for this level.
-			USE_HYST = (1 << 0),
-		};
-	};
 
 private:
-	std::vector<Level> m_lodLevelList;
+	std::vector<KX_LodLevel *> m_lodLevelList;
 
 	/** Get the hysteresis from the level or the scene.
 	 * \param scene Scene used to get default hysteresis.
@@ -57,27 +44,14 @@ private:
 
 	int m_refcount;
 
-	STR_String m_lodListName;
-
 public:
-	KX_LodList(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
-	virtual ~KX_LodList();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
+	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
+	virtual ~KX_LodManager();
 
 #ifdef WITH_PYTHON
 
-	//static PyObject *pyattr_get_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-
-	KX_PYMETHOD_DOC(KX_LodList, getLevelMeshName);
 
 #endif //WITH_PYTHON
 
@@ -86,7 +60,7 @@ public:
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
-	const KX_LodList::Level& GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
+	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
 
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const
@@ -94,12 +68,12 @@ public:
 		return m_lodLevelList.empty();
 	}
 
-	KX_LodList *AddRef()
+	KX_LodManager *AddRef()
 	{
 		++m_refcount;
 		return this;
 	}
-	KX_LodList *Release()
+	KX_LodManager *Release()
 	{
 		if (--m_refcount == 0) {
 			delete this;

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -21,11 +21,11 @@
  */
 
 #include "EXP_Value.h"
-#include "KX_LodLevel.h"
 #include <vector>
 
 class KX_Scene;
 class KX_BlenderSceneConverter;
+class KX_LodLevel;
 struct Object;
 
 class KX_LodManager: public PyObjectPlus

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -34,7 +34,7 @@ class KX_LodManager: public PyObjectPlus
 public:
 
 private:
-	std::vector<KX_LodLevel *> m_lodLevelList;
+	std::vector<KX_LodLevel *> m_levels;
 
 	/** Get the hysteresis from the level or the scene.
 	 * \param scene Scene used to get default hysteresis.
@@ -61,7 +61,7 @@ public:
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const
 	{
-		return m_lodLevelList.empty();
+		return m_levels.empty();
 	}
 
 	KX_LodManager *AddRef()

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -52,6 +52,11 @@ public:
 
 #ifdef WITH_PYTHON
 
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString("KX_LodManager");
+	}
+
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,6 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
+#include "KX_LodLevel.h"
 #include "KX_LodManager.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,7 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
-#include "KX_Lod.h"
+#include "KX_LodManager.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"
 #include "KX_MouseFocusSensor.h"
@@ -226,7 +226,8 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, KX_GameObject, init_getset);
 		PyType_Ready_Attr(dict, KX_LibLoadStatus, init_getset);
 		PyType_Ready_Attr(dict, KX_LightObject, init_getset);
-		PyType_Ready_Attr(dict, KX_LodList, init_getset);
+		PyType_Ready_Attr(dict, KX_LodLevel, init_getset);
+		PyType_Ready_Attr(dict, KX_LodManager, init_getset);
 		PyType_Ready_Attr(dict, KX_FontObject, init_getset);
 		PyType_Ready_Attr(dict, KX_MeshProxy, init_getset);
 		PyType_Ready_Attr(dict, KX_MouseFocusSensor, init_getset);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,6 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
+#include "KX_Lod.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"
 #include "KX_MouseFocusSensor.h"
@@ -225,6 +226,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, KX_GameObject, init_getset);
 		PyType_Ready_Attr(dict, KX_LibLoadStatus, init_getset);
 		PyType_Ready_Attr(dict, KX_LightObject, init_getset);
+		PyType_Ready_Attr(dict, KX_LodList, init_getset);
 		PyType_Ready_Attr(dict, KX_FontObject, init_getset);
 		PyType_Ready_Attr(dict, KX_MeshProxy, init_getset);
 		PyType_Ready_Attr(dict, KX_MouseFocusSensor, init_getset);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1790,11 +1790,12 @@ void KX_Scene::UpdateObjectLods()
 		return;
 
 	const MT_Vector3& cam_pos = m_active_camera->NodeGetWorldPosition();
+	const float lodfactor = m_active_camera->GetLodFactor();
 
 	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 		KX_GameObject *gameobj = (KX_GameObject *)*it;
 		if (!gameobj->GetCulled()) {
-			gameobj->UpdateLod(cam_pos);
+			gameobj->UpdateLod(cam_pos, lodfactor);
 		}
 	}
 }
@@ -2203,7 +2204,6 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
-	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
 	
 	/* dict style access */
@@ -2644,42 +2644,6 @@ KX_PYMETHODDEF_DOC(KX_Scene, get, "")
 	
 	Py_INCREF(def);
 	return def;
-}
-
-KX_PYMETHODDEF_DOC(KX_Scene, setLodScale, "setLodScale(pythonObjectList, scale")
-{
-	PyObject *list;
-	KX_GameObject *gameobj;
-	float scale;
-	if (!PyArg_ParseTuple(args, "Of", &list, &scale)) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
-		return NULL;
-	}
-
-	PyObject *iter = PyObject_GetIter(list);
-	if (!iter) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
-		return NULL;
-	}
-
-	while (true) {
-		PyObject *next = PyIter_Next(iter);
-		if (!next) {
-			// nothing left in the iterator
-			break;
-		}
-
-		if (!ConvertPythonToGameObject(m_logicmgr, next, &gameobj, false, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float"))
-			return NULL;
-
-		if (!gameobj->GetLodManager()) {
-			PyErr_SetString(PyExc_ValueError, "Warning: KX_Scene.setLodScale(pythonObjectList, scale): One or several KX_GameObject in the python object list have no LOD");
-		}
-		if (gameobj->GetLodManager()) {
-			gameobj->GetLodManager()->SetScale(scale);
-		}
-	}
-	Py_RETURN_NONE;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1790,7 +1790,7 @@ void KX_Scene::UpdateObjectLods()
 		return;
 
 	const MT_Vector3& cam_pos = m_active_camera->NodeGetWorldPosition();
-	const float lodfactor = m_active_camera->GetLodFactor();
+	const float lodfactor = m_active_camera->GetLodDistanceFactor();
 
 	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 		KX_GameObject *gameobj = (KX_GameObject *)*it;

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -59,6 +59,7 @@
 #include "KX_PyMath.h"
 #include "RAS_MeshObject.h"
 #include "SCA_IScene.h"
+#include "KX_LodManager.h"
 
 #include "RAS_IRasterizer.h"
 #include "RAS_ICanvas.h"
@@ -153,7 +154,9 @@ KX_Scene::KX_Scene(class SCA_IInputDevice* keyboarddevice,
 	m_ueberExecutionPriority(0),
 	m_blenderScene(scene),
 	m_isActivedHysteresis(false),
-	m_lodHysteresisValue(0)
+	m_lodHysteresisValue(0),
+	m_lodGlobalScale(1.0f),
+	m_lodObjectList(NULL)
 {
 	m_suspendedtime = 0.0;
 	m_suspendeddelta = 0.0;
@@ -1803,6 +1806,14 @@ void KX_Scene::SetLodHysteresis(bool active)
 	m_isActivedHysteresis = active;
 }
 
+void KX_Scene::SetGlobalLodScale(float scale)
+{
+	for (int i = 0; i < m_lodObjectList.size(); i++) {
+		m_lodObjectList[i]->GetLodManager()->SetScale(scale);
+		m_lodGlobalScale = scale;
+	}
+}
+
 bool KX_Scene::IsActivedLodHysteresis(void)
 {
 	return m_isActivedHysteresis;
@@ -2514,6 +2525,27 @@ int KX_Scene::pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef
 	return PY_SET_ATTR_SUCCESS;
 }
 
+PyObject *KX_Scene::pyattr_get_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_Scene* self = static_cast<KX_Scene*>(self_v);
+
+	return PyFloat_FromDouble(self->m_lodGlobalScale);
+}
+
+int KX_Scene::pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_Scene* self = static_cast<KX_Scene*>(self_v);
+
+	float scale = PyFloat_AsDouble(value);
+	if (scale == -1.0f && PyErr_Occurred()) {
+		PyErr_SetString(PyExc_ValueError, "KX_Scene.lodGlobalScale: KX_Scene expected a float");
+		return NULL;
+	}
+	CLAMP(scale, 0.0f, 99999999.0f);
+	self->SetGlobalLodScale(scale);
+	return PY_SET_ATTR_SUCCESS;
+}
+
 PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("name",				KX_Scene, pyattr_get_name),
 	KX_PYATTRIBUTE_RO_FUNCTION("objects",			KX_Scene, pyattr_get_objects),
@@ -2527,6 +2559,7 @@ PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("post_draw",			KX_Scene, pyattr_get_drawing_callback_post, pyattr_set_drawing_callback_post),
 	KX_PYATTRIBUTE_RW_FUNCTION("pre_draw_setup",	KX_Scene, pyattr_get_drawing_setup_callback_pre, pyattr_set_drawing_setup_callback_pre),
 	KX_PYATTRIBUTE_RW_FUNCTION("gravity",			KX_Scene, pyattr_get_gravity, pyattr_set_gravity),
+	KX_PYATTRIBUTE_RW_FUNCTION("lodGlobalScale",	KX_Scene, pyattr_get_lod_global_scale, pyattr_set_lod_global_scale),
 	KX_PYATTRIBUTE_BOOL_RO("suspended",				KX_Scene, m_suspend),
 	KX_PYATTRIBUTE_BOOL_RO("activity_culling",		KX_Scene, m_activity_culling),
 	KX_PYATTRIBUTE_FLOAT_RW("activity_culling_radius", 0.5f, FLT_MAX, KX_Scene, m_activity_box_radius),

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -154,9 +154,7 @@ KX_Scene::KX_Scene(class SCA_IInputDevice* keyboarddevice,
 	m_ueberExecutionPriority(0),
 	m_blenderScene(scene),
 	m_isActivedHysteresis(false),
-	m_lodHysteresisValue(0),
-	m_lodGlobalScale(1.0f),
-	m_lodObjectList(NULL)
+	m_lodHysteresisValue(0)
 {
 	m_suspendedtime = 0.0;
 	m_suspendeddelta = 0.0;
@@ -1806,14 +1804,6 @@ void KX_Scene::SetLodHysteresis(bool active)
 	m_isActivedHysteresis = active;
 }
 
-void KX_Scene::SetGlobalLodScale(float scale)
-{
-	for (int i = 0; i < m_lodObjectList.size(); i++) {
-		m_lodObjectList[i]->GetLodManager()->SetScale(scale);
-		m_lodGlobalScale = scale;
-	}
-}
-
 bool KX_Scene::IsActivedLodHysteresis(void)
 {
 	return m_isActivedHysteresis;
@@ -2213,6 +2203,7 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
+	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
 	
 	/* dict style access */
@@ -2525,27 +2516,6 @@ int KX_Scene::pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef
 	return PY_SET_ATTR_SUCCESS;
 }
 
-PyObject *KX_Scene::pyattr_get_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
-{
-	KX_Scene* self = static_cast<KX_Scene*>(self_v);
-
-	return PyFloat_FromDouble(self->m_lodGlobalScale);
-}
-
-int KX_Scene::pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
-{
-	KX_Scene* self = static_cast<KX_Scene*>(self_v);
-
-	float scale = PyFloat_AsDouble(value);
-	if (scale == -1.0f && PyErr_Occurred()) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.lodGlobalScale: KX_Scene expected a float");
-		return NULL;
-	}
-	CLAMP(scale, 0.0f, 99999999.0f);
-	self->SetGlobalLodScale(scale);
-	return PY_SET_ATTR_SUCCESS;
-}
-
 PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("name",				KX_Scene, pyattr_get_name),
 	KX_PYATTRIBUTE_RO_FUNCTION("objects",			KX_Scene, pyattr_get_objects),
@@ -2559,7 +2529,6 @@ PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("post_draw",			KX_Scene, pyattr_get_drawing_callback_post, pyattr_set_drawing_callback_post),
 	KX_PYATTRIBUTE_RW_FUNCTION("pre_draw_setup",	KX_Scene, pyattr_get_drawing_setup_callback_pre, pyattr_set_drawing_setup_callback_pre),
 	KX_PYATTRIBUTE_RW_FUNCTION("gravity",			KX_Scene, pyattr_get_gravity, pyattr_set_gravity),
-	KX_PYATTRIBUTE_RW_FUNCTION("lodGlobalScale",	KX_Scene, pyattr_get_lod_global_scale, pyattr_set_lod_global_scale),
 	KX_PYATTRIBUTE_BOOL_RO("suspended",				KX_Scene, m_suspend),
 	KX_PYATTRIBUTE_BOOL_RO("activity_culling",		KX_Scene, m_activity_culling),
 	KX_PYATTRIBUTE_FLOAT_RW("activity_culling_radius", 0.5f, FLT_MAX, KX_Scene, m_activity_box_radius),
@@ -2675,6 +2644,42 @@ KX_PYMETHODDEF_DOC(KX_Scene, get, "")
 	
 	Py_INCREF(def);
 	return def;
+}
+
+KX_PYMETHODDEF_DOC(KX_Scene, setLodScale, "setLodScale(pythonObjectList, scale")
+{
+	PyObject *list;
+	KX_GameObject *gameobj;
+	float scale;
+	if (!PyArg_ParseTuple(args, "Of", &list, &scale)) {
+		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
+		return NULL;
+	}
+
+	PyObject *iter = PyObject_GetIter(list);
+	if (!iter) {
+		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
+		return NULL;
+	}
+
+	while (true) {
+		PyObject *next = PyIter_Next(iter);
+		if (!next) {
+			// nothing left in the iterator
+			break;
+		}
+
+		if (!ConvertPythonToGameObject(m_logicmgr, next, &gameobj, false, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float"))
+			return NULL;
+
+		if (!gameobj->GetLodManager()) {
+			PyErr_SetString(PyExc_ValueError, "Warning: KX_Scene.setLodScale(pythonObjectList, scale): One or several KX_GameObject in the python object list have no LOD");
+		}
+		if (gameobj->GetLodManager()) {
+			gameobj->GetLodManager()->SetScale(scale);
+		}
+	}
+	Py_RETURN_NONE;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -627,7 +627,6 @@ public:
 	KX_PYMETHOD_DOC(KX_Scene, resume);
 	KX_PYMETHOD_DOC(KX_Scene, get);
 	KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
-	KX_PYMETHOD_DOC(KX_Scene, setLodScale);
 
 
 	/* attributes */

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -297,6 +297,10 @@ protected:
 	bool m_isActivedHysteresis;
 	int m_lodHysteresisValue;
 
+	float m_lodGlobalScale;
+
+	std::vector<KX_GameObject *>m_lodObjectList;
+
 public:
 	KX_Scene(class SCA_IInputDevice* keyboarddevice,
 		class SCA_IInputDevice* mousedevice,
@@ -553,6 +557,12 @@ public:
 	bool IsActivedLodHysteresis();
 	void SetLodHysteresisValue(int hysteresisvalue);
 	int GetLodHysteresisValue();
+
+	void SetGlobalLodScale(float scale);
+
+	void LodObjectListAppend(KX_GameObject *gameob) {
+		m_lodObjectList.push_back(gameob);
+	}
 	
 	// Update the activity box settings for objects in this scene, if needed.
 	void UpdateObjectActivity(void);
@@ -647,6 +657,8 @@ public:
 	static int			pyattr_set_drawing_setup_callback_pre(void *selv_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_gravity(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_lod_global_scale(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int			pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	virtual PyObject *py_repr(void) { return PyUnicode_From_STR_String(GetName()); }
 	

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -297,10 +297,6 @@ protected:
 	bool m_isActivedHysteresis;
 	int m_lodHysteresisValue;
 
-	float m_lodGlobalScale;
-
-	std::vector<KX_GameObject *>m_lodObjectList;
-
 public:
 	KX_Scene(class SCA_IInputDevice* keyboarddevice,
 		class SCA_IInputDevice* mousedevice,
@@ -557,12 +553,6 @@ public:
 	bool IsActivedLodHysteresis();
 	void SetLodHysteresisValue(int hysteresisvalue);
 	int GetLodHysteresisValue();
-
-	void SetGlobalLodScale(float scale);
-
-	void LodObjectListAppend(KX_GameObject *gameob) {
-		m_lodObjectList.push_back(gameob);
-	}
 	
 	// Update the activity box settings for objects in this scene, if needed.
 	void UpdateObjectActivity(void);
@@ -637,6 +627,7 @@ public:
 	KX_PYMETHOD_DOC(KX_Scene, resume);
 	KX_PYMETHOD_DOC(KX_Scene, get);
 	KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
+	KX_PYMETHOD_DOC(KX_Scene, setLodScale);
 
 
 	/* attributes */
@@ -657,8 +648,6 @@ public:
 	static int			pyattr_set_drawing_setup_callback_pre(void *selv_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_gravity(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_lod_global_scale(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int			pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	virtual PyObject *py_repr(void) { return PyUnicode_From_STR_String(GetName()); }
 	

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -39,6 +39,7 @@
 
 #include <vector>
 #include <list>
+#include "EXP_Value.h"
 
 #include "RAS_MaterialBucket.h"
 #include "RAS_MeshMaterial.h"
@@ -56,7 +57,7 @@ class RAS_Polygon;
  * but the actual vertices and index arrays are stored in material
  * buckets, referenced by the list of RAS_MeshMaterials. */
 
-class RAS_MeshObject
+class RAS_MeshObject: public PyObjectPlus
 {
 private:
 	short m_modifiedFlag;
@@ -85,6 +86,12 @@ public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
 	RAS_MeshObject(Mesh *mesh);
 	virtual ~RAS_MeshObject();
+#ifdef WITH_PYTHON
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString(m_name);
+	}
+#endif // WITH_PYTTHON
 
 	// materials
 	int NumMaterials();

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -39,7 +39,6 @@
 
 #include <vector>
 #include <list>
-#include "EXP_Value.h"
 
 #include "RAS_MaterialBucket.h"
 #include "RAS_MeshMaterial.h"
@@ -57,7 +56,7 @@ class RAS_Polygon;
  * but the actual vertices and index arrays are stored in material
  * buckets, referenced by the list of RAS_MeshMaterials. */
 
-class RAS_MeshObject: public PyObjectPlus
+class RAS_MeshObject
 {
 private:
 	short m_modifiedFlag;
@@ -86,12 +85,6 @@ public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
 	RAS_MeshObject(Mesh *mesh);
 	virtual ~RAS_MeshObject();
-#ifdef WITH_PYTHON
-	virtual PyObject *py_repr()
-	{
-		return PyUnicode_FromString(m_name);
-	}
-#endif // WITH_PYTTHON
 
 	// materials
 	int NumMaterials();


### PR DESCRIPTION
I renamed KX_LodList to KX_LodManager.
I created a separate class for old struct Level outside of KX_LodManager.

The goal was to have
KX_GameObject.lodManager.lodLevel[index].attributeGet/set

This needs to be reviewed as it's my first little
"refactor"

We could nevertheless need a struct m_savedData to save Blender lodlevel attributes at game engine start and restore it at game engine exit.

Test file: http://www.pasteall.org/blend/42108

New test file for the complete python API: http://www.pasteall.org/blend/42122