### PR TITLE
UPBGE: Add resolution and size to KX_Font API and fix clamp values

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
@@ -30,3 +30,15 @@ base class --- :class:`KX_GameObject`
 
       :type: string
 
+   .. attribute:: resolution
+
+      The resolution of the font police. .. warning:: (\n) High resolutions can use a lot of memory and may crash Blender.
+
+      :type: float (0.1 to 50.0)
+
+   .. attribute:: size
+
+      The size (scale factor) of the font object, scaled from font object origin (affects text resolution). .. warning:: (\n) High sizes can use a lot of memory and may crash Blender.
+
+      :type: float (0.0001 to 40.0)
+

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -250,8 +250,8 @@ PyMethodDef KX_FontObject::Methods[] = {
 PyAttributeDef KX_FontObject::Attributes[] = {
 	//KX_PYATTRIBUTE_STRING_RW("text", 0, 280, false, KX_FontObject, m_text[0]), //arbitrary limit. 280 = 140 unicode chars in unicode
 	KX_PYATTRIBUTE_RW_FUNCTION("text", KX_FontObject, pyattr_get_text, pyattr_set_text),
-	KX_PYATTRIBUTE_FLOAT_RW("size", 0.0001f, 10000.0f, KX_FontObject, m_fsize),
-	KX_PYATTRIBUTE_FLOAT_RW("resolution", 0.0001f, 10000.0f, KX_FontObject, m_resolution),
+	KX_PYATTRIBUTE_FLOAT_RW("size", 0.0001f, 40.0f, KX_FontObject, m_fsize),
+	KX_PYATTRIBUTE_FLOAT_RW("resolution", 0.1f, 50.0f, KX_FontObject, m_resolution),
 	/* KX_PYATTRIBUTE_INT_RW("dpi", 0, 10000, false, KX_FontObject, m_dpi), */// no real need for expose this I think
 	{NULL}    //Sentinel
 };


### PR DESCRIPTION
I had crash with some resolutions and some sizes (Malloc returns null:
len=8690500 in glyph bitmap, total 517588916) so I changed clamp values.

test file: http://www.pasteall.org/blend/42691