### PR TITLE
Gometry shader

### DIFF
--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -400,7 +400,7 @@ GPUShader *GPU_shader_create_ex(const char *vertexcode,
 	}
 
 	if (geocode) {
-		const char *source[6];
+		const char *source[7];
 		int num_source = 0;
 
 		source[num_source++] = gpu_shader_version();
@@ -408,6 +408,10 @@ GPUShader *GPU_shader_create_ex(const char *vertexcode,
 		source[num_source++] = standard_defines;
 
 		if (defines) source[num_source++] = defines;
+		if (resetline) {
+			/* Print error message with the correct line number corresponding to the passed code */
+			source[num_source++] = "#line 0\n";
+		}
 		source[num_source++] = geocode;
 
 		glAttachShader(shader->program, shader->geometry);

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -28,6 +28,7 @@ public:
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);
+	KX_PYMETHOD_DOC(BL_Shader, setSourceDict);
 	KX_PYMETHOD_DOC(BL_Shader, delSource);
 	KX_PYMETHOD_DOC(BL_Shader, getVertexProg);
 	KX_PYMETHOD_DOC(BL_Shader, getFragmentProg);

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -283,6 +283,10 @@ void RAS_Shader::DeleteShader()
 
 bool RAS_Shader::LinkProgram()
 {
+	const char *vert;
+	const char *frag;
+	const char *geom;
+
 	if (m_error) {
 		goto program_error;
 	}
@@ -292,7 +296,10 @@ bool RAS_Shader::LinkProgram()
 		return false;
 	}
 
-	m_shader = GPU_shader_create_ex(m_progs[VERTEX_PROGRAM].ReadPtr(), m_progs[FRAGMENT_PROGRAM].ReadPtr(), NULL, NULL, NULL, 0, 0, 0, GPU_SHADER_FLAGS_SPECIAL_RESET_LINE);
+	vert = m_progs[VERTEX_PROGRAM].ReadPtr();
+	frag = m_progs[FRAGMENT_PROGRAM].ReadPtr();
+	geom = (m_progs[GEOMETRY_PROGRAM] == "") ? NULL : m_progs[GEOMETRY_PROGRAM].ReadPtr();
+	m_shader = GPU_shader_create_ex(vert, frag, geom, NULL, NULL, 0, 0, 0, GPU_SHADER_FLAGS_SPECIAL_RESET_LINE);
 	if (!m_shader) {
 		goto program_error;
 	}
@@ -302,10 +309,12 @@ bool RAS_Shader::LinkProgram()
 	return true;
 
 program_error:
+{
 	m_ok = 0;
 	m_use = 0;
 	m_error = 1;
 	return false;
+}
 }
 
 void RAS_Shader::ValidateProgram()

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -94,6 +94,7 @@ public:
 	enum ProgramType {
 		VERTEX_PROGRAM = 0,
 		FRAGMENT_PROGRAM,
+		GEOMETRY_PROGRAM,
 		MAX_PROGRAM
 	};
 


### PR DESCRIPTION
This branch implement geometry shader for custom shaders. As we use GPUShader we just have to pass the string to the GPU_shader_create function.

The major issue of this feature is that the geometry shader can't be passed to the python function `setSource` as it will look like : `setSource(vert, frag, apply, geom)` and latter if we add tesselation shader it will became more complicated. To solve this issue a second function was added : `setSourceDict(sources, apply)`. The `sources` argument is a dictionnary containing all shader script used it will look at a full usage like :
```
sources = {"vertex" : vert,
                  "fragment" : frag,
                  "geometry" : geom
                 }
```

The only think changed in `setSource` is that we set the geometry shader to an empty string.

Questions:
1) What name for `setSourceDict` ? `setSources`, `setSourceList` ?