### PR TITLE
Implement geometry shader

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -67,7 +67,7 @@ base class --- :class:`PyObjectPlus`
       :arg index: Texture sample index.
       :type index: integer
 
-   .. method:: setSource(vertexProgram, fragmentProgram)
+   .. method:: setSource(vertexProgram, fragmentProgram, apply)
 
       Set the vertex and fragment programs
 
@@ -75,6 +75,28 @@ base class --- :class:`PyObjectPlus`
       :type vertexProgram: string
       :arg fragmentProgram: Fragment program
       :type fragmentProgram: string
+      :arg apply: Enable the shader.
+      :type apply: boolean
+
+   .. method:: setSourceList(sources, apply)
+
+      Set the vertex, fragment and geometry shader programs.
+
+      :arg sources: Dictionary of all programs. The keys :data:`vertex`, :data:`fragment` and :data:`geometry` represent shader programs of the same name.
+          :data:`geometry` is an optional program.
+          This dictionary can be similar to:
+
+          .. code-block:: python
+
+             sources = {
+                 "vertex" : vertexProgram,
+                 "fragment" : fragmentProgram,
+                 "geometry" : geometryProgram
+             }
+
+      :type sources: dict
+      :arg apply: Enable the shader.
+      :type apply: boolean
 
    .. method:: setUniform1f(name, fx)
 

--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -400,7 +400,7 @@ GPUShader *GPU_shader_create_ex(const char *vertexcode,
 	}
 
 	if (geocode) {
-		const char *source[6];
+		const char *source[7];
 		int num_source = 0;
 
 		source[num_source++] = gpu_shader_version();
@@ -408,6 +408,10 @@ GPUShader *GPU_shader_create_ex(const char *vertexcode,
 		source[num_source++] = standard_defines;
 
 		if (defines) source[num_source++] = defines;
+		if (resetline) {
+			/* Print error message with the correct line number corresponding to the passed code */
+			source[num_source++] = "#line 0\n";
+		}
 		source[num_source++] = geocode;
 
 		glAttachShader(shader->program, shader->geometry);

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -166,15 +166,16 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSourceList, " setSourceList(sources, apply)")
 				if (!pyprog) {
 					error = true;
 					PyErr_Format(PyExc_SystemError, "setSourceList(sources, apply): BL_Shader, non optional %s program missing", progname[i]);
+					break;
 				}
 				else if (!PyUnicode_Check(pyprog)) {
 					error = true;
 					PyErr_Format(PyExc_SystemError, "setSourceList(sources, apply): BL_Shader, non optional %s program is not a string", progname[i]);
+					break;
 				}
 			}
-			else {
-				m_progs[i] = STR_String(_PyUnicode_AsString(pyprog));
-			}
+
+			m_progs[i] = STR_String(_PyUnicode_AsString(pyprog));
 		}
 
 		if (!error && LinkProgram()) {

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -158,12 +158,19 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSourceDict, " setSourceDict(sources, apply)")
 	if (PyArg_ParseTuple(args, "O!i:setSourceDict", &PyDict_Type, &pydict, &apply)) {
 		bool error = false;
 		static const char *progname[MAX_PROGRAM] = {"vertex", "fragment", "geometry"};
-		static const bool progneeded[MAX_PROGRAM] = {true, true, false};
+		static const bool optional[MAX_PROGRAM] = {false, false, true};
 
 		for (unsigned short i = 0; i < MAX_PROGRAM; ++i) {
 			PyObject *pyprog = PyDict_GetItemString(pydict, progname[i]);
-			if (!pyprog) {
-				error = progneeded[i];
+			if (!optional[i]) {
+				if (!pyprog) {
+					error = true;
+					PyErr_Format(PyExc_SystemError, "setSourceDict(sources, apply): BL_Shader, non optional %s program missing", progname[i]);
+				}
+				else if (!PyUnicode_Check(pyprog)) {
+					error = true;
+					PyErr_Format(PyExc_SystemError, "setSourceDict(sources, apply): BL_Shader, non optional %s program is not a string", progname[i]);
+				}
 			}
 			else {
 				m_progs[i] = STR_String(_PyUnicode_AsString(pyprog));

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -118,7 +118,7 @@ int BL_Shader::pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrde
 
 KX_PYMETHODDEF_DOC(BL_Shader, setSource, " setSource(vertexProgram, fragmentProgram, apply)")
 {
-	if (m_shader != 0 && m_ok) {
+	if (m_shader && m_ok) {
 		// already set...
 		Py_RETURN_NONE;
 	}
@@ -147,7 +147,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSource, " setSource(vertexProgram, fragmentProg
 
 KX_PYMETHODDEF_DOC(BL_Shader, setSourceList, " setSourceList(sources, apply)")
 {
-	if (m_shader != 0 && m_ok) {
+	if (m_shader && m_ok) {
 		// already set...
 		Py_RETURN_NONE;
 	}
@@ -207,7 +207,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, delSource, "delSource( )")
 
 KX_PYMETHODDEF_DOC(BL_Shader, isValid, "isValid()")
 {
-	return PyBool_FromLong((m_shader != 0 && m_ok));
+	return PyBool_FromLong((m_shader && m_ok));
 }
 
 KX_PYMETHODDEF_DOC(BL_Shader, getVertexProg, "getVertexProg( )")
@@ -226,7 +226,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, validate, "validate()")
 		Py_RETURN_NONE;
 	}
 
-	if (m_shader == 0) {
+	if (!m_shader) {
 		PyErr_SetString(PyExc_TypeError, "shader.validate(): BL_Shader, invalid shader object");
 		return NULL;
 	}
@@ -758,7 +758,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, setAttrib, "setAttrib(enum)")
 
 	attr = SHD_TANGENT; // user input is ignored for now, there is only 1 attr
 
-	if (m_shader == 0) {
+	if (!m_shader) {
 		PyErr_SetString(PyExc_ValueError, "shader.setAttrib() BL_Shader, invalid shader object");
 		return NULL;
 	}

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -44,7 +44,7 @@ BL_Shader::~BL_Shader()
 PyMethodDef BL_Shader::Methods[] = {
 	// creation
 	KX_PYMETHODTABLE(BL_Shader, setSource),
-	KX_PYMETHODTABLE(BL_Shader, setSourceDict),
+	KX_PYMETHODTABLE(BL_Shader, setSourceList),
 	KX_PYMETHODTABLE(BL_Shader, delSource),
 	KX_PYMETHODTABLE(BL_Shader, getVertexProg),
 	KX_PYMETHODTABLE(BL_Shader, getFragmentProg),
@@ -145,7 +145,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSource, " setSource(vertexProgram, fragmentProg
 	return NULL;
 }
 
-KX_PYMETHODDEF_DOC(BL_Shader, setSourceDict, " setSourceDict(sources, apply)")
+KX_PYMETHODDEF_DOC(BL_Shader, setSourceList, " setSourceList(sources, apply)")
 {
 	if (m_shader != 0 && m_ok) {
 		// already set...
@@ -155,7 +155,7 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSourceDict, " setSourceDict(sources, apply)")
 	PyObject *pydict;
 	int apply = 0;
 
-	if (PyArg_ParseTuple(args, "O!i:setSourceDict", &PyDict_Type, &pydict, &apply)) {
+	if (PyArg_ParseTuple(args, "O!i:setSourceList", &PyDict_Type, &pydict, &apply)) {
 		bool error = false;
 		static const char *progname[MAX_PROGRAM] = {"vertex", "fragment", "geometry"};
 		static const bool optional[MAX_PROGRAM] = {false, false, true};
@@ -165,11 +165,11 @@ KX_PYMETHODDEF_DOC(BL_Shader, setSourceDict, " setSourceDict(sources, apply)")
 			if (!optional[i]) {
 				if (!pyprog) {
 					error = true;
-					PyErr_Format(PyExc_SystemError, "setSourceDict(sources, apply): BL_Shader, non optional %s program missing", progname[i]);
+					PyErr_Format(PyExc_SystemError, "setSourceList(sources, apply): BL_Shader, non optional %s program missing", progname[i]);
 				}
 				else if (!PyUnicode_Check(pyprog)) {
 					error = true;
-					PyErr_Format(PyExc_SystemError, "setSourceDict(sources, apply): BL_Shader, non optional %s program is not a string", progname[i]);
+					PyErr_Format(PyExc_SystemError, "setSourceList(sources, apply): BL_Shader, non optional %s program is not a string", progname[i]);
 				}
 			}
 			else {

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -28,7 +28,7 @@ public:
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);
-	KX_PYMETHOD_DOC(BL_Shader, setSourceDict);
+	KX_PYMETHOD_DOC(BL_Shader, setSourceList);
 	KX_PYMETHOD_DOC(BL_Shader, delSource);
 	KX_PYMETHOD_DOC(BL_Shader, getVertexProg);
 	KX_PYMETHOD_DOC(BL_Shader, getFragmentProg);

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -28,6 +28,7 @@ public:
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);
+	KX_PYMETHOD_DOC(BL_Shader, setSourceDict);
 	KX_PYMETHOD_DOC(BL_Shader, delSource);
 	KX_PYMETHOD_DOC(BL_Shader, getVertexProg);
 	KX_PYMETHOD_DOC(BL_Shader, getFragmentProg);

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -158,7 +158,7 @@ void *RAS_Shader::RAS_Uniform::GetData()
 
 bool RAS_Shader::Ok()const
 {
-	return (m_shader != 0 && m_ok && m_use);
+	return (m_shader && m_ok && m_use);
 }
 
 RAS_Shader::RAS_Shader()

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -308,13 +308,13 @@ bool RAS_Shader::LinkProgram()
 	m_error = 0;
 	return true;
 
-program_error:
-{
-	m_ok = 0;
-	m_use = 0;
-	m_error = 1;
-	return false;
-}
+	program_error:
+	{
+		m_ok = 0;
+		m_use = 0;
+		m_error = 1;
+		return false;
+	}
 }
 
 void RAS_Shader::ValidateProgram()

--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -283,6 +283,10 @@ void RAS_Shader::DeleteShader()
 
 bool RAS_Shader::LinkProgram()
 {
+	const char *vert;
+	const char *frag;
+	const char *geom;
+
 	if (m_error) {
 		goto program_error;
 	}
@@ -292,7 +296,10 @@ bool RAS_Shader::LinkProgram()
 		return false;
 	}
 
-	m_shader = GPU_shader_create_ex(m_progs[VERTEX_PROGRAM].ReadPtr(), m_progs[FRAGMENT_PROGRAM].ReadPtr(), NULL, NULL, NULL, 0, 0, 0, GPU_SHADER_FLAGS_SPECIAL_RESET_LINE);
+	vert = m_progs[VERTEX_PROGRAM].ReadPtr();
+	frag = m_progs[FRAGMENT_PROGRAM].ReadPtr();
+	geom = (m_progs[GEOMETRY_PROGRAM] == "") ? NULL : m_progs[GEOMETRY_PROGRAM].ReadPtr();
+	m_shader = GPU_shader_create_ex(vert, frag, geom, NULL, NULL, 0, 0, 0, GPU_SHADER_FLAGS_SPECIAL_RESET_LINE);
 	if (!m_shader) {
 		goto program_error;
 	}
@@ -302,10 +309,12 @@ bool RAS_Shader::LinkProgram()
 	return true;
 
 program_error:
+{
 	m_ok = 0;
 	m_use = 0;
 	m_error = 1;
 	return false;
+}
 }
 
 void RAS_Shader::ValidateProgram()

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -94,6 +94,7 @@ public:
 	enum ProgramType {
 		VERTEX_PROGRAM = 0,
 		FRAGMENT_PROGRAM,
+		GEOMETRY_PROGRAM,
 		MAX_PROGRAM
 	};
 


### PR DESCRIPTION
This branch implement geometry shader for custom shaders. As we use GPUShader we just have to pass the string to the GPU_shader_create function.

The major issue of this feature is that the geometry shader can't be passed to the python function `setSource` as it will look like : `setSource(vert, frag, apply, geom)` and latter if we add tesselation shader it will became more complicated. To solve this issue a second function was added : `setSourceDict(sources, apply)`. The `sources` argument is a dictionnary containing all shader script used it will look at a full usage like :
```
sources = {"vertex" : vert,
                  "fragment" : frag,
                  "geometry" : geom
                 }
```

The only think changed in `setSource` is that we set the geometry shader to an empty string.

Questions:
1) What name for `setSourceDict` ? `setSources`, `setSourceList` ?