### PR TITLE
Bug fixes for off screen render.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -463,8 +463,7 @@ class RENDER_PT_game_display(RenderButtonsPanel, Panel):
         col = layout.column()
         col.label(text="Framing:")
         col.row().prop(gs, "frame_type", expand=True)
-        if gs.frame_type == 'LETTERBOX':
-            col.prop(gs, "frame_color", text="")
+        col.prop(gs, "frame_color", text="")
 
 
 class SceneButtonsPanel:

--- a/source/blender/gpu/intern/gpu_framebuffer.c
+++ b/source/blender/gpu/intern/gpu_framebuffer.c
@@ -827,6 +827,9 @@ void GPU_offscreen_blit(GPUOffScreen *srcofs, GPUOffScreen *dstofs)
 	glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, srcofs->fb->object);
 	glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, dstofs->fb->object);
 
+	glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+	glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+
 	int height = min_ff(GPU_offscreen_height(srcofs), GPU_offscreen_height(dstofs));
 	int width = min_ff(GPU_offscreen_width(srcofs), GPU_offscreen_width(dstofs));
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -590,7 +590,6 @@ protected:
 	void PostProcessScene(KX_Scene *scene);
 
 	bool BeginFrame();
-	void ClearFrame();
 	void EndFrame();
 
 #ifdef WITH_CXX_GUARDEDALLOC

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -209,12 +209,14 @@ void KX_WorldInfo::RenderBackground(RAS_IRasterizer *rasty)
 			static float texcofac[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
 			GPU_material_bind(gpumat, 0xFFFFFFFF, m_scene->lay, 1.0f, false, viewmat, invviewmat, texcofac, false);
 
+			rasty->Disable(RAS_IRasterizer::RAS_CULL_FACE);
 			rasty->Enable(RAS_IRasterizer::RAS_DEPTH_TEST);
 			rasty->SetDepthFunc(RAS_IRasterizer::RAS_ALWAYS);
 
 			rasty->DrawOverlayPlane();
 
 			rasty->SetDepthFunc(RAS_IRasterizer::RAS_LEQUAL);
+			rasty->Enable(RAS_IRasterizer::RAS_CULL_FACE);
 
 			GPU_material_unbind(gpumat);
 		}

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -225,6 +225,14 @@ void KX_WorldInfo::RenderBackground(RAS_IRasterizer *rasty)
 			rasty->Clear(RAS_IRasterizer::RAS_COLOR_BUFFER_BIT);
 		}
 	}
+	// Else render a dummy gray background.
+	else {
+		/* Grey color computed by linearrgb_to_srgb_v3_v3 with a color of
+		 * 0.050, 0.050, 0.050 (the default world horizon color).
+		 */
+		rasty->SetClearColor(0.247784f, 0.247784f, 0.247784f, 1.0f);
+		rasty->Clear(RAS_IRasterizer::RAS_COLOR_BUFFER_BIT);
+	}
 }
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterManager.cpp
@@ -92,6 +92,7 @@ void RAS_2DFilterManager::RenderFilters(RAS_IRasterizer *rasty, RAS_ICanvas *can
 	unsigned short colorfbo = rasty->GetCurrentOffScreenIndex();
 	unsigned short depthfbo = colorfbo;
 
+	rasty->Disable(RAS_IRasterizer::RAS_CULL_FACE);
 	rasty->SetDepthFunc(RAS_IRasterizer::RAS_ALWAYS);
 	rasty->Disable(RAS_IRasterizer::RAS_BLEND);
 	rasty->Disable(RAS_IRasterizer::RAS_ALPHA_TEST);
@@ -137,6 +138,7 @@ void RAS_2DFilterManager::RenderFilters(RAS_IRasterizer *rasty, RAS_ICanvas *can
 	}
 
 	rasty->SetDepthFunc(RAS_IRasterizer::RAS_LEQUAL);
+	rasty->Enable(RAS_IRasterizer::RAS_CULL_FACE);
 }
 
 RAS_2DFilter *RAS_2DFilterManager::CreateFilter(RAS_2DFilterData& filterData)

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -350,8 +350,6 @@ public:
 	virtual void UpdateOffScreens(RAS_ICanvas *canvas) = 0;
 	/// Bind the off screen at the given index.
 	virtual void BindOffScreen(unsigned short index) = 0;
-	/// Unbind the off screen at the given index.
-	virtual void RestoreScreenFrameBuffer() = 0;
 
 	/** Draw off screen without set viewport.
 	 * Used to copy the frame buffer object to another.

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -904,12 +904,14 @@ void RAS_OpenGLRasterizer::DrawOffScreen(RAS_ICanvas *canvas, unsigned short ind
 	SetViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 	SetScissor(viewport[0], viewport[1], viewport[2], viewport[3]);
 
+	Disable(RAS_CULL_FACE);
 	SetDepthFunc(RAS_ALWAYS);
 
 	m_offScreens.RestoreScreen();
 	DrawOffScreen(index, 0);
 
 	SetDepthFunc(RAS_LEQUAL);
+	Enable(RAS_CULL_FACE);
 }
 
 void RAS_OpenGLRasterizer::DrawStereoOffScreen(RAS_ICanvas *canvas, unsigned short lefteyeindex, unsigned short righteyeindex)
@@ -930,6 +932,7 @@ void RAS_OpenGLRasterizer::DrawStereoOffScreen(RAS_ICanvas *canvas, unsigned sho
 	SetViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 	SetScissor(viewport[0], viewport[1], viewport[2], viewport[3]);
 
+	Disable(RAS_CULL_FACE);
 	SetDepthFunc(RAS_ALWAYS);
 
 	m_offScreens.RestoreScreen();
@@ -975,6 +978,7 @@ void RAS_OpenGLRasterizer::DrawStereoOffScreen(RAS_ICanvas *canvas, unsigned sho
 	}
 
 	SetDepthFunc(RAS_LEQUAL);
+	Enable(RAS_CULL_FACE);
 }
 
 void RAS_OpenGLRasterizer::BindOffScreenTexture(unsigned short index, unsigned short slot, OffScreen type)

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -100,6 +100,7 @@ class RAS_OpenGLRasterizer : public RAS_IRasterizer
 
 		void Update(RAS_ICanvas *canvas);
 		void Bind(unsigned short index);
+		void RestoreScreen();
 		/// NOTE: This function has the side effect to leave the destination off screen bound.
 		void Blit(unsigned short srcindex, unsigned short dstindex);
 		void BindTexture(unsigned short index, unsigned short slot, OffScreen type);
@@ -247,7 +248,6 @@ public:
 
 	virtual void UpdateOffScreens(RAS_ICanvas *canvas);
 	virtual void BindOffScreen(unsigned short index);
-	virtual void RestoreScreenFrameBuffer();
 	virtual void DrawOffScreen(unsigned short srcindex, unsigned short dstindex);
 	virtual void DrawOffScreen(RAS_ICanvas *canvas, unsigned short index);
 	virtual void DrawStereoOffScreen(RAS_ICanvas *canvas, unsigned short lefteyeindex, unsigned short righteyeindex);

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -302,8 +302,6 @@ bool ImageRender::Render()
 	m_rasterizer->SetViewport(m_position[0], m_position[1], m_position[0] + m_capSize[0], m_position[1] + m_capSize[1]);
 	m_rasterizer->SetScissor(m_position[0], m_position[1], m_position[0] + m_capSize[0], m_position[1] + m_capSize[1]);
 
-	m_rasterizer->SetClearColor(0.247784f, 0.247784f, 0.247784f, 1.0f);
-	m_rasterizer->Clear(RAS_IRasterizer::RAS_COLOR_BUFFER_BIT | RAS_IRasterizer::RAS_DEPTH_BUFFER_BIT);
 	m_rasterizer->BeginFrame(m_engine->GetClockTime());
 	m_scene->GetWorldInfo()->UpdateWorldSettings(m_rasterizer);
 	m_rasterizer->SetAuxilaryClientInfo(m_scene);
@@ -394,7 +392,7 @@ bool ImageRender::Render()
 	}
 
 	// Render Background
-	if (m_scene->GetWorldInfo()->m_hasworld) {
+	if (m_scene->GetWorldInfo()) {
 		const MT_Vector3 hor = m_scene->GetWorldInfo()->m_horizoncolor;
 		const MT_Vector3 zen = m_scene->GetWorldInfo()->m_zenithcolor;
 		m_scene->GetWorldInfo()->setHorizonColor(MT_Vector3(m_horizon[0], m_horizon[1], m_horizon[2]));


### PR DESCRIPTION
This branch introduced fixes around the previous version of gd_fbo.

It fixes the culling quad draw for the water filter, stereo gray clear and glitch on blenderplayer resize.

@DCubix, @youle31 : Can you test this branch with the files bugged ? thanks.