### PR TITLE
Fix full framerate timing issue.

### DIFF
--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -108,7 +108,7 @@ private:
 
 	bool m_bInitialized;
 	int m_activecam;
-	bool m_bFixedTime;
+	bool m_fixedFramerate;
 	bool m_useExternalClock;
 
 	bool m_firstframe;
@@ -330,16 +330,16 @@ public:
 	void UpdateAnimations(KX_Scene *scene);
 
 	/**
-	 * Sets display of all frames.
-	 * \param bUseFixedTime	New setting for display all frames.
+	 * Sets display of fixed frames.
+	 * \param fixedFramerate New setting for display all frames.
 	 */
-	void SetUseFixedTime(bool bUseFixedTime);
+	void SetUseFixedFramerate(bool fixedFramerate);
 
 	/**
-	 * Returns display of all frames.
+	 * Returns display of fixed frames.
 	 * \return Current setting for display all frames.
 	 */
-	bool GetUseFixedTime(void) const;
+	bool GetUseFixedFramerate(void) const;
 
 	/**
 	 * Sets if the BGE relies on a external clock or its own internal clock

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1491,7 +1491,7 @@ void KX_Scene::DrawDebug(RAS_IRasterizer *rasty)
 }
 
 // logic stuff
-void KX_Scene::LogicBeginFrame(double curtime)
+void KX_Scene::LogicBeginFrame(double curtime, double framestep)
 {
 	// have a look at temp objects ...
 	int lastobj = m_tempObjectList->GetCount() - 1;
@@ -1503,7 +1503,7 @@ void KX_Scene::LogicBeginFrame(double curtime)
 		
 		if (propval)
 		{
-			float timeleft = (float)(propval->GetNumber() - 1.0/KX_KetsjiEngine::GetTicRate());
+			float timeleft = propval->GetNumber() - framestep;
 			
 			if (timeleft > 0)
 			{
@@ -1520,7 +1520,7 @@ void KX_Scene::LogicBeginFrame(double curtime)
 			// all object is the tempObjectList should have a clock
 		}
 	}
-	m_logicmgr->BeginFrame(curtime, 1.0/KX_KetsjiEngine::GetTicRate());
+	m_logicmgr->BeginFrame(curtime, framestep);
 }
 
 void KX_Scene::AddAnimatedObject(CValue* gameobj)

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -344,7 +344,7 @@ public:
 	 * \section Logic stuff
 	 * Initiate an update of the logic system.
 	 */
-	void LogicBeginFrame(double curtime);
+	void LogicBeginFrame(double curtime, double framestep);
 	void LogicUpdateFrame(double curtime, bool frame);
 	void UpdateAnimations(double curtime);
 

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -140,7 +140,8 @@ void LA_Launcher::InitEngine()
 	bool showPhysics = (gm->flag & GAME_SHOW_PHYSICS);
 	SYS_WriteCommandLineInt(syshandle, "show_physics", showPhysics);
 
-	bool fixed_framerate = (SYS_GetCommandLineInt(syshandle, "fixedtime", (gm->flag & GAME_ENABLE_ALL_FRAMES)) != 0);
+	// WARNING: Fixed time is the opposite of fixed framerate.
+	bool fixed_framerate = (SYS_GetCommandLineInt(syshandle, "fixedtime", (gm->flag & GAME_ENABLE_ALL_FRAMES)) == 0);
 	bool frameRate = (SYS_GetCommandLineInt(syshandle, "show_framerate", 0) != 0);
 	bool showBoundingBox = (SYS_GetCommandLineInt(syshandle, "show_bounding_box", gm->flag & GAME_SHOW_BOUNDING_BOX) != 0);
 	bool showArmatures = (SYS_GetCommandLineInt(syshandle, "show_armatures", gm->flag & GAME_SHOW_ARMATURES) != 0);
@@ -239,7 +240,7 @@ void LA_Launcher::InitEngine()
 	(void)nodepwarnings;
 #endif
 
-	m_ketsjiEngine->SetUseFixedTime(fixed_framerate);
+	m_ketsjiEngine->SetUseFixedFramerate(fixed_framerate);
 	m_ketsjiEngine->SetTimingDisplay(frameRate, profile, properties);
 	m_ketsjiEngine->SetRender(true);
 	m_ketsjiEngine->SetRestrictAnimationFPS(restrictAnimFPS);


### PR DESCRIPTION
Previously the full framerate mode incremented the clock time by the frame time step (= scale / fps) to be sure to proceed a frame with the algorithm:
```
frames = int(deltatime * m_ticrate / m_timescale + 1e-6);
```

But by doing this the clock time and the frame time was totally wrong and not constant.

To fix this issue in case of non-fixed framerate an other way was used. First the clock time is incremented only by the time from the previous frame as for fixed FPS. Second the number of frame to proceed is always set to 1. Third the frame time step is set to the increment value of the clock time.

This patch also remove the ambiguity about "fixed time" and "fixed framerate". The both therms are opposite in the code.

It was tested with physics simulation and time scaling.

@youle31, @lordloki, @DCubix : Can you test this patch with every blend and play around options vsync and "use framerate" ? Thanks in advance.