### PR TITLE
Lod distance scale

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -9,7 +9,7 @@ base class --- :class:`BL_Shader`
 
    2D filter shader object. Can be alterated with :class:`BL_Shader`'s functions.
 
-   .. method:: setTexture(index, bindCode)
+   .. method:: setTexture(index, bindCode, samplerName)
 
       Set specified texture bind code :data:`bindCode` in specified slot :data:`index`. Any call to :data:`setTexture`
       should be followed by a call to :data:`BL_Shader.setSampler` with the same :data:`index`.
@@ -18,3 +18,5 @@ base class --- :class:`BL_Shader`
       :type index: integer
       :arg bindCode: The texture bind code/Id.
       :type bindCode: integer
+      :arg samplerName: The shader sampler name set to :data:`index` if :data:`samplerName` is passed in the function. (optional)
+      :type samplerName: string

--- a/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
@@ -27,6 +27,12 @@ base class --- :class:`KX_GameObject`
 
       :type: float
 
+   .. attribute:: lodFactor
+
+      The camera's level of detail factor value.
+
+      :type: float
+
    .. attribute:: fov
 
       The camera's field of view value.

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -496,6 +496,15 @@ base class --- :class:`SCA_IObject`
 
       :type: int
 
+   .. attribute:: lodManager
+
+      Return the :class:`KX_LodManager` of this KX_GameObject.
+      We need to access lodManager to set attributes of levels of detail
+      for this KX_GameObject. Example:
+      KX_GameObject.lodManager.lodLevel[0].distance = 25.0.
+
+      :type: :class:`KX_LodManager` (read-only)
+
    .. method:: endObject()
 
       Delete this object, can be used in place of the EndObject Actuator.

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -1,0 +1,34 @@
+KX_LodLevel(PyObjectPlus)
+=========================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_LodLevel(PyObjectPlus)
+
+   A single Lod Level for a KX_GameObject.
+
+   .. attribute:: meshName
+
+      The name of the mesh used at this lod level.
+
+      :type: string (read only)
+
+   .. attribute:: useHysteresis
+
+      return true is this lod level use hysteresis override and false if not.
+
+      :type: boolean (read only)
+
+   .. attribute:: distance
+
+      Distance to begin using this level of detail.
+
+      :type: float (0.0 to 99999999.0)
+
+   .. attribute:: hysteresis
+
+      Minimum distance change required to transition to the previous level of detail.
+
+      :type: float (0.0 to 100.0 (percents))

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
@@ -1,0 +1,28 @@
+KX_LodManager(PyObjectPlus)
+===========================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_LodManager(PyObjectPlus)
+
+   This class contains a list of all levels of detail for a KX_GameObject.
+
+   .. attribute:: lodLevel
+
+      Return the list of all levels of detail of the KX_GameObject.
+      To select one level (:class:`KX_LodLevel`), you can do:
+      KX_GameObject.lodManager.lodLevel[index] and then you can set
+      individual attributes for this level of detail.
+
+      :type: list (read only)
+
+   .. attribute:: lodLevelScale
+
+      Method to set the distance of all levels of detail for a game object at the same time.
+      For example, if a KX_GameObject has a lod1 with a distance = 25.0 and a lod2 with
+      a distance = 50.0 and you set the lodLevelScale to 2.0, lod1.distance will be equal to 50.0
+      and lod2 will be equal to 100.0.
+
+      :type: float

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,6 +143,12 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
+   .. attribute:: lodGlobalScale
+
+      All the scene objects with level of detail LOD scale.
+
+      :type: float
+
    .. method:: addObject(object, reference, time=0.0)
 
       Adds an object to the scene like the Add Object Actuator would.

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,17 +143,6 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
-   .. method:: setLodScale(pythonObjectList, scale)
-
-      Set LOD scale for all objects with LOD in the pythonObjectList.
-
-      :arg pythonObjectList: list of KX_GameObject with LOD to set 
-      :type: list
-      :arg scale: factor to scale initial LOD distance. If the initial distance of a
-      KX_GameObject in the list is 25.0 and the scale is 2.0, the LOD distance for
-      this KX_GameObject will become 50.0.
-      :type: float
-
    .. method:: addObject(object, reference, time=0.0)
 
       Adds an object to the scene like the Add Object Actuator would.

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -143,10 +143,15 @@ base class --- :class:`PyObjectPlus`
 
       :type: Vector((gx, gy, gz))
 
-   .. attribute:: lodGlobalScale
+   .. method:: setLodScale(pythonObjectList, scale)
 
-      All the scene objects with level of detail LOD scale.
+      Set LOD scale for all objects with LOD in the pythonObjectList.
 
+      :arg pythonObjectList: list of KX_GameObject with LOD to set 
+      :type: list
+      :arg scale: factor to scale initial LOD distance. If the initial distance of a
+      KX_GameObject in the list is 25.0 and the scale is 2.0, the LOD distance for
+      this KX_GameObject will become 50.0.
       :type: float
 
    .. method:: addObject(object, reference, time=0.0)

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -76,6 +76,7 @@
 #include "KX_Camera.h"
 #include "KX_EmptyObject.h"
 #include "KX_FontObject.h"
+#include "KX_LodManager.h"
 
 #include "RAS_ICanvas.h"
 #include "RAS_Polygon.h"
@@ -176,8 +177,6 @@ extern Material defmaterial;	/* material.c */
 
 #include "KX_NavMeshObject.h"
 #include "KX_ObstacleSimulation.h"
-
-#include "KX_Lod.h"
 
 #include "BLI_threads.h"
 
@@ -952,9 +951,9 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 	}
 }
 
-static KX_LodList *lodlist_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
+static KX_LodManager *lodlist_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
 {
-	KX_LodList *lodList = new KX_LodList(ob, scene, converter, libloading);
+	KX_LodManager *lodList = new KX_LodManager(ob, scene, converter, libloading);
 	if (lodList->Empty()) {
 		lodList->Release();
 		return NULL;
@@ -1085,8 +1084,8 @@ static KX_GameObject *gameobject_from_blenderobject(
 		gameobj->AddMesh(meshobj);
 
 		// gather levels of detail
-		KX_LodList *lodList = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
-		gameobj->SetLodList(lodList);
+		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
+		gameobj->SetLodManager(lodManager);
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1086,6 +1086,10 @@ static KX_GameObject *gameobject_from_blenderobject(
 		// gather levels of detail
 		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
+		if (gameobj->GetLodManager()) {
+			KX_Scene *kxscene = gameobj->GetScene();
+			kxscene->LodObjectListAppend(gameobj);
+		}
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1086,10 +1086,6 @@ static KX_GameObject *gameobject_from_blenderobject(
 		// gather levels of detail
 		KX_LodManager *lodManager = lodlist_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
-		if (gameobj->GetLodManager()) {
-			KX_Scene *kxscene = gameobj->GetScene();
-			kxscene->LodObjectListAppend(gameobj);
-		}
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Expressions/EXP_ListWrapper.h
+++ b/source/gameengine/Expressions/EXP_ListWrapper.h
@@ -59,14 +59,24 @@ private:
 	/// Sets the nex item to the index place, return false when failed item conversion.
 	bool (*m_setItem)(void *, int, PyObject *);
 
+	/// Flags used to define special behaviours of the list.
+	int m_flag;
+
 public:
+	enum {
+		FLAG_NONE = 0,
+		/// Allow iterating on all items and compare the value of it with a research key.
+		FLAG_FIND_VALUE = (1 << 0)
+	};
+
 	CListWrapper(void *client,
 						PyObject *base,
 						bool (*checkValid)(void *),
 						int (*getSize)(void *),
 						PyObject *(*getItem)(void *, int),
 						const char *(*getItemName)(void *, int),
-						bool (*setItem)(void *, int, PyObject *));
+						bool (*setItem)(void *, int, PyObject *),
+						int flag = FLAG_NONE);
 	~CListWrapper();
 
 	/// \section Python Interface
@@ -77,6 +87,7 @@ public:
 	bool SetItem(int index, PyObject *item);
 	bool AllowSetItem();
 	bool AllowGetItemByName();
+	bool AllowFindValue();
 
 	/// \section CValue Inherited Functions.
 	virtual const STR_String &GetText();

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -88,7 +88,8 @@ set(SRC
 	KX_KetsjiEngine.cpp
 	KX_Light.cpp
 	KX_LightIpoSGController.cpp
-	KX_Lod.cpp
+	KX_LodLevel.cpp
+	KX_LodManager.cpp
 	KX_MaterialIpoController.cpp
 	KX_MeshProxy.cpp
 	KX_MotionState.cpp
@@ -170,7 +171,8 @@ set(SRC
 	KX_KetsjiEngine.h
 	KX_Light.h
 	KX_LightIpoSGController.h
-	KX_Lod.h
+	KX_LodLevel.h
+	KX_LodManager.h
 	KX_MaterialIpoController.h
 	KX_MeshProxy.h
 	KX_MotionState.h

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -75,22 +75,35 @@ PyAttributeDef KX_2DFilter::Attributes[] = {
 };
 
 
-KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode)")
+KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode, samplerName)")
 {
 	int index = 0;
 	int bindCode = 0;
+	char *samplerName = NULL;
 
-	if (!PyArg_ParseTuple(args, "ii:setTexture", &index, &bindCode)) {
+	if (!PyArg_ParseTuple(args, "ii|s:setTexture", &index, &bindCode, &samplerName)) {
 		return NULL;
 	}
 	if (index < 0 || index >= RAS_Texture::MaxUnits) {
-		PyErr_SetString(PyExc_ValueError, "setTexture(index, bindCode): KX_2DFilter, index out of range [0, 7]");
+		PyErr_SetString(PyExc_ValueError, "setTexture(index, bindCode, samplerName): KX_2DFilter, index out of range [0, 7]");
 		return NULL;
 	}
 
 	if (!RAS_Texture::CheckBindCode(bindCode)) {
-		PyErr_Format(PyExc_ValueError, "setTexture(index, bindCode): KX_2DFilter, bindCode (%i) invalid", bindCode);
+		PyErr_Format(PyExc_ValueError, "setTexture(index, bindCode, samplerName): KX_2DFilter, bindCode (%i) invalid", bindCode);
 		return NULL;
+	}
+
+	if (samplerName) {
+		int loc = GetUniformLocation(samplerName);
+
+		if (loc != -1) {
+#ifdef SORT_UNIFORMS
+			SetUniformiv(loc, RAS_Uniform::UNI_INT, &index, (sizeof(int)), 1);
+#else
+			SetUniform(loc, index);
+#endif
+		}
 	}
 
 	m_textures[index] = bindCode;

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -53,7 +53,8 @@ KX_Camera::KX_Camera(void* sgReplicationInfo,
       m_frustum_culling(frustum_culling),
       m_set_projection_matrix(false),
       m_set_frustum_center(false),
-      m_delete_node(delete_node)
+      m_delete_node(delete_node),
+	  m_lod_factor(1.0f)
 {
 	// setting a name would be nice...
 	m_name = "cam";
@@ -541,6 +542,7 @@ PyAttributeDef KX_Camera::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("perspective", KX_Camera, pyattr_get_perspective, pyattr_set_perspective),
 	
 	KX_PYATTRIBUTE_RW_FUNCTION("lens",	KX_Camera,	pyattr_get_lens, pyattr_set_lens),
+	KX_PYATTRIBUTE_RW_FUNCTION("lodFactor", KX_Camera, pyattr_get_lod_factor, pyattr_set_lod_factor),
 	KX_PYATTRIBUTE_RW_FUNCTION("fov",	KX_Camera,	pyattr_get_fov,  pyattr_set_fov),
 	KX_PYATTRIBUTE_RW_FUNCTION("ortho_scale",	KX_Camera,	pyattr_get_ortho_scale, pyattr_set_ortho_scale),
 	KX_PYATTRIBUTE_RW_FUNCTION("near",	KX_Camera,	pyattr_get_near, pyattr_set_near),
@@ -921,6 +923,24 @@ int KX_Camera::pyattr_set_use_viewport(void *self_v, const KX_PYATTRIBUTE_DEF *a
 	return PY_SET_ATTR_SUCCESS;
 }
 
+PyObject *KX_Camera::pyattr_get_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_Camera* self = static_cast<KX_Camera*>(self_v);
+	return PyFloat_FromDouble(self->GetLodFactor());
+}
+
+int KX_Camera::pyattr_set_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_Camera* self = static_cast<KX_Camera*>(self_v);
+	float factor = PyFloat_AsDouble(value);
+	if (factor == -1.0f && PyErr_Occurred()) {
+		PyErr_SetString(PyExc_AttributeError, "camera.lodScaleFactor = float: KX_Camera, expected a float");
+		return PY_SET_ATTR_FAIL;
+	}
+	CLAMP(factor, 0.001f, 100000.0f);
+	self->SetLodFactor(factor);
+	return PY_SET_ATTR_SUCCESS;
+}
 
 PyObject *KX_Camera::pyattr_get_projection_matrix(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -48,13 +48,13 @@ KX_Camera::KX_Camera(void* sgReplicationInfo,
     :
       KX_GameObject(sgReplicationInfo,callbacks),
       m_camdata(camdata),
+	  m_lodFactor(1.0f),
       m_dirty(true),
       m_normalized(false),
       m_frustum_culling(frustum_culling),
       m_set_projection_matrix(false),
       m_set_frustum_center(false),
-      m_delete_node(delete_node),
-	  m_lod_factor(1.0f)
+      m_delete_node(delete_node)
 {
 	// setting a name would be nice...
 	m_name = "cam";
@@ -542,7 +542,7 @@ PyAttributeDef KX_Camera::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("perspective", KX_Camera, pyattr_get_perspective, pyattr_set_perspective),
 	
 	KX_PYATTRIBUTE_RW_FUNCTION("lens",	KX_Camera,	pyattr_get_lens, pyattr_set_lens),
-	KX_PYATTRIBUTE_RW_FUNCTION("lodFactor", KX_Camera, pyattr_get_lod_factor, pyattr_set_lod_factor),
+	KX_PYATTRIBUTE_FLOAT_RW("lodFactor", 0.0f, FLT_MAX, KX_Camera, m_lodFactor),
 	KX_PYATTRIBUTE_RW_FUNCTION("fov",	KX_Camera,	pyattr_get_fov,  pyattr_set_fov),
 	KX_PYATTRIBUTE_RW_FUNCTION("ortho_scale",	KX_Camera,	pyattr_get_ortho_scale, pyattr_set_ortho_scale),
 	KX_PYATTRIBUTE_RW_FUNCTION("near",	KX_Camera,	pyattr_get_near, pyattr_set_near),
@@ -920,25 +920,6 @@ int KX_Camera::pyattr_set_use_viewport(void *self_v, const KX_PYATTRIBUTE_DEF *a
 		return PY_SET_ATTR_FAIL;
 	}
 	self->EnableViewport((bool)param);
-	return PY_SET_ATTR_SUCCESS;
-}
-
-PyObject *KX_Camera::pyattr_get_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
-{
-	KX_Camera* self = static_cast<KX_Camera*>(self_v);
-	return PyFloat_FromDouble(self->GetLodFactor());
-}
-
-int KX_Camera::pyattr_set_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
-{
-	KX_Camera* self = static_cast<KX_Camera*>(self_v);
-	float factor = PyFloat_AsDouble(value);
-	if (factor == -1.0f && PyErr_Occurred()) {
-		PyErr_SetString(PyExc_AttributeError, "camera.lodScaleFactor = float: KX_Camera, expected a float");
-		return PY_SET_ATTR_FAIL;
-	}
-	CLAMP(factor, 0.001f, 100000.0f);
-	self->SetLodFactor(factor);
 	return PY_SET_ATTR_SUCCESS;
 }
 

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -82,6 +82,9 @@ protected:
 	 * Storage for the modelview matrix that is passed to the
 	 * rasterizer. */
 	MT_Matrix4x4 m_modelview_matrix;
+
+	/** Factor for level of detail*/
+	float m_lod_factor;
 	
 	/**
 	 * true if the view frustum (modelview/projection matrix)
@@ -218,6 +221,16 @@ public:
 	float				GetFocalLength() const;
 	/** Gets all camera data. */
 	RAS_CameraData*		GetCameraData();
+
+	/** Get level of detail factor */
+	float GetLodFactor() {
+		return m_lod_factor;
+	}
+
+	/** Set level of detail factor */
+	void SetLodFactor(float lodfactor) {
+		m_lod_factor = lodfactor;
+	}
 	
 	/**
 	 * Tests if the given sphere is inside this camera's view frustum.
@@ -328,6 +341,10 @@ public:
 	static PyObject*	pyattr_get_INSIDE(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_OUTSIDE(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_INTERSECT(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+
+	/** Level of detail factor get/set */
+	static PyObject*	pyattr_get_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int			pyattr_set_lod_factor(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 #endif
 };
 

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -83,8 +83,8 @@ protected:
 	 * rasterizer. */
 	MT_Matrix4x4 m_modelview_matrix;
 
-	/** Factor for level of detail*/
-	float m_lod_factor;
+	/** Factor for level of detail */
+	float m_lodFactor;
 	
 	/**
 	 * true if the view frustum (modelview/projection matrix)
@@ -223,13 +223,15 @@ public:
 	RAS_CameraData*		GetCameraData();
 
 	/** Get level of detail factor */
-	float GetLodFactor() {
-		return m_lod_factor;
+	float GetLodFactor() const
+	{
+		return m_lodFactor;
 	}
 
 	/** Set level of detail factor */
-	void SetLodFactor(float lodfactor) {
-		m_lod_factor = lodfactor;
+	void SetLodFactor(float lodfactor)
+	{
+		m_lodFactor = lodfactor;
 	}
 	
 	/**

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -811,9 +811,9 @@ void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos, float lodfactor)
 	}
 
 	KX_Scene *scene = GetScene();
-	float dist = NodeGetWorldPosition().distance2(cam_pos);
+	float distance = NodeGetWorldPosition().distance(cam_pos);
 	dist /= lodfactor;
-	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, dist);
+	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, distance);
 	const unsigned short level = lodLevel->GetLevel();
 
 	if (m_previousLodLevel != level) {

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -811,8 +811,8 @@ void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos, float lodfactor)
 	}
 
 	KX_Scene *scene = GetScene();
-	float distance = NodeGetWorldPosition().distance(cam_pos);
-	dist /= lodfactor;
+	float distance = NodeGetWorldPosition().distance2(cam_pos);
+	distance /= (lodfactor * lodfactor);
 	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, distance);
 	const unsigned short level = lodLevel->GetLevel();
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -62,7 +62,7 @@
 #include "KX_NetworkMessageScene.h" //Needed for sendMessage()
 #include "KX_ObstacleSimulation.h"
 #include "KX_Scene.h"
-#include "KX_Lod.h"
+#include "KX_LodManager.h"
 #include "KX_CollisionContactPoints.h"
 
 #include "BKE_object.h"
@@ -102,7 +102,7 @@ KX_GameObject::KX_GameObject(
     : SCA_IObject(),
       m_bDyna(false),
       m_layer(0),
-      m_lodList(NULL),
+      m_lodManager(NULL),
       m_currentLodLevel(0),
       m_previousLodLevel(0),
       m_meshUser(NULL),
@@ -205,8 +205,8 @@ KX_GameObject::~KX_GameObject()
 	{
 		m_pInstanceObjects->Release();
 	}
-	if (m_lodList) {
-		m_lodList->Release();
+	if (m_lodManager) {
+		m_lodManager->Release();
 	}
 }
 
@@ -545,8 +545,8 @@ void KX_GameObject::ProcessReplica()
 	m_state = 0;
 
 	m_meshUser = NULL;
-	if (m_lodList) {
-		m_lodList->AddRef();
+	if (m_lodManager) {
+		m_lodManager->AddRef();
 	}
 
 #ifdef WITH_PYTHON
@@ -805,18 +805,18 @@ void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos)
 		}
 	}
 
-	if (!m_lodList) {
+	if (!m_lodManager) {
 		return;
 	}
 
 	KX_Scene *scene = GetScene();
 	float distance2 = NodeGetWorldPosition().distance2(cam_pos);
 
-	const KX_LodList::Level& lodLevel = m_lodList->GetLevel(scene, m_previousLodLevel, distance2);
-	const unsigned short level = lodLevel.level;
+	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, distance2);
+	const unsigned short level = lodLevel->GetLevel();
 
 	if (m_previousLodLevel != level) {
-		RAS_MeshObject *mesh = lodLevel.meshobj;
+		RAS_MeshObject *mesh = lodLevel->GetMesh();
 		if (mesh != m_meshes[0]) {
 			scene->ReplaceMesh(this, mesh, true, false);
 		}
@@ -2063,7 +2063,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("debug",	KX_GameObject, pyattr_get_debug, pyattr_set_debug),
 	KX_PYATTRIBUTE_RO_FUNCTION("components", KX_GameObject, pyattr_get_components),
 	KX_PYATTRIBUTE_RW_FUNCTION("debugRecursive",	KX_GameObject, pyattr_get_debugRecursive, pyattr_set_debugRecursive),
-	KX_PYATTRIBUTE_RO_FUNCTION("lod", KX_GameObject, pyattr_get_lodlist),
+	KX_PYATTRIBUTE_RO_FUNCTION("lodManager", KX_GameObject, pyattr_get_lodmanager),
 	
 	/* experimental, don't rely on these yet */
 	KX_PYATTRIBUTE_RO_FUNCTION("sensors",		KX_GameObject, pyattr_get_sensors),
@@ -3284,15 +3284,15 @@ int KX_GameObject::pyattr_set_debugRecursive(void *self_v, const KX_PYATTRIBUTE_
 	return PY_SET_ATTR_SUCCESS;
 }
 
-PyObject *KX_GameObject::pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *KX_GameObject::pyattr_get_lodmanager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_GameObject *self = static_cast<KX_GameObject*>(self_v);
-	if (!self->m_lodList) {
+	if (!self->m_lodManager) {
 		PyErr_SetString(PyExc_ValueError, "KX_GameObject.lod: there is no lod levels for this gameobject");
 		return NULL;
 	}
 
-	return self->m_lodList->GetProxy();
+	return self->m_lodManager->GetProxy();
 }
 
 PyObject *KX_GameObject::PyApplyForce(PyObject *args)

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2063,6 +2063,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("debug",	KX_GameObject, pyattr_get_debug, pyattr_set_debug),
 	KX_PYATTRIBUTE_RO_FUNCTION("components", KX_GameObject, pyattr_get_components),
 	KX_PYATTRIBUTE_RW_FUNCTION("debugRecursive",	KX_GameObject, pyattr_get_debugRecursive, pyattr_set_debugRecursive),
+	KX_PYATTRIBUTE_RO_FUNCTION("lod", KX_GameObject, pyattr_get_lodlist),
 	
 	/* experimental, don't rely on these yet */
 	KX_PYATTRIBUTE_RO_FUNCTION("sensors",		KX_GameObject, pyattr_get_sensors),
@@ -3281,6 +3282,17 @@ int KX_GameObject::pyattr_set_debugRecursive(void *self_v, const KX_PYATTRIBUTE_
 	self->SetUseDebugProperties(param, true);
 
 	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_GameObject *self = static_cast<KX_GameObject*>(self_v);
+	if (!self->m_lodList) {
+		PyErr_SetString(PyExc_ValueError, "KX_GameObject.lod: there is no lod levels for this gameobject");
+		return NULL;
+	}
+
+	return self->m_lodList->GetProxy();
 }
 
 PyObject *KX_GameObject::PyApplyForce(PyObject *args)

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -62,6 +62,7 @@
 #include "KX_NetworkMessageScene.h" //Needed for sendMessage()
 #include "KX_ObstacleSimulation.h"
 #include "KX_Scene.h"
+#include "KX_LodLevel.h"
 #include "KX_LodManager.h"
 #include "KX_CollisionContactPoints.h"
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -796,13 +796,13 @@ void KX_GameObject::RemoveMeshes()
 	m_meshes.clear();
 }
 
-void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos)
+void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos, float lodfactor)
 {
 	// Handle dupligroups
 	if (m_pInstanceObjects) {
 		for (CListValue::iterator it = m_pInstanceObjects->GetBegin(), end = m_pInstanceObjects->GetEnd(); it != end; ++it) {
 			KX_GameObject *instob = (KX_GameObject *)*it;
-			instob->UpdateLod(cam_pos);
+			instob->UpdateLod(cam_pos, lodfactor);
 		}
 	}
 
@@ -811,9 +811,9 @@ void KX_GameObject::UpdateLod(const MT_Vector3& cam_pos)
 	}
 
 	KX_Scene *scene = GetScene();
-	float distance2 = NodeGetWorldPosition().distance2(cam_pos);
-
-	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, distance2);
+	float dist = NodeGetWorldPosition().distance2(cam_pos);
+	dist /= lodfactor;
+	KX_LodLevel *lodLevel = m_lodManager->GetLevel(scene, m_previousLodLevel, dist);
 	const unsigned short level = lodLevel->GetLevel();
 
 	if (m_previousLodLevel != level) {

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -813,7 +813,7 @@ public:
 	/**
 	 * Updates the current lod level based on distance from camera.
 	 */
-	void UpdateLod(const MT_Vector3& cam_pos);
+	void UpdateLod(const MT_Vector3& cam_pos, float lodfactor);
 
 	/**
 	 * Pick out a mesh associated with the integer 'num'.

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -54,7 +54,7 @@
 //Forward declarations.
 struct KX_ClientObjectInfo;
 class KX_RayCast;
-class KX_LodList;
+class KX_LodManager;
 class RAS_MeshObject;
 class RAS_MeshUser;
 class PHY_IGraphicController;
@@ -89,7 +89,7 @@ protected:
 	STR_String							m_text;
 	int									m_layer;
 	std::vector<RAS_MeshObject*>		m_meshes;
-	KX_LodList							*m_lodList;
+	KX_LodManager						*m_lodManager;
 	int                                 m_currentLodLevel;
 	short								m_previousLodLevel;
 	RAS_MeshUser						*m_meshUser;
@@ -800,14 +800,14 @@ public:
 	/**
 	 * Set library of lod meshes
 	 */
-	void SetLodList(KX_LodList *lodList)
+	void SetLodManager(KX_LodManager *lodManager)
 	{
-		m_lodList = lodList;
+		m_lodManager = lodManager;
 	}
 
-	KX_LodList *GetLodList()
+	KX_LodManager *GetLodManager()
 	{
-		return m_lodList;
+		return m_lodManager;
 	}
 
 	/**
@@ -1114,7 +1114,7 @@ public:
 	static int			pyattr_set_linearDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject*	pyattr_get_lodmanager(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
 	/* Experimental! */
 	static PyObject*	pyattr_get_sensors(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -1114,6 +1114,7 @@ public:
 	static int			pyattr_set_linearDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_angularDamping(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_lodlist(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
 	/* Experimental! */
 	static PyObject*	pyattr_get_sensors(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_Lod.h
+++ b/source/gameengine/Ketsji/KX_Lod.h
@@ -21,15 +21,16 @@
  */
 
 #include "EXP_Value.h"
+#include "RAS_MeshObject.h"
 #include <vector>
 
-class RAS_MeshObject;
 class KX_Scene;
 class KX_BlenderSceneConverter;
 struct Object;
 
-class KX_LodList
+class KX_LodList: public CValue
 {
+	Py_Header
 public:
 	struct Level
 	{
@@ -56,9 +57,29 @@ private:
 
 	int m_refcount;
 
+	STR_String m_lodListName;
+
 public:
 	KX_LodList(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodList();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
+
+#ifdef WITH_PYTHON
+
+	//static PyObject *pyattr_get_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
+	KX_PYMETHOD_DOC(KX_LodList, getLevelMeshName);
+
+#endif //WITH_PYTHON
 
 	/** Get lod level cooresponding to distance and previous level.
 	 * \param scene Scene used to get default hysteresis.

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -1,0 +1,117 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* Contributor(s): Porteries Tristan.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+#include "KX_LodLevel.h"
+
+KX_LodLevel::KX_LodLevel()
+{
+}
+
+KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag)
+	:m_distance(distance),
+	m_hysteresis(hysteresis),
+	m_level(level),
+	m_meshobj(meshobj),
+	m_flags(flag)
+{
+}
+
+KX_LodLevel::~KX_LodLevel()
+{
+}
+
+// stuff for cvalue related things
+CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+const STR_String &KX_LodLevel::GetText()
+{
+	return GetName();
+}
+
+double KX_LodLevel::GetNumber()
+{
+	return -1.0;
+}
+
+STR_String &KX_LodLevel::GetName()
+{
+	return m_meshobj->GetName();
+}
+
+void KX_LodLevel::SetName(const char *name)
+{
+}
+
+CValue *KX_LodLevel::GetReplica()
+{
+	return NULL;
+}
+
+#ifdef WITH_PYTHON
+
+PyTypeObject KX_LodLevel::Type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"KX_LodLevel",
+	sizeof(PyObjectPlus_Proxy),
+	0,
+	py_base_dealloc,
+	0,
+	0,
+	0,
+	0,
+	py_base_repr,
+	0, 0, 0, 0, 0, 0, 0, 0, 0,
+	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	0, 0, 0, 0, 0, 0, 0,
+	Methods,
+	0,
+	0,
+	&CValue::Type,
+	0, 0, 0, 0, 0, 0,
+	py_base_new
+};
+
+PyMethodDef KX_LodLevel::Methods[] = {
+	//KX_PYMETHODTABLE(KX_LodLevel, getLevelMeshName),
+	{ NULL, NULL } //Sentinel
+};
+
+PyAttributeDef KX_LodLevel::Attributes[] = {
+	KX_PYATTRIBUTE_RO_FUNCTION("meshName", KX_LodLevel, pyattr_get_mesh_name),
+	{ NULL }    //Sentinel
+};
+
+PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	return PyUnicode_FromString(self->GetName());
+}
+
+#endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -33,6 +33,7 @@ KX_LodLevel::KX_LodLevel(float distance, float hysteresis, unsigned short level,
 	m_meshobj(meshobj),
 	m_flags(flag)
 {
+	m_initialDistance = distance;
 }
 
 KX_LodLevel::~KX_LodLevel()

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -105,6 +105,9 @@ PyMethodDef KX_LodLevel::Methods[] = {
 
 PyAttributeDef KX_LodLevel::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("meshName", KX_LodLevel, pyattr_get_mesh_name),
+	KX_PYATTRIBUTE_RO_FUNCTION("useHysteresis", KX_LodLevel, pyattr_get_use_hysteresis),
+	KX_PYATTRIBUTE_FLOAT_RW("distance", 0.0f, 99999999.0f, KX_LodLevel, m_distance),
+	KX_PYATTRIBUTE_FLOAT_RW("hysteresis", 0.0f, 100.0f, KX_LodLevel, m_hysteresis),
 	{ NULL }    //Sentinel
 };
 
@@ -112,6 +115,13 @@ PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_D
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
 	return PyUnicode_FromString(self->GetName());
+}
+
+PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
+	int useHysteresis = self->GetFlag();
+	return PyBool_FromLong(useHysteresis);
 }
 
 #endif //WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -40,6 +40,41 @@ KX_LodLevel::~KX_LodLevel()
 {
 }
 
+// stuff for cvalue related things
+CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
+{
+	return NULL;
+}
+
+const STR_String &KX_LodLevel::GetText()
+{
+	return GetName();
+}
+
+double KX_LodLevel::GetNumber()
+{
+	return -1.0;
+}
+
+STR_String &KX_LodLevel::GetName()
+{
+	return m_meshobj->GetName();
+}
+
+void KX_LodLevel::SetName(const char *name)
+{
+}
+
+CValue *KX_LodLevel::GetReplica()
+{
+	return NULL;
+}
+
 #ifdef WITH_PYTHON
 
 PyTypeObject KX_LodLevel::Type = {
@@ -80,7 +115,7 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return PyUnicode_FromString(self->m_meshobj->GetName());
+	return PyUnicode_FromString(self->GetName());
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_LodLevel.cpp
+++ b/source/gameengine/Ketsji/KX_LodLevel.cpp
@@ -40,41 +40,6 @@ KX_LodLevel::~KX_LodLevel()
 {
 }
 
-// stuff for cvalue related things
-CValue *KX_LodLevel::Calc(VALUE_OPERATOR op, CValue *val)
-{
-	return NULL;
-}
-
-CValue *KX_LodLevel::CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val)
-{
-	return NULL;
-}
-
-const STR_String &KX_LodLevel::GetText()
-{
-	return GetName();
-}
-
-double KX_LodLevel::GetNumber()
-{
-	return -1.0;
-}
-
-STR_String &KX_LodLevel::GetName()
-{
-	return m_meshobj->GetName();
-}
-
-void KX_LodLevel::SetName(const char *name)
-{
-}
-
-CValue *KX_LodLevel::GetReplica()
-{
-	return NULL;
-}
-
 #ifdef WITH_PYTHON
 
 PyTypeObject KX_LodLevel::Type = {
@@ -115,7 +80,7 @@ PyAttributeDef KX_LodLevel::Attributes[] = {
 PyObject *KX_LodLevel::pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_LodLevel *self = static_cast<KX_LodLevel *>(self_v);
-	return PyUnicode_FromString(self->GetName());
+	return PyUnicode_FromString(self->m_meshobj->GetName());
 }
 
 PyObject *KX_LodLevel::pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -1,0 +1,81 @@
+/*
+* ***** BEGIN GPL LICENSE BLOCK *****
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+* Contributor(s): Porteries Tristan.
+*
+* ***** END GPL LICENSE BLOCK *****
+*/
+
+#include "EXP_Value.h"
+#include "RAS_MeshObject.h"
+
+class KX_LodLevel : public CValue
+{
+	Py_Header
+
+private:
+
+	float m_distance;
+	float m_hysteresis;
+	unsigned short m_level;
+	unsigned short m_flags;
+	RAS_MeshObject *m_meshobj;
+
+public:
+	KX_LodLevel();
+	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
+	virtual ~KX_LodLevel();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
+
+	float GetDistance() {
+		return m_distance;
+	}
+	float GetHysteresis() {
+		return m_hysteresis;
+	}
+	unsigned short GetLevel() {
+		return m_level;
+	}
+	unsigned short GetFlag() {
+		return m_flags;
+	}
+	RAS_MeshObject *GetMesh() {
+		return m_meshobj;
+	}
+	enum {
+		// Use custom hysteresis for this level.
+		USE_HYST = (1 << 0),
+	};
+
+#ifdef WITH_PYTHON
+
+	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
+	//KX_PYMETHOD_DOC(KX_LodLevel, getMeshName);
+
+#endif //WITH_PYTHON
+
+};

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -30,6 +30,7 @@ class KX_LodLevel : public CValue
 private:
 
 	float m_distance;
+	float m_initialDistance;
 	float m_hysteresis;
 	unsigned short m_level;
 	unsigned short m_flags;
@@ -51,6 +52,12 @@ public:
 
 	float GetDistance() {
 		return m_distance;
+	}
+	void SetDistance(float dist) {
+		m_distance = dist;
+	}
+	float GetInitialDistance() {
+		return m_initialDistance;
 	}
 	float GetHysteresis() {
 		return m_hysteresis;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public PyObjectPlus
+class KX_LodLevel : public CValue
 {
 	Py_Header
 
@@ -40,6 +40,15 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
+
+	// stuff for cvalue related things
+	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
+	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
+	virtual const STR_String& GetText();
+	virtual double GetNumber();
+	virtual STR_String& GetName();
+	virtual void SetName(const char *name); // Set the name of the value
+	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public CValue
+class KX_LodLevel : public PyObjectPlus
 {
 	Py_Header
 
@@ -40,15 +40,6 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -72,9 +72,9 @@ public:
 #ifdef WITH_PYTHON
 
 	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 
-	//KX_PYMETHOD_DOC(KX_LodLevel, getMeshName);
+	//KX_PYMETHOD_DOC(KX_LodLevel, ...);
 
 #endif //WITH_PYTHON
 

--- a/source/gameengine/Ketsji/KX_LodLevel.h
+++ b/source/gameengine/Ketsji/KX_LodLevel.h
@@ -23,7 +23,7 @@
 #include "EXP_Value.h"
 #include "RAS_MeshObject.h"
 
-class KX_LodLevel : public CValue
+class KX_LodLevel : public PyObjectPlus
 {
 	Py_Header
 
@@ -40,15 +40,6 @@ public:
 	KX_LodLevel();
 	KX_LodLevel(float distance, float hysteresis, unsigned short level, RAS_MeshObject *meshobj, unsigned short flag);
 	virtual ~KX_LodLevel();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
 
 	float GetDistance() {
 		return m_distance;
@@ -77,6 +68,11 @@ public:
 	};
 
 #ifdef WITH_PYTHON
+
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString(m_meshobj->GetName());
+	}
 
 	static PyObject *pyattr_get_mesh_name(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_use_hysteresis(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -89,7 +89,7 @@ float KX_LodManager::GetHysteresis(KX_Scene *scene, unsigned short level)
 	return MT_abs(lodnext->GetDistance() - lod->GetDistance()) * hysteresis;
 }
 
-KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod, float distance)
+KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2)
 {
 	unsigned short level = 0;
 	unsigned short count = m_lodLevelList.size();
@@ -102,14 +102,14 @@ KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod
 		else if (level == previouslod || level == (previouslod + 1)) {
 			const float hystvariance = GetHysteresis(scene, level);
 			const float newdistance = m_lodLevelList[level + 1]->GetDistance() + hystvariance;
-			if (newdistance > distance) {
+			if (newdistance * newdistance > distance) {
 				break;
 			}
 		}
 		else if (level == (previouslod - 1)) {
 			const float hystvariance = GetHysteresis(scene, level);
 			const float newdistance = m_lodLevelList[level + 1]->GetDistance() - hystvariance;
-			if (newdistance > distance) {
+			if (newdistance * newdistance > distance) {
 				break;
 			}
 		}

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -30,7 +30,7 @@
 
 KX_LodManager::KX_LodManager(Object *ob, KX_Scene* scene, KX_BlenderSceneConverter* converter, bool libloading)
 	:m_refcount(1),
-	m_distanceScale(1.0f)
+	m_lodFactor(1.0f)
 {
 	if (BLI_listbase_count_ex(&ob->lodlevels, 2) > 1) {
 		LodLevel *lod = (LodLevel*)ob->lodlevels.first;
@@ -93,7 +93,7 @@ KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod
 {
 	unsigned short level = 0;
 	unsigned short count = m_lodLevelList.size();
-	distance *= m_distanceScale;
+	distance2 *= m_lodFactor;
 
 	while (level < count) {
 		if (level == (count - 1)) {
@@ -102,14 +102,14 @@ KX_LodLevel *KX_LodManager::GetLevel(KX_Scene *scene, unsigned short previouslod
 		else if (level == previouslod || level == (previouslod + 1)) {
 			const float hystvariance = GetHysteresis(scene, level);
 			const float newdistance = m_lodLevelList[level + 1]->GetDistance() + hystvariance;
-			if (newdistance * newdistance > distance) {
+			if (newdistance * newdistance > distance2) {
 				break;
 			}
 		}
 		else if (level == (previouslod - 1)) {
 			const float hystvariance = GetHysteresis(scene, level);
 			const float newdistance = m_lodLevelList[level + 1]->GetDistance() - hystvariance;
-			if (newdistance * newdistance > distance) {
+			if (newdistance * newdistance > distance2) {
 				break;
 			}
 		}
@@ -149,7 +149,7 @@ PyMethodDef KX_LodManager::Methods[] = {
 
 PyAttributeDef KX_LodManager::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("lodLevel", KX_LodManager, pyattr_get_lodlevels),
-	KX_PYATTRIBUTE_FLOAT_RW("distanceScale", 0.0f, FLT_MAX, KX_LodManager, m_distanceScale),
+	KX_PYATTRIBUTE_FLOAT_RW("lodFactor", 0.0f, FLT_MAX, KX_LodManager, m_lodFactor),
 	{ NULL }    //Sentinel
 };
 

--- a/source/gameengine/Ketsji/KX_LodManager.cpp
+++ b/source/gameengine/Ketsji/KX_LodManager.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "KX_LodManager.h"
+#include "KX_LodLevel.h"
 #include "KX_Scene.h"
 #include "BL_BlenderDataConversion.h"
 #include "DNA_object_types.h"

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -85,4 +85,5 @@ public:
 		}
 		return this;
 	}
+	void SetScale(float scale);
 };

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -44,7 +44,8 @@ private:
 
 	int m_refcount;
 
-	float m_distanceScale;
+	/// Factor applied to camera to object distance.
+	float m_lodFactor;
 
 public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -44,6 +44,8 @@ private:
 
 	int m_refcount;
 
+	float m_lodLevelsScale;
+
 public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
 	virtual ~KX_LodManager();
@@ -52,6 +54,8 @@ public:
 
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 #endif //WITH_PYTHON
 

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -44,7 +44,7 @@ private:
 
 	int m_refcount;
 
-	float m_lodLevelsScale;
+	float m_distanceScale;
 
 public:
 	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
@@ -59,8 +59,6 @@ public:
 
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int pyattr_set_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 #endif //WITH_PYTHON
 
@@ -69,7 +67,7 @@ public:
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
-	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
+	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance);
 
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const
@@ -90,5 +88,4 @@ public:
 		}
 		return this;
 	}
-	void SetScale(float scale);
 };

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -21,33 +21,20 @@
  */
 
 #include "EXP_Value.h"
-#include "RAS_MeshObject.h"
+#include "KX_LodLevel.h"
 #include <vector>
 
 class KX_Scene;
 class KX_BlenderSceneConverter;
 struct Object;
 
-class KX_LodList: public CValue
+class KX_LodManager: public PyObjectPlus
 {
 	Py_Header
 public:
-	struct Level
-	{
-		float distance;
-		float hysteresis;
-		unsigned short level;
-		unsigned short flags;
-		RAS_MeshObject *meshobj;
-
-		enum {
-			// Use custom hysteresis for this level.
-			USE_HYST = (1 << 0),
-		};
-	};
 
 private:
-	std::vector<Level> m_lodLevelList;
+	std::vector<KX_LodLevel *> m_lodLevelList;
 
 	/** Get the hysteresis from the level or the scene.
 	 * \param scene Scene used to get default hysteresis.
@@ -57,27 +44,14 @@ private:
 
 	int m_refcount;
 
-	STR_String m_lodListName;
-
 public:
-	KX_LodList(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
-	virtual ~KX_LodList();
-
-	// stuff for cvalue related things
-	virtual CValue *Calc(VALUE_OPERATOR op, CValue *val);
-	virtual CValue *CalcFinal(VALUE_DATA_TYPE dtype, VALUE_OPERATOR op, CValue *val);
-	virtual const STR_String& GetText();
-	virtual double GetNumber();
-	virtual STR_String& GetName();
-	virtual void SetName(const char *name); // Set the name of the value
-	virtual CValue *GetReplica();
+	KX_LodManager(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading);
+	virtual ~KX_LodManager();
 
 #ifdef WITH_PYTHON
 
-	//static PyObject *pyattr_get_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-
-	KX_PYMETHOD_DOC(KX_LodList, getLevelMeshName);
 
 #endif //WITH_PYTHON
 
@@ -86,7 +60,7 @@ public:
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
-	const KX_LodList::Level& GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
+	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
 
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const
@@ -94,12 +68,12 @@ public:
 		return m_lodLevelList.empty();
 	}
 
-	KX_LodList *AddRef()
+	KX_LodManager *AddRef()
 	{
 		++m_refcount;
 		return this;
 	}
-	KX_LodList *Release()
+	KX_LodManager *Release()
 	{
 		if (--m_refcount == 0) {
 			delete this;

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -21,11 +21,11 @@
  */
 
 #include "EXP_Value.h"
-#include "KX_LodLevel.h"
 #include <vector>
 
 class KX_Scene;
 class KX_BlenderSceneConverter;
+class KX_LodLevel;
 struct Object;
 
 class KX_LodManager: public PyObjectPlus

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -52,6 +52,11 @@ public:
 
 #ifdef WITH_PYTHON
 
+	virtual PyObject *py_repr()
+	{
+		return PyUnicode_FromString("KX_LodManager");
+	}
+
 	static PyObject *pyattr_get_lodlevels(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	//static int pyattr_set_(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject *pyattr_get_lod_levels_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -67,7 +67,7 @@ public:
 	 * \param previouslod Previous lod computed by this function before.
 	 * \param distance2 Squared distance object to the camera.
 	 */
-	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance);
+	KX_LodLevel *GetLevel(KX_Scene *scene, unsigned short previouslod, float distance2);
 
 	/// If it returns true, then the lod is useless then.
 	inline bool Empty() const

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,6 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
+#include "KX_LodLevel.h"
 #include "KX_LodManager.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,7 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
-#include "KX_Lod.h"
+#include "KX_LodManager.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"
 #include "KX_MouseFocusSensor.h"
@@ -226,7 +226,8 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, KX_GameObject, init_getset);
 		PyType_Ready_Attr(dict, KX_LibLoadStatus, init_getset);
 		PyType_Ready_Attr(dict, KX_LightObject, init_getset);
-		PyType_Ready_Attr(dict, KX_LodList, init_getset);
+		PyType_Ready_Attr(dict, KX_LodLevel, init_getset);
+		PyType_Ready_Attr(dict, KX_LodManager, init_getset);
 		PyType_Ready_Attr(dict, KX_FontObject, init_getset);
 		PyType_Ready_Attr(dict, KX_MeshProxy, init_getset);
 		PyType_Ready_Attr(dict, KX_MouseFocusSensor, init_getset);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -55,6 +55,7 @@
 #include "KX_GameActuator.h"
 #include "KX_LibLoadStatus.h"
 #include "KX_Light.h"
+#include "KX_Lod.h"
 #include "KX_FontObject.h"
 #include "KX_MeshProxy.h"
 #include "KX_MouseFocusSensor.h"
@@ -225,6 +226,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, KX_GameObject, init_getset);
 		PyType_Ready_Attr(dict, KX_LibLoadStatus, init_getset);
 		PyType_Ready_Attr(dict, KX_LightObject, init_getset);
+		PyType_Ready_Attr(dict, KX_LodList, init_getset);
 		PyType_Ready_Attr(dict, KX_FontObject, init_getset);
 		PyType_Ready_Attr(dict, KX_MeshProxy, init_getset);
 		PyType_Ready_Attr(dict, KX_MouseFocusSensor, init_getset);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1775,11 +1775,12 @@ void KX_Scene::UpdateObjectLods()
 		return;
 
 	const MT_Vector3& cam_pos = m_active_camera->NodeGetWorldPosition();
+	const float lodfactor = m_active_camera->GetLodFactor();
 
 	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 		KX_GameObject *gameobj = (KX_GameObject *)*it;
 		if (!gameobj->GetCulled()) {
-			gameobj->UpdateLod(cam_pos);
+			gameobj->UpdateLod(cam_pos, lodfactor);
 		}
 	}
 }
@@ -2188,9 +2189,7 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
-	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
-	
 	/* dict style access */
 	KX_PYMETHODTABLE(KX_Scene, get),
 	

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1779,7 +1779,7 @@ void KX_Scene::UpdateObjectLods()
 	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 		KX_GameObject *gameobj = (KX_GameObject *)*it;
 		if (!gameobj->GetCulled()) {
-			gameobj->UpdateLod(cam_pos, m_active_camera->GetLodFactor());
+			gameobj->UpdateLod(cam_pos);
 		}
 	}
 }
@@ -2188,6 +2188,7 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
+	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
 	
 	/* dict style access */

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1779,7 +1779,7 @@ void KX_Scene::UpdateObjectLods()
 	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 		KX_GameObject *gameobj = (KX_GameObject *)*it;
 		if (!gameobj->GetCulled()) {
-			gameobj->UpdateLod(cam_pos);
+			gameobj->UpdateLod(cam_pos, m_active_camera->GetLodFactor());
 		}
 	}
 }
@@ -2188,7 +2188,6 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
-	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
 	
 	/* dict style access */
@@ -2629,42 +2628,6 @@ KX_PYMETHODDEF_DOC(KX_Scene, get, "")
 	
 	Py_INCREF(def);
 	return def;
-}
-
-KX_PYMETHODDEF_DOC(KX_Scene, setLodScale, "setLodScale(pythonObjectList, scale")
-{
-	PyObject *list;
-	KX_GameObject *gameobj;
-	float scale;
-	if (!PyArg_ParseTuple(args, "Of", &list, &scale)) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
-		return NULL;
-	}
-
-	PyObject *iter = PyObject_GetIter(list);
-	if (!iter) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
-		return NULL;
-	}
-
-	while (true) {
-		PyObject *next = PyIter_Next(iter);
-		if (!next) {
-			// nothing left in the iterator
-			break;
-		}
-
-		if (!ConvertPythonToGameObject(m_logicmgr, next, &gameobj, false, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float"))
-			return NULL;
-
-		if (!gameobj->GetLodManager()) {
-			PyErr_SetString(PyExc_ValueError, "Warning: KX_Scene.setLodScale(pythonObjectList, scale): One or several KX_GameObject in the python object list have no LOD");
-		}
-		if (gameobj->GetLodManager()) {
-			gameobj->GetLodManager()->SetScale(scale);
-		}
-	}
-	Py_RETURN_NONE;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -154,9 +154,7 @@ KX_Scene::KX_Scene(class SCA_IInputDevice* keyboarddevice,
 	m_ueberExecutionPriority(0),
 	m_blenderScene(scene),
 	m_isActivedHysteresis(false),
-	m_lodHysteresisValue(0),
-	m_lodGlobalScale(1.0f),
-	m_lodObjectList(NULL)
+	m_lodHysteresisValue(0)
 {
 	m_suspendedtime = 0.0;
 	m_suspendeddelta = 0.0;
@@ -1791,14 +1789,6 @@ void KX_Scene::SetLodHysteresis(bool active)
 	m_isActivedHysteresis = active;
 }
 
-void KX_Scene::SetGlobalLodScale(float scale)
-{
-	for (int i = 0; i < m_lodObjectList.size(); i++) {
-		m_lodObjectList[i]->GetLodManager()->SetScale(scale);
-		m_lodGlobalScale = scale;
-	}
-}
-
 bool KX_Scene::IsActivedLodHysteresis(void)
 {
 	return m_isActivedHysteresis;
@@ -2198,6 +2188,7 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
+	KX_PYMETHODTABLE(KX_Scene, setLodScale),
 
 	
 	/* dict style access */
@@ -2510,27 +2501,6 @@ int KX_Scene::pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef
 	return PY_SET_ATTR_SUCCESS;
 }
 
-PyObject *KX_Scene::pyattr_get_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
-{
-	KX_Scene* self = static_cast<KX_Scene*>(self_v);
-
-	return PyFloat_FromDouble(self->m_lodGlobalScale);
-}
-
-int KX_Scene::pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
-{
-	KX_Scene* self = static_cast<KX_Scene*>(self_v);
-
-	float scale = PyFloat_AsDouble(value);
-	if (scale == -1.0f && PyErr_Occurred()) {
-		PyErr_SetString(PyExc_ValueError, "KX_Scene.lodGlobalScale: KX_Scene expected a float");
-		return NULL;
-	}
-	CLAMP(scale, 0.0f, 99999999.0f);
-	self->SetGlobalLodScale(scale);
-	return PY_SET_ATTR_SUCCESS;
-}
-
 PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("name",				KX_Scene, pyattr_get_name),
 	KX_PYATTRIBUTE_RO_FUNCTION("objects",			KX_Scene, pyattr_get_objects),
@@ -2544,7 +2514,6 @@ PyAttributeDef KX_Scene::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("post_draw",			KX_Scene, pyattr_get_drawing_callback_post, pyattr_set_drawing_callback_post),
 	KX_PYATTRIBUTE_RW_FUNCTION("pre_draw_setup",	KX_Scene, pyattr_get_drawing_setup_callback_pre, pyattr_set_drawing_setup_callback_pre),
 	KX_PYATTRIBUTE_RW_FUNCTION("gravity",			KX_Scene, pyattr_get_gravity, pyattr_set_gravity),
-	KX_PYATTRIBUTE_RW_FUNCTION("lodGlobalScale",	KX_Scene, pyattr_get_lod_global_scale, pyattr_set_lod_global_scale),
 	KX_PYATTRIBUTE_BOOL_RO("suspended",				KX_Scene, m_suspend),
 	KX_PYATTRIBUTE_BOOL_RO("activity_culling",		KX_Scene, m_activity_culling),
 	KX_PYATTRIBUTE_FLOAT_RW("activity_culling_radius", 0.5f, FLT_MAX, KX_Scene, m_activity_box_radius),
@@ -2660,6 +2629,42 @@ KX_PYMETHODDEF_DOC(KX_Scene, get, "")
 	
 	Py_INCREF(def);
 	return def;
+}
+
+KX_PYMETHODDEF_DOC(KX_Scene, setLodScale, "setLodScale(pythonObjectList, scale")
+{
+	PyObject *list;
+	KX_GameObject *gameobj;
+	float scale;
+	if (!PyArg_ParseTuple(args, "Of", &list, &scale)) {
+		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
+		return NULL;
+	}
+
+	PyObject *iter = PyObject_GetIter(list);
+	if (!iter) {
+		PyErr_SetString(PyExc_ValueError, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float");
+		return NULL;
+	}
+
+	while (true) {
+		PyObject *next = PyIter_Next(iter);
+		if (!next) {
+			// nothing left in the iterator
+			break;
+		}
+
+		if (!ConvertPythonToGameObject(m_logicmgr, next, &gameobj, false, "KX_Scene.setLodScale(pythonObjectList, scale): KX_Scene expected a list of KX_GameObject and a float"))
+			return NULL;
+
+		if (!gameobj->GetLodManager()) {
+			PyErr_SetString(PyExc_ValueError, "Warning: KX_Scene.setLodScale(pythonObjectList, scale): One or several KX_GameObject in the python object list have no LOD");
+		}
+		if (gameobj->GetLodManager()) {
+			gameobj->GetLodManager()->SetScale(scale);
+		}
+	}
+	Py_RETURN_NONE;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -627,7 +627,6 @@ public:
 	KX_PYMETHOD_DOC(KX_Scene, resume);
 	KX_PYMETHOD_DOC(KX_Scene, get);
 	KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
-	KX_PYMETHOD_DOC(KX_Scene, setLodScale);
 
 
 	/* attributes */

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -297,6 +297,10 @@ protected:
 	bool m_isActivedHysteresis;
 	int m_lodHysteresisValue;
 
+	float m_lodGlobalScale;
+
+	std::vector<KX_GameObject *>m_lodObjectList;
+
 public:
 	KX_Scene(class SCA_IInputDevice* keyboarddevice,
 		class SCA_IInputDevice* mousedevice,
@@ -553,6 +557,12 @@ public:
 	bool IsActivedLodHysteresis();
 	void SetLodHysteresisValue(int hysteresisvalue);
 	int GetLodHysteresisValue();
+
+	void SetGlobalLodScale(float scale);
+
+	void LodObjectListAppend(KX_GameObject *gameob) {
+		m_lodObjectList.push_back(gameob);
+	}
 	
 	// Update the activity box settings for objects in this scene, if needed.
 	void UpdateObjectActivity(void);
@@ -647,6 +657,8 @@ public:
 	static int			pyattr_set_drawing_setup_callback_pre(void *selv_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_gravity(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_lod_global_scale(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int			pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	virtual PyObject *py_repr(void) { return PyUnicode_From_STR_String(GetName()); }
 	

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -297,10 +297,6 @@ protected:
 	bool m_isActivedHysteresis;
 	int m_lodHysteresisValue;
 
-	float m_lodGlobalScale;
-
-	std::vector<KX_GameObject *>m_lodObjectList;
-
 public:
 	KX_Scene(class SCA_IInputDevice* keyboarddevice,
 		class SCA_IInputDevice* mousedevice,
@@ -557,12 +553,6 @@ public:
 	bool IsActivedLodHysteresis();
 	void SetLodHysteresisValue(int hysteresisvalue);
 	int GetLodHysteresisValue();
-
-	void SetGlobalLodScale(float scale);
-
-	void LodObjectListAppend(KX_GameObject *gameob) {
-		m_lodObjectList.push_back(gameob);
-	}
 	
 	// Update the activity box settings for objects in this scene, if needed.
 	void UpdateObjectActivity(void);
@@ -637,6 +627,7 @@ public:
 	KX_PYMETHOD_DOC(KX_Scene, resume);
 	KX_PYMETHOD_DOC(KX_Scene, get);
 	KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
+	KX_PYMETHOD_DOC(KX_Scene, setLodScale);
 
 
 	/* attributes */
@@ -657,8 +648,6 @@ public:
 	static int			pyattr_set_drawing_setup_callback_pre(void *selv_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_gravity(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_gravity(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_lod_global_scale(void* self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int			pyattr_set_lod_global_scale(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	virtual PyObject *py_repr(void) { return PyUnicode_From_STR_String(GetName()); }
 	


### PR DESCRIPTION
mplement KX_LodManager.distanceScale

The distance to camera is now mulplied by the the lod distance scale in
KX_LodManager::GetLevel, which by the side obligate us to use non-squared
distances.

The distance scale is currently simply named distanceScale, this name is
to debate, maybe distanceFactor ?.


Example file : http://www.pasteall.org/blend/42171

@youle31 : I was thinking to something like this for the distance scale, can you add your opinion on it, please ?
@Maujoe; you too, please ?