### PR TITLE
UPBGE: Implement game object bounding volume box python API.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
@@ -28,13 +28,13 @@ base class --- :class:`PyObjectPlus`
 
    .. attribute:: min
 
-      The minimal point of the bounding box.
+      The minimal point in x, y and z axis of the bounding box.
 
       :type: :class:`mathutils.Vector`
 
    .. attribute:: max
 
-      The maximal point of the bounding box.
+      The maximal point in x, y and z axis of the bounding box.
 
       :type: :class:`mathutils.Vector`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
@@ -17,7 +17,7 @@ base class --- :class:`PyObjectPlus`
       owner = logic.getCurrentController().owner
       bounds = owner.bounds
       
-      # Desactivate auto update to allow modificate the bounds.
+      # Disable auto update to allow modify the bounds.
       bounds.autoUpdate = False
       
       print(bounds)

--- a/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
@@ -15,16 +15,16 @@ base class --- :class:`PyObjectPlus`
       from mathutils import Vector
       
       owner = logic.getCurrentController().owner
-      bounds = owner.bounds
+      box = owner.cullingBox
       
-      # Disable auto update to allow modify the bounds.
-      bounds.autoUpdate = False
+      # Disable auto update to allow modify the box.
+      box.autoUpdate = False
       
-      print(bounds)
-      # Increase the height of the bounds of 1.
-      bounds.max = bounds.max + Vector((0, 0, 1))
+      print(box)
+      # Increase the height of the box of 1.
+      box.max = box.max + Vector((0, 0, 1))
       
-      print(bounds)
+      print(box)
 
    .. attribute:: min
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
@@ -1,0 +1,57 @@
+KX_BoundingBox(PyObjectPlus)
+=============================
+
+.. module:: bge.types
+
+base class --- :class:`PyObjectPlus`
+
+.. class:: KX_BoundingBox(PyObjectPlus)
+
+   A bounding volume box of a game object. Used to get and alterate the volume box or AABB.
+
+   .. code-block:: python
+
+      from bge import logic
+      from mathutils import Vector
+      
+      owner = logic.getCurrentController().owner
+      bounds = owner.bounds
+      
+      # Desactivate auto update to allow modificate the bounds.
+      bounds.autoUpdate = False
+      
+      print(bounds)
+      # Increase the height of the bounds of 1.
+      bounds.max = bounds.max + Vector((0, 0, 1))
+      
+      print(bounds)
+
+   .. attribute:: min
+
+      The minimal point of the bounding box.
+
+      :type: :class:`mathutils.Vector`
+
+   .. attribute:: max
+
+      The maximal point of the bounding box.
+
+      :type: :class:`mathutils.Vector`
+
+   .. attribute:: center
+
+      The center of the bounding box. (read only)
+
+      :type: :class:`mathutils.Vector`
+
+   .. attribute:: radius
+
+      The radius of the bounding box. (read only)
+
+      :type: float
+
+   .. attribute:: autoUpdate
+
+      Allow to update the bounding box if the mesh is modified.
+
+      :type: boolean

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -266,7 +266,7 @@ base class --- :class:`SCA_IObject`
 
          Game logic will still run for invisible objects.
 
-   .. attribute:: bounds
+   .. attribute:: cullingBox
 
       The object's bounding volume box used for culling.
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -266,6 +266,12 @@ base class --- :class:`SCA_IObject`
 
          Game logic will still run for invisible objects.
 
+   .. attribute:: bounds
+
+      The object's bounding volume box used for culling.
+
+      :type: :class:`KX_BoundingBox`
+
    .. attribute:: record_animation
 
       Record animation for this object.

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SRC
 	KX_2DFilterManager.cpp
 	KX_ArmatureSensor.cpp
 	KX_BlenderMaterial.cpp
+	KX_BoundingBox.cpp
 	KX_Camera.cpp
 	KX_CameraActuator.cpp
 	KX_CameraIpoSGController.cpp
@@ -147,6 +148,7 @@ set(SRC
 	KX_2DFilterManager.h
 	KX_ArmatureSensor.h
 	KX_BlenderMaterial.h
+	KX_BoundingBox.h
 	KX_Camera.h
 	KX_CameraActuator.h
 	KX_CameraIpoSGController.h

--- a/source/gameengine/Ketsji/KX_BoundingBox.cpp
+++ b/source/gameengine/Ketsji/KX_BoundingBox.cpp
@@ -1,0 +1,235 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+
+#include "KX_BoundingBox.h"
+#include "KX_GameObject.h"
+#include "KX_PyMath.h"
+
+#ifdef WITH_PYTHON
+
+KX_BoundingBox::KX_BoundingBox(KX_GameObject *owner)
+	:m_owner(owner),
+	m_proxy(owner->GetProxy())
+{
+}
+
+KX_BoundingBox::~KX_BoundingBox()
+{
+}
+
+bool KX_BoundingBox::IsValidOwner()
+{
+	if (!BGE_PROXY_REF(m_proxy)) {
+		PyErr_SetString(PyExc_SystemError, "KX_BoundingBox, " BGE_PROXY_ERROR_MSG);
+		return false;
+	}
+	return true;
+}
+
+const MT_Vector3& KX_BoundingBox::GetMax() const
+{
+	// Update AABB to make sure we have the last one.
+	m_owner->UpdateBounds(false);
+	SG_BBox &box = m_owner->GetSGNode()->BBox();
+	return box.GetMax();
+}
+
+const MT_Vector3& KX_BoundingBox::GetMin() const
+{
+	// Update AABB to make sure we have the last one.
+	m_owner->UpdateBounds(false);
+	SG_BBox &box = m_owner->GetSGNode()->BBox();
+	return box.GetMin();
+}
+
+const MT_Vector3 KX_BoundingBox::GetCenter() const
+{
+	// Update AABB to make sure we have the last one.
+	m_owner->UpdateBounds(false);
+	SG_BBox &box = m_owner->GetSGNode()->BBox();
+	return box.GetCenter();
+}
+
+float KX_BoundingBox::GetRadius() const
+{
+	// Update AABB to make sure we have the last one.
+	m_owner->UpdateBounds(false);
+	SG_BBox &box = m_owner->GetSGNode()->BBox();
+	return box.GetRadius();
+}
+
+void KX_BoundingBox::SetMax(MT_Vector3 max)
+{
+	m_owner->SetBoundsAabb(GetMin(), max);
+}
+
+void KX_BoundingBox::SetMin(MT_Vector3 min)
+{
+	m_owner->SetBoundsAabb(min, GetMax());
+}
+
+PyTypeObject KX_BoundingBox::Type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"KX_BoundingBox",
+	sizeof(PyObjectPlus_Proxy),
+	0,
+	py_base_dealloc,
+	0,
+	0,
+	0,
+	0,
+	py_base_repr,
+	0, 0, 0, 0, 0, 0, 0, 0, 0,
+	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	0, 0, 0, 0, 0, 0, 0,
+	Methods,
+	0,
+	0,
+	&PyObjectPlus::Type,
+	0, 0, 0, 0, 0, 0,
+	py_base_new
+};
+
+PyMethodDef KX_BoundingBox::Methods[] = {
+	{NULL, NULL} // Sentinel
+};
+
+PyAttributeDef KX_BoundingBox::Attributes[] = {
+	KX_PYATTRIBUTE_RW_FUNCTION("min", KX_BoundingBox, pyattr_get_min, pyattr_set_min),
+	KX_PYATTRIBUTE_RW_FUNCTION("max", KX_BoundingBox, pyattr_get_max, pyattr_set_max),
+	KX_PYATTRIBUTE_RO_FUNCTION("center", KX_BoundingBox, pyattr_get_center),
+	KX_PYATTRIBUTE_RO_FUNCTION("radius", KX_BoundingBox, pyattr_get_radius),
+	KX_PYATTRIBUTE_RW_FUNCTION("autoUpdate", KX_BoundingBox, pyattr_get_auto_update, pyattr_set_auto_update),
+	{NULL} // Sentinel
+};
+
+PyObject *KX_BoundingBox::py_repr()
+{
+	if (!IsValidOwner()) {
+		return PyUnicode_FromString("KX_BoundingBox of invalid object");
+	}
+	return PyUnicode_FromFormat("KX_BoundingBox of object %s, min: %R, max: %R", m_owner->GetName().ReadPtr(),
+								PyObjectFrom(GetMin()), PyObjectFrom(GetMax()));
+}
+
+PyObject *KX_BoundingBox::pyattr_get_min(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return NULL;
+	}
+
+	return PyObjectFrom(self->GetMin());
+}
+
+int KX_BoundingBox::pyattr_set_min(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return PY_SET_ATTR_FAIL;
+	}
+
+	MT_Vector3 min;
+	if (!PyVecTo(value, min)) {
+		return PY_SET_ATTR_FAIL;
+	}
+	self->SetMin(min);
+
+	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_BoundingBox::pyattr_get_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return NULL;
+	}
+
+	return PyObjectFrom(self->GetMax());
+}
+
+int KX_BoundingBox::pyattr_set_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return PY_SET_ATTR_FAIL;
+	}
+
+	MT_Vector3 max;
+	if (!PyVecTo(value, max)) {
+		return PY_SET_ATTR_FAIL;
+	}
+	self->SetMax(max);
+
+	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_BoundingBox::pyattr_get_center(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return NULL;
+	}
+
+	return PyObjectFrom(self->GetCenter());
+}
+
+PyObject *KX_BoundingBox::pyattr_get_radius(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return NULL;
+	}
+
+	return PyFloat_FromDouble(self->GetRadius());
+}
+
+PyObject *KX_BoundingBox::pyattr_get_auto_update(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return NULL;
+	}
+
+	return PyBool_FromLong(self->m_owner->GetAutoUpdateBounds());
+}
+
+int KX_BoundingBox::pyattr_set_auto_update(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>(self_v);
+	if (!self->IsValidOwner()) {
+		return PY_SET_ATTR_FAIL;
+	}
+
+	int autoUpdate = PyObject_IsTrue(value);
+	if (autoUpdate == -1) {
+		PyErr_SetString(PyExc_AttributeError, "bounds.autoUpdate = bool: KX_BoundingBox, expected True or False");
+		return PY_SET_ATTR_FAIL;
+	}
+
+	self->m_owner->SetAutoUpdateBounds((bool)autoUpdate);
+
+	return PY_SET_ATTR_SUCCESS;
+}
+
+#endif  // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_BoundingBox.cpp
+++ b/source/gameengine/Ketsji/KX_BoundingBox.cpp
@@ -102,6 +102,109 @@ bool KX_BoundingBox::SetMin(MT_Vector3 min)
 	return true;
 }
 
+
+#ifdef USE_MATHUTILS
+
+#define MATHUTILS_VEC_CB_BOX_MIN 1
+#define MATHUTILS_VEC_CB_BOX_MAX 2
+
+static unsigned char mathutils_kxboundingbox_vector_cb_index = -1; /* index for our callbacks */
+
+static int mathutils_kxboundingbox_generic_check(BaseMathObject *bmo)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>BGE_PROXY_REF(bmo->cb_user);
+	if (!self)
+		return -1;
+
+	return 0;
+}
+
+static int mathutils_kxboundingbox_vector_get(BaseMathObject *bmo, int subtype)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>BGE_PROXY_REF(bmo->cb_user);
+	if (!self)
+		return -1;
+
+	switch (subtype) {
+		case MATHUTILS_VEC_CB_BOX_MIN:
+		{
+			self->GetMin().getValue(bmo->data);
+			break;
+		}
+		case MATHUTILS_VEC_CB_BOX_MAX:
+		{
+			self->GetMax().getValue(bmo->data);
+			break;
+		}
+	}
+
+	return 0;
+}
+
+static int mathutils_kxboundingbox_vector_set(BaseMathObject *bmo, int subtype)
+{
+	KX_BoundingBox *self = static_cast<KX_BoundingBox *>BGE_PROXY_REF(bmo->cb_user);
+	if (!self)
+		return -1;
+
+	switch (subtype) {
+		case MATHUTILS_VEC_CB_BOX_MIN:
+		{
+			if (!self->SetMin(MT_Vector3(bmo->data))) {
+				PyErr_SetString(PyExc_AttributeError, "bounds.min = Vector: KX_BoundingBox, min bigger than max");
+				return -1;
+			}
+			break;
+		}
+		case MATHUTILS_VEC_CB_BOX_MAX:
+		{
+			if (!self->SetMax(MT_Vector3(bmo->data))) {
+				PyErr_SetString(PyExc_AttributeError, "bounds.max = Vector: KX_BoundingBox, max smaller than min");
+				return -1;
+			}
+			break;
+		}
+	}
+
+	return 0;
+}
+
+static int mathutils_kxboundingbox_vector_get_index(BaseMathObject *bmo, int subtype, int index)
+{
+	/* lazy, avoid repeteing the case statement */
+	if (mathutils_kxboundingbox_vector_get(bmo, subtype) == -1)
+		return -1;
+	return 0;
+}
+
+static int mathutils_kxboundingbox_vector_set_index(BaseMathObject *bmo, int subtype, int index)
+{
+	float f = bmo->data[index];
+
+	/* lazy, avoid repeateing the case statement */
+	if (mathutils_kxboundingbox_vector_get(bmo, subtype) == -1)
+		return -1;
+
+	bmo->data[index] = f;
+	return mathutils_kxboundingbox_vector_set(bmo, subtype);
+}
+
+static Mathutils_Callback mathutils_kxboundingbox_vector_cb = {
+	mathutils_kxboundingbox_generic_check,
+	mathutils_kxboundingbox_vector_get,
+	mathutils_kxboundingbox_vector_set,
+	mathutils_kxboundingbox_vector_get_index,
+	mathutils_kxboundingbox_vector_set_index
+};
+
+void KX_BoundingBox_Mathutils_Callback_Init()
+{
+	// register mathutils callbacks, ok to run more than once.
+	mathutils_kxboundingbox_vector_cb_index = Mathutils_RegisterCallback(&mathutils_kxboundingbox_vector_cb);
+}
+
+#endif  // USE_MATHUTILS
+
 PyTypeObject KX_BoundingBox::Type = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"KX_BoundingBox",
@@ -153,7 +256,13 @@ PyObject *KX_BoundingBox::pyattr_get_min(void *self_v, const KX_PYATTRIBUTE_DEF 
 		return NULL;
 	}
 
+#ifdef USE_MATHUTILS
+	return Vector_CreatePyObject_cb(
+	        BGE_PROXY_FROM_REF_BORROW(self_v), 3,
+	        mathutils_kxboundingbox_vector_cb_index, MATHUTILS_VEC_CB_BOX_MIN);
+#else
 	return PyObjectFrom(self->GetMin());
+#endif  // USE_MATHUTILS
 }
 
 int KX_BoundingBox::pyattr_set_min(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
@@ -182,7 +291,13 @@ PyObject *KX_BoundingBox::pyattr_get_max(void *self_v, const KX_PYATTRIBUTE_DEF 
 		return NULL;
 	}
 
+#ifdef USE_MATHUTILS
+	return Vector_CreatePyObject_cb(
+	        BGE_PROXY_FROM_REF_BORROW(self_v), 3,
+	        mathutils_kxboundingbox_vector_cb_index, MATHUTILS_VEC_CB_BOX_MAX);
+#else
 	return PyObjectFrom(self->GetMax());
+#endif  // USE_MATHUTILS
 }
 
 int KX_BoundingBox::pyattr_set_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)

--- a/source/gameengine/Ketsji/KX_BoundingBox.h
+++ b/source/gameengine/Ketsji/KX_BoundingBox.h
@@ -30,6 +30,11 @@
 
 class KX_GameObject;
 
+#ifdef USE_MATHUTILS
+/// Setup mathutils callbacks.
+void KX_BoundingBox_Mathutils_Callback_Init();
+#endif
+
 /** \brief Temporary python proxy class to alterate the game object
  * bounding box/AABB. Any instance of this class is owned by python.
  */

--- a/source/gameengine/Ketsji/KX_BoundingBox.h
+++ b/source/gameengine/Ketsji/KX_BoundingBox.h
@@ -59,10 +59,10 @@ public:
 	const MT_Vector3 GetCenter() const;
 	/// Return AABB radius.
 	float GetRadius() const;
-	/// Set AABB max.
-	void SetMax(MT_Vector3 max);
-	/// Set AABB min.
-	void SetMin(MT_Vector3 min);
+	/// Set AABB max, return false if the max is lesser than min.
+	bool SetMax(MT_Vector3 max);
+	/// Set AABB min, return true if the max is greater than max.
+	bool SetMin(MT_Vector3 min);
 
 	virtual PyObject *py_repr();
 

--- a/source/gameengine/Ketsji/KX_BoundingBox.h
+++ b/source/gameengine/Ketsji/KX_BoundingBox.h
@@ -1,0 +1,81 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+#ifndef __KX_BOUNDING_BOX_H__
+#define __KX_BOUNDING_BOX_H__
+
+#ifdef WITH_PYTHON
+
+#include "EXP_PyObjectPlus.h"
+#include "MT_Vector3.h"
+
+class KX_GameObject;
+
+/** \brief Temporary python proxy class to alterate the game object
+ * bounding box/AABB. Any instance of this class is owned by python.
+ */
+class KX_BoundingBox : public PyObjectPlus
+{
+	Py_Header
+protected:
+	/// The game object owner of this bounding box proxy.
+	KX_GameObject *m_owner;
+	/// The game object owner python proxy.
+	PyObject *m_proxy;
+
+public:
+	KX_BoundingBox(KX_GameObject *owner);
+	virtual ~KX_BoundingBox();
+
+	/** Return true if the object owner is still valid.
+	 * Else return false and print a python error.
+	 */
+	bool IsValidOwner();
+
+	/// Return AABB max.
+	const MT_Vector3& GetMax() const;
+	/// Return AABB min.
+	const MT_Vector3& GetMin() const;
+	/// Return AABB center.
+	const MT_Vector3 GetCenter() const;
+	/// Return AABB radius.
+	float GetRadius() const;
+	/// Set AABB max.
+	void SetMax(MT_Vector3 max);
+	/// Set AABB min.
+	void SetMin(MT_Vector3 min);
+
+	virtual PyObject *py_repr();
+
+	static PyObject *pyattr_get_min(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_min(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_center(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_radius(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_auto_update(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_auto_update(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+};
+
+#endif  // WITH_PYTHON
+
+#endif  // __KX_BOUNDING_BOX_H__

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2022,7 +2022,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("angularVelocityMin", KX_GameObject, pyattr_get_ang_vel_min, pyattr_set_ang_vel_min),
 	KX_PYATTRIBUTE_RW_FUNCTION("angularVelocityMax", KX_GameObject, pyattr_get_ang_vel_max, pyattr_set_ang_vel_max),
 	KX_PYATTRIBUTE_RW_FUNCTION("visible",	KX_GameObject, pyattr_get_visible,	pyattr_set_visible),
-	KX_PYATTRIBUTE_RO_FUNCTION("bounds",	KX_GameObject, pyattr_get_bounds),
+	KX_PYATTRIBUTE_RO_FUNCTION("cullingBox",	KX_GameObject, pyattr_get_cullingBox),
 	KX_PYATTRIBUTE_BOOL_RW    ("occlusion", KX_GameObject, m_bOccluder),
 	KX_PYATTRIBUTE_RW_FUNCTION("position",	KX_GameObject, pyattr_get_worldPosition,	pyattr_set_localPosition),
 	KX_PYATTRIBUTE_RO_FUNCTION("localInertia",	KX_GameObject, pyattr_get_localInertia),
@@ -2663,7 +2663,7 @@ int KX_GameObject::pyattr_set_visible(void *self_v, const KX_PYATTRIBUTE_DEF *at
 	return PY_SET_ATTR_SUCCESS;
 }
 
-PyObject *KX_GameObject::pyattr_get_bounds(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *KX_GameObject::pyattr_get_cullingBox(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
 	return (new KX_BoundingBox(self))->NewProxy(true);

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -63,6 +63,7 @@
 #include "KX_ObstacleSimulation.h"
 #include "KX_Scene.h"
 #include "KX_Lod.h"
+#include "KX_BoundingBox.h"
 #include "KX_CollisionContactPoints.h"
 
 #include "BKE_object.h"
@@ -1417,7 +1418,7 @@ const MT_Vector3& KX_GameObject::NodeGetLocalPosition() const
 void KX_GameObject::UpdateBounds(bool force)
 {
 	RAS_Deformer *deformer = GetDeformer();
-	bool meshModified = (!m_meshes.empty() && (m_meshes[0]->GetModifiedFlag() & RAS_MeshObject::AABB_MODIFIED)) ||
+	bool meshModified = ((m_meshes.size() > 0) && (m_meshes[0]->GetModifiedFlag() & RAS_MeshObject::AABB_MODIFIED)) ||
 						(deformer && deformer->IsDynamic());
 
 	if (!(m_autoUpdateBounds && meshModified) && !force) {
@@ -2021,6 +2022,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("angularVelocityMin", KX_GameObject, pyattr_get_ang_vel_min, pyattr_set_ang_vel_min),
 	KX_PYATTRIBUTE_RW_FUNCTION("angularVelocityMax", KX_GameObject, pyattr_get_ang_vel_max, pyattr_set_ang_vel_max),
 	KX_PYATTRIBUTE_RW_FUNCTION("visible",	KX_GameObject, pyattr_get_visible,	pyattr_set_visible),
+	KX_PYATTRIBUTE_RO_FUNCTION("bounds",	KX_GameObject, pyattr_get_bounds),
 	KX_PYATTRIBUTE_BOOL_RW    ("occlusion", KX_GameObject, m_bOccluder),
 	KX_PYATTRIBUTE_RW_FUNCTION("position",	KX_GameObject, pyattr_get_worldPosition,	pyattr_set_localPosition),
 	KX_PYATTRIBUTE_RO_FUNCTION("localInertia",	KX_GameObject, pyattr_get_localInertia),
@@ -2659,6 +2661,12 @@ int KX_GameObject::pyattr_set_visible(void *self_v, const KX_PYATTRIBUTE_DEF *at
 
 	self->SetVisible(param, false);
 	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_bounds(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+	return (new KX_BoundingBox(self))->NewProxy(true);
 }
 
 PyObject *KX_GameObject::pyattr_get_worldPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -1063,6 +1063,7 @@ public:
 	static int			pyattr_set_ang_vel_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_visible(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_visible(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_bounds(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_worldPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_worldPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_localPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -1063,7 +1063,7 @@ public:
 	static int			pyattr_set_ang_vel_max(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_visible(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_visible(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject*	pyattr_get_bounds(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject*	pyattr_get_cullingBox(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_worldPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_worldPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_localPosition(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -47,6 +47,7 @@
 #include "KX_WorldInfo.h"
 #include "KX_ArmatureSensor.h"
 #include "KX_BlenderMaterial.h"
+#include "KX_BoundingBox.h"
 #include "KX_Camera.h"
 #include "KX_CameraActuator.h"
 #include "KX_CharacterWrapper.h"
@@ -216,6 +217,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 		PyType_Ready_Attr(dict, KX_2DFilterManager, init_getset);
 		PyType_Ready_Attr(dict, KX_ArmatureSensor, init_getset);
 		PyType_Ready_Attr(dict, KX_BlenderMaterial, init_getset);
+		PyType_Ready_Attr(dict, KX_BoundingBox, init_getset);
 		PyType_Ready_Attr(dict, KX_Camera, init_getset);
 		PyType_Ready_Attr(dict, KX_CameraActuator, init_getset);
 		PyType_Ready_Attr(dict, KX_CharacterWrapper, init_getset);

--- a/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInitTypes.cpp
@@ -293,6 +293,7 @@ PyMODINIT_FUNC initGameTypesPythonBinding(void)
 	KX_ObjectActuator_Mathutils_Callback_Init();
 	KX_WorldInfo_Mathutils_Callback_Init();
 	KX_BlenderMaterial_Mathutils_Callback_Init();
+	KX_BoundingBox_Mathutils_Callback_Init();
 #endif
 
 	return m;


### PR DESCRIPTION
The user wasn't able to set or just read the AABB previously, this can be useful
for "predefined AABB" for animated objects or at least to know the volume of the
mesh.

The API now exposes a KX_BoundingBox python class accesible in KX_GameObject.bounds.
This class is temporary created when accesing obj.bounds, none logic is proceed in
it for internal usage.
The class contains the following attributes:
- min (Vector3, rw),
- max (Vector3, rw),
- center (Vector3, ro),
- radius (float, ro),
- autoUpdate (bool, rw)