### PR TITLE
UPBGE: Implement PCF shadow and sharpness variance shadow.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -831,7 +831,7 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         if lamp.ge_shadow_buffer_type == "VARIANCE":
             col.prop(lamp, "shadow_buffer_bleed_bias", text="Bleed Bias")
             col.prop(lamp, "shadow_buffer_sharp", text="Sharpness")
-        elif lamp.shadow_filter == "PCF":
+        elif lamp.shadow_filter in ("PCF", "PCF_BAIL"):
             col.prop(lamp, "shadow_buffer_samples", text="Samples")
             col.prop(lamp, "shadow_buffer_soft", text="Soft")
 

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -824,7 +824,9 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         col = layout.column(align=True)
         col.prop(lamp, "shadow_buffer_size", text="Size")
         col.prop(lamp, "shadow_buffer_bias", text="Bias")
-        col.prop(lamp, "shadow_buffer_bleed_bias", text="Bleed Bias")
+        if lamp.ge_shadow_buffer_type == "VARIANCE":
+            col.prop(lamp, "shadow_buffer_bleed_bias", text="Bleed Bias")
+            col.prop(lamp, "shadow_buffer_sharp", text="Sharpness")
 
         row = layout.row()
         row.label("Clipping:")

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -820,6 +820,10 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         col = layout.column()
         col.label("Buffer Type:")
         col.prop(lamp, "ge_shadow_buffer_type", text="", toggle=True)
+        if lamp.ge_shadow_buffer_type == "SIMPLE":
+            col.label("Filter Type:")
+            col.prop(lamp, "shadow_filter", text="", toggle=True)
+
         col.label("Quality:")
         col = layout.column(align=True)
         col.prop(lamp, "shadow_buffer_size", text="Size")
@@ -827,7 +831,7 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         if lamp.ge_shadow_buffer_type == "VARIANCE":
             col.prop(lamp, "shadow_buffer_bleed_bias", text="Bleed Bias")
             col.prop(lamp, "shadow_buffer_sharp", text="Sharpness")
-        else:
+        elif lamp.shadow_filter == "PCF":
             col.prop(lamp, "shadow_buffer_samples", text="Samples")
             col.prop(lamp, "shadow_buffer_soft", text="Soft")
 

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -827,6 +827,9 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         if lamp.ge_shadow_buffer_type == "VARIANCE":
             col.prop(lamp, "shadow_buffer_bleed_bias", text="Bleed Bias")
             col.prop(lamp, "shadow_buffer_sharp", text="Sharpness")
+        else:
+            col.prop(lamp, "shadow_buffer_samples", text="Samples")
+            col.prop(lamp, "shadow_buffer_soft", text="Soft")
 
         row = layout.row()
         row.label("Clipping:")

--- a/source/blender/gpu/GPU_framebuffer.h
+++ b/source/blender/gpu/GPU_framebuffer.h
@@ -69,7 +69,7 @@ bool GPU_framebuffer_bound(GPUFrameBuffer *fb);
 void GPU_framebuffer_restore(void);
 void GPU_framebuffer_blur(
         GPUFrameBuffer *fb, struct GPUTexture *tex,
-        GPUFrameBuffer *blurfb, struct GPUTexture *blurtex);
+        GPUFrameBuffer *blurfb, struct GPUTexture *blurtex, float sharpness);
 
 typedef enum GPURenderBufferType {
 	GPU_RENDERBUFFER_COLOR = 0,

--- a/source/blender/gpu/intern/gpu_framebuffer.c
+++ b/source/blender/gpu/intern/gpu_framebuffer.c
@@ -414,10 +414,10 @@ void GPU_framebuffer_restore(void)
 
 void GPU_framebuffer_blur(
         GPUFrameBuffer *fb, GPUTexture *tex,
-        GPUFrameBuffer *blurfb, GPUTexture *blurtex)
+        GPUFrameBuffer *blurfb, GPUTexture *blurtex, float sharpness)
 {
-	const float scaleh[2] = {1.0f / GPU_texture_width(blurtex), 0.0f};
-	const float scalev[2] = {0.0f, 1.0f / GPU_texture_height(tex)};
+	const float scaleh[2] = {(1.0f - sharpness) / GPU_texture_width(blurtex), 0.0f};
+	const float scalev[2] = {0.0f, (1.0f - sharpness) / GPU_texture_height(tex)};
 
 	GPUShader *blur_shader = GPU_shader_get_builtin_shader(GPU_SHADER_SEP_GAUSSIAN_BLUR);
 	int scale_uniform, texture_source_uniform;

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -989,21 +989,23 @@ static void shade_one_light(GPUShadeInput *shi, GPUShadeResult *shr, GPULamp *la
 				         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias), inp, &shadfac);
 			}
 			else {
-				if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+				if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f && lamp->la->shadow_filter != LA_SHADOW_FILTER_NONE) {
 					float samp = lamp->la->samp;
-					GPU_link(mat, "test_shadowbuf_pcf",
-				             GPU_builtin(GPU_VIEW_POSITION),
-				             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-				             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadfac);
-				}
-				else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
-					float samp = lamp->la->samp;
-					GPU_link(mat, "test_shadowbuf_pcf_early_bail",
-				             GPU_builtin(GPU_VIEW_POSITION),
-				             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-				             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadfac);
+					float samplesize = lamp->la->soft / lamp->la->shadow_frustum_size;
+					if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF) {
+						GPU_link(mat, "test_shadowbuf_pcf",
+								 GPU_builtin(GPU_VIEW_POSITION),
+								 GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+								 GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+								 GPU_uniform(&samp), GPU_uniform(&samplesize), GPU_uniform(&lamp->bias), inp, &shadfac);
+					}
+					else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL) {
+						GPU_link(mat, "test_shadowbuf_pcf_early_bail",
+								 GPU_builtin(GPU_VIEW_POSITION),
+								 GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+								 GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+								 GPU_uniform(&samp), GPU_uniform(&samplesize), GPU_uniform(&lamp->bias), inp, &shadfac);
+					}
 				}
 				else {
 					GPU_link(mat, "test_shadowbuf",
@@ -2800,21 +2802,23 @@ GPUNodeLink *GPU_lamp_get_data(
 			         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias), inp, &shadowfac);
 		}
 		else {
-			if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+			if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f && lamp->la->shadow_filter != LA_SHADOW_FILTER_NONE) {
 				float samp = lamp->la->samp;
-				GPU_link(mat, "test_shadowbuf_pcf",
-			             GPU_builtin(GPU_VIEW_POSITION),
-			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadowfac);
-			}
-			else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
-				float samp = lamp->la->samp;
-				GPU_link(mat, "test_shadowbuf_pcf_early_bail",
-			             GPU_builtin(GPU_VIEW_POSITION),
-			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadowfac);
+				float samplesize = lamp->la->soft / lamp->la->shadow_frustum_size;
+				if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF) {
+					GPU_link(mat, "test_shadowbuf_pcf",
+							 GPU_builtin(GPU_VIEW_POSITION),
+							 GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+							 GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+							 GPU_uniform(&samp), GPU_uniform(&samplesize), GPU_uniform(&lamp->bias), inp, &shadowfac);
+				}
+				else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL) {
+					GPU_link(mat, "test_shadowbuf_pcf_early_bail",
+							 GPU_builtin(GPU_VIEW_POSITION),
+							 GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+							 GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+							 GPU_uniform(&samp), GPU_uniform(&samplesize), GPU_uniform(&lamp->bias), inp, &shadowfac);
+				}
 			}
 			else {
 				GPU_link(mat, "test_shadowbuf",

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -997,6 +997,14 @@ static void shade_one_light(GPUShadeInput *shi, GPUShadeResult *shr, GPULamp *la
 				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
 				             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadfac);
 				}
+				else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+					float samp = lamp->la->samp;
+					GPU_link(mat, "test_shadowbuf_pcf_early_bail",
+				             GPU_builtin(GPU_VIEW_POSITION),
+				             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+				             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadfac);
+				}
 				else {
 					GPU_link(mat, "test_shadowbuf",
 				             GPU_builtin(GPU_VIEW_POSITION),
@@ -2795,6 +2803,14 @@ GPUNodeLink *GPU_lamp_get_data(
 			if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
 				float samp = lamp->la->samp;
 				GPU_link(mat, "shadows_only_pcf",
+			             GPU_builtin(GPU_VIEW_POSITION),
+			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			}
+			else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+				float samp = lamp->la->samp;
+				GPU_link(mat, "shadows_only_pcf_early_bail",
 			             GPU_builtin(GPU_VIEW_POSITION),
 			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
 			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -989,7 +989,7 @@ static void shade_one_light(GPUShadeInput *shi, GPUShadeResult *shr, GPULamp *la
 				         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias), inp, &shadfac);
 			}
 			else {
-				if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+				if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
 					float samp = lamp->la->samp;
 					GPU_link(mat, "test_shadowbuf_pcf",
 				             GPU_builtin(GPU_VIEW_POSITION),
@@ -2792,7 +2792,7 @@ GPUNodeLink *GPU_lamp_get_data(
 			         GPU_uniform(lamp->shadow_color), inp, r_shadow);
 		}
 		else {
-			if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+			if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
 				float samp = lamp->la->samp;
 				GPU_link(mat, "shadows_only_pcf",
 			             GPU_builtin(GPU_VIEW_POSITION),

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -2777,6 +2777,7 @@ GPUNodeLink *GPU_lamp_get_data(
         GPUNodeLink **r_col, GPUNodeLink **r_lv, GPUNodeLink **r_dist, GPUNodeLink **r_shadow, GPUNodeLink **r_energy)
 {
 	GPUNodeLink *visifac;
+	GPUNodeLink *shadowfac;
 
 	*r_col = GPU_dynamic_uniform(lamp->dyncol, GPU_DYNAMIC_LAMP_DYNCOL, lamp->ob);
 	*r_energy = GPU_dynamic_uniform(&lamp->dynenergy, GPU_DYNAMIC_LAMP_DYNENERGY, lamp->ob);
@@ -2792,38 +2793,38 @@ GPUNodeLink *GPU_lamp_get_data(
 		mat->dynproperty |= DYN_LAMP_PERSMAT;
 
 		if (lamp->la->shadowmap_type == LA_SHADMAP_VARIANCE) {
-			GPU_link(mat, "shadows_only_vsm",
+			GPU_link(mat, "test_shadowbuf_vsm",
 			         GPU_builtin(GPU_VIEW_POSITION),
 			         GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
 			         GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias),
-			         GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias), inp, &shadowfac);
 		}
 		else {
 			if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
 				float samp = lamp->la->samp;
-				GPU_link(mat, "shadows_only_pcf",
+				GPU_link(mat, "test_shadowbuf_pcf",
 			             GPU_builtin(GPU_VIEW_POSITION),
 			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
 			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadowfac);
 			}
 			else if (lamp->la->shadow_filter == LA_SHADOW_FILTER_PCF_BAIL && lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
 				float samp = lamp->la->samp;
-				GPU_link(mat, "shadows_only_pcf_early_bail",
+				GPU_link(mat, "test_shadowbuf_pcf_early_bail",
 			             GPU_builtin(GPU_VIEW_POSITION),
 			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
 			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadowfac);
 			}
 			else {
-				GPU_link(mat, "shadows_only",
+				GPU_link(mat, "test_shadowbuf",
 			             GPU_builtin(GPU_VIEW_POSITION),
 			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
 			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			             GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			             GPU_uniform(&lamp->bias), inp, &shadowfac);
 			}
 		}
+		GPU_link(mat, "shadows_only", inp, shadowfac, GPU_uniform(lamp->shadow_color), r_shadow);
 	}
 	else {
 		GPU_link(mat, "set_rgb_one", r_shadow);

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -989,11 +989,21 @@ static void shade_one_light(GPUShadeInput *shi, GPUShadeResult *shr, GPULamp *la
 				         GPU_uniform(&lamp->bias), GPU_uniform(&lamp->la->bleedbias), inp, &shadfac);
 			}
 			else {
-				GPU_link(mat, "test_shadowbuf",
-				         GPU_builtin(GPU_VIEW_POSITION),
-				         GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-				         GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-				         GPU_uniform(&lamp->bias), inp, &shadfac);
+				if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+					float samp = lamp->la->samp;
+					GPU_link(mat, "test_shadowbuf_pcf",
+				             GPU_builtin(GPU_VIEW_POSITION),
+				             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+				             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), inp, &shadfac);
+				}
+				else {
+					GPU_link(mat, "test_shadowbuf",
+				             GPU_builtin(GPU_VIEW_POSITION),
+				             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+				             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+				             GPU_uniform(&lamp->bias), inp, &shadfac);
+				}
 			}
 			
 			if (lamp->mode & LA_ONLYSHADOW) {
@@ -2782,11 +2792,21 @@ GPUNodeLink *GPU_lamp_get_data(
 			         GPU_uniform(lamp->shadow_color), inp, r_shadow);
 		}
 		else {
-			GPU_link(mat, "shadows_only",
-			         GPU_builtin(GPU_VIEW_POSITION),
-			         GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
-			         GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
-			         GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			if (lamp->la->samp > 1 && lamp->la->soft >= 0.01f) {
+				float samp = lamp->la->samp;
+				GPU_link(mat, "shadows_only_pcf",
+			             GPU_builtin(GPU_VIEW_POSITION),
+			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+			             GPU_uniform(&samp), GPU_uniform(&lamp->la->soft), GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			}
+			else {
+				GPU_link(mat, "shadows_only",
+			             GPU_builtin(GPU_VIEW_POSITION),
+			             GPU_dynamic_texture(lamp->tex, GPU_DYNAMIC_SAMPLER_2DSHADOW, lamp->ob),
+			             GPU_dynamic_uniform((float *)lamp->dynpersmat, GPU_DYNAMIC_LAMP_DYNPERSMAT, lamp->ob),
+			             GPU_uniform(&lamp->bias), GPU_uniform(lamp->shadow_color), inp, r_shadow);
+			}
 		}
 	}
 	else {

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -2723,7 +2723,7 @@ void GPU_lamp_shadow_buffer_unbind(GPULamp *lamp)
 {
 	if (lamp->la->shadowmap_type == LA_SHADMAP_VARIANCE) {
 		GPU_shader_unbind();
-		GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex);
+		GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex, lamp->la->bufsharp);
 	}
 
 	GPU_framebuffer_texture_unbind(lamp->fb, lamp->tex);

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -2318,10 +2318,61 @@ void test_shadowbuf(
 		//float bias = (1.5 - inp*inp)*shadowbias;
 		co.z -= shadowbias * co.w;
 
-		if (co.w > 0.0 && co.x > 0.0 && co.x / co.w < 1.0 && co.y > 0.0 && co.y / co.w < 1.0)
+		if (co.w > 0.0 && co.x > 0.0 && co.x / co.w < 1.0 && co.y > 0.0 && co.y / co.w < 1.0) {
 			result = shadow2DProj(shadowmap, co).x;
-		else
+		}
+		else {
 			result = 1.0;
+		}
+	}
+}
+
+void test_shadowbuf_pcf(
+        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat, float samples, float samplesize, float shadowbias, float inp,
+        out float result)
+{
+	if (inp <= 0.0) {
+		result = 0.0;
+	}
+	else {
+		vec4 co = shadowpersmat * vec4(rco, 1.0);
+
+		//float bias = (1.5 - inp*inp)*shadowbias;
+		co.z -= shadowbias * co.w;
+
+		if (co.w > 0.0 && co.x > 0.0 && co.x / co.w < 1.0 && co.y > 0.0 && co.y / co.w < 1.0) {
+			float step = samplesize / samples;
+			float fullstep = samplesize - step * 0.95;
+			float halfsample = samplesize / 2.0 - step * 0.5 * 0.95;
+
+			result = 0.0;
+			for (float y = -halfsample; y <= halfsample; y += fullstep) {
+				for (float x = -halfsample; x <= halfsample; x += fullstep) {
+					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+				}
+			}
+
+			if (result > 0.0 && result < 4.0) {
+				float sampleoffset = halfsample - step;
+				for (float y = -sampleoffset; y <= sampleoffset; y += step) {
+					for (float x = -halfsample; x <= halfsample; x += step) {
+						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+					}
+				}
+				for (float y = -halfsample; y <= halfsample; y += fullstep) {
+					for (float x = -sampleoffset; x <= sampleoffset; x += step) {
+						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+					}
+				}
+				result /= (samples) * (samples);
+			}
+			else {
+				result /= 4.0;
+			}
+		}
+		else {
+			result = 1.0;
+		}
 	}
 }
 
@@ -2370,6 +2421,21 @@ void shadows_only(
 		float shadfac;
 
 		test_shadowbuf(rco, shadowmap, shadowpersmat, shadowbias, inp, shadfac);
+		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
+	}
+}
+
+void shadows_only_pcf(
+        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat,
+        float samples, float samplesize, float shadowbias, vec3 shadowcolor, float inp,
+        out vec3 result)
+{
+	result = vec3(1.0);
+
+	if (inp > 0.0) {
+		float shadfac;
+
+		test_shadowbuf_pcf(rco, shadowmap, shadowpersmat, samples, samplesize, shadowbias, inp, shadfac);
 		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
 	}
 }

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -2399,7 +2399,6 @@ void test_shadowbuf_pcf(
 					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
 				}
 			}
-
 			result /= (samples * samples);
 		}
 		else {
@@ -2442,62 +2441,11 @@ void test_shadowbuf_vsm(
 	}
 }
 
-void shadows_only(
-        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat,
-        float shadowbias, vec3 shadowcolor, float inp,
-        out vec3 result)
+void shadows_only(float inp, float shadfac, vec3 shadowcolor, out vec3 result)
 {
 	result = vec3(1.0);
 
 	if (inp > 0.0) {
-		float shadfac;
-
-		test_shadowbuf(rco, shadowmap, shadowpersmat, shadowbias, inp, shadfac);
-		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
-	}
-}
-
-void shadows_only_pcf_early_bail(
-        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat,
-        float samples, float samplesize, float shadowbias, vec3 shadowcolor, float inp,
-        out vec3 result)
-{
-	result = vec3(1.0);
-
-	if (inp > 0.0) {
-		float shadfac;
-
-		test_shadowbuf_pcf_early_bail(rco, shadowmap, shadowpersmat, samples, samplesize, shadowbias, inp, shadfac);
-		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
-	}
-}
-
-void shadows_only_pcf(
-        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat,
-        float samples, float samplesize, float shadowbias, vec3 shadowcolor, float inp,
-        out vec3 result)
-{
-	result = vec3(1.0);
-
-	if (inp > 0.0) {
-		float shadfac;
-
-		test_shadowbuf_pcf(rco, shadowmap, shadowpersmat, samples, samplesize, shadowbias, inp, shadfac);
-		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
-	}
-}
-
-void shadows_only_vsm(
-        vec3 rco, sampler2D shadowmap, mat4 shadowpersmat,
-        float shadowbias, float bleedbias, vec3 shadowcolor, float inp,
-        out vec3 result)
-{
-	result = vec3(1.0);
-
-	if (inp > 0.0) {
-		float shadfac;
-
-		test_shadowbuf_vsm(rco, shadowmap, shadowpersmat, shadowbias, bleedbias, inp, shadfac);
 		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
 	}
 }

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -2327,7 +2327,7 @@ void test_shadowbuf(
 	}
 }
 
-void test_shadowbuf_pcf(
+void test_shadowbuf_pcf_early_bail(
         vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat, float samples, float samplesize, float shadowbias, float inp,
         out float result)
 {
@@ -2364,11 +2364,43 @@ void test_shadowbuf_pcf(
 						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
 					}
 				}
-				result /= (samples) * (samples);
+				result /= (samples * samples);
 			}
 			else {
 				result /= 4.0;
 			}
+		}
+		else {
+			result = 1.0;
+		}
+	}
+}
+
+void test_shadowbuf_pcf(
+        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat, float samples, float samplesize, float shadowbias, float inp,
+        out float result)
+{
+	if (inp <= 0.0) {
+		result = 0.0;
+	}
+	else {
+		vec4 co = shadowpersmat * vec4(rco, 1.0);
+
+		//float bias = (1.5 - inp*inp)*shadowbias;
+		co.z -= shadowbias * co.w;
+
+		if (co.w > 0.0 && co.x > 0.0 && co.x / co.w < 1.0 && co.y > 0.0 && co.y / co.w < 1.0) {
+			float step = samplesize / samples;
+			float halfsample = samplesize / 2.0 - step * 0.5 * 0.95;
+
+			result = 0.0;
+			for (float y = -halfsample; y <= halfsample; y += step) {
+				for (float x = -halfsample; x <= halfsample; x += step) {
+					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+				}
+			}
+
+			result /= (samples * samples);
 		}
 		else {
 			result = 1.0;
@@ -2421,6 +2453,21 @@ void shadows_only(
 		float shadfac;
 
 		test_shadowbuf(rco, shadowmap, shadowpersmat, shadowbias, inp, shadfac);
+		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
+	}
+}
+
+void shadows_only_pcf_early_bail(
+        vec3 rco, sampler2DShadow shadowmap, mat4 shadowpersmat,
+        float samples, float samplesize, float shadowbias, vec3 shadowcolor, float inp,
+        out vec3 result)
+{
+	result = vec3(1.0);
+
+	if (inp > 0.0) {
+		float shadfac;
+
+		test_shadowbuf_pcf_early_bail(rco, shadowmap, shadowpersmat, samples, samplesize, shadowbias, inp, shadfac);
 		result -= (1.0 - shadfac) * (vec3(1.0) - shadowcolor);
 	}
 }

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -2348,7 +2348,7 @@ void test_shadowbuf_pcf_early_bail(
 			result = 0.0;
 			for (float y = -halfsample; y <= halfsample; y += fullstep) {
 				for (float x = -halfsample; x <= halfsample; x += fullstep) {
-					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.1, co.z, co.w)).x;
 				}
 			}
 
@@ -2356,12 +2356,12 @@ void test_shadowbuf_pcf_early_bail(
 				float sampleoffset = halfsample - step;
 				for (float y = -sampleoffset; y <= sampleoffset; y += step) {
 					for (float x = -halfsample; x <= halfsample; x += step) {
-						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.1, co.z, co.w)).x;
 					}
 				}
 				for (float y = -halfsample; y <= halfsample; y += fullstep) {
 					for (float x = -sampleoffset; x <= sampleoffset; x += step) {
-						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+						result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.1, co.z, co.w)).x;
 					}
 				}
 				result /= (samples * samples);
@@ -2396,7 +2396,7 @@ void test_shadowbuf_pcf(
 			result = 0.0;
 			for (float y = -halfsample; y <= halfsample; y += step) {
 				for (float x = -halfsample; x <= halfsample; x += step) {
-					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.005, co.z, co.w)).x;
+					result += shadow2DProj(shadowmap, vec4(co.xy + vec2(x, y) * 0.1, co.z, co.w)).x;
 				}
 			}
 			result /= (samples * samples);

--- a/source/blender/makesdna/DNA_lamp_types.h
+++ b/source/blender/makesdna/DNA_lamp_types.h
@@ -79,6 +79,7 @@ typedef struct Lamp {
 	float adapt_thresh;
 	short ray_samp_method;
 	short shadowmap_type;
+	short shadow_filter, pad3[3];
 	
 	/* texact is for buttons */
 	short texact, shadhalostep;
@@ -153,6 +154,10 @@ typedef struct Lamp {
 #define LA_SHOW_CONE    (1 << 17)
 #define LA_SHOW_SHADOW_BOX (1 << 18)
 #define LA_STATIC_SHADOW (1 << 19)
+
+/* shadow_filter */
+#define LA_SHADOW_FILTER_NONE 0
+#define LA_SHADOW_FILTER_PCF 1
 
 /* layer_shadow */
 #define LA_LAYER_SHADOW_BOTH	0

--- a/source/blender/makesdna/DNA_lamp_types.h
+++ b/source/blender/makesdna/DNA_lamp_types.h
@@ -67,7 +67,8 @@ typedef struct Lamp {
 	short pad2;
 	
 	float clipsta, clipend;
-	float bias, soft, compressthresh, bleedbias, pad5;
+	float bias, soft, compressthresh, bleedbias;
+	float bufsharp;
 	short bufsize, samp, buffers, filtertype;
 	char bufflag, buftype;
 	

--- a/source/blender/makesdna/DNA_lamp_types.h
+++ b/source/blender/makesdna/DNA_lamp_types.h
@@ -156,8 +156,9 @@ typedef struct Lamp {
 #define LA_STATIC_SHADOW (1 << 19)
 
 /* shadow_filter */
-#define LA_SHADOW_FILTER_NONE 0
-#define LA_SHADOW_FILTER_PCF 1
+#define LA_SHADOW_FILTER_NONE		0
+#define LA_SHADOW_FILTER_PCF		1
+#define LA_SHADOW_FILTER_PCF_BAIL	2
 
 /* layer_shadow */
 #define LA_LAYER_SHADOW_BOTH	0

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -548,6 +548,7 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	static EnumPropertyItem prop_shadow_filter_type_items[] = {
 		{LA_SHADOW_FILTER_NONE, "NONE", 0, "None", "None filtering"},
 		{LA_SHADOW_FILTER_PCF, "PCF", 0, "PCF", "Percentage Closer Filtering"},
+		{LA_SHADOW_FILTER_PCF_BAIL, "PCF_BAIL", 0, "PCF Early Bail", "Percentage Closer Filtering Eraly Bail"},
 		{0, NULL, 0, NULL, NULL}
 	};
 

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -545,6 +545,12 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 		{0, NULL, 0, NULL, NULL}
 	};
 
+	static EnumPropertyItem prop_shadow_filter_type_items[] = {
+		{LA_SHADOW_FILTER_NONE, "NONE", 0, "None", "None filtering"},
+		{LA_SHADOW_FILTER_PCF, "PCF", 0, "PCF", "Percentage Closer Filtering"},
+		{0, NULL, 0, NULL, NULL}
+	};
+
 	prop = RNA_def_property(srna, "use_shadow", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_funcs(prop, "rna_use_shadow_get", "rna_use_shadow_set");
 	RNA_def_property_update(prop, 0, "rna_Lamp_draw_update");
@@ -637,6 +643,11 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	RNA_def_property_ui_text(prop, "Shadow Map Type", "The shadow mapping algorithm used");
 	RNA_def_property_update(prop, 0, "rna_Lamp_update");
 
+	prop = RNA_def_property(srna, "shadow_filter", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_sdna(prop, NULL, "shadow_filter");
+	RNA_def_property_enum_items(prop, prop_shadow_filter_type_items);
+	RNA_def_property_ui_text(prop, "Shadow Map Filter Type", "The shadow mapping filtering algorithm used");
+	RNA_def_property_update(prop, 0, "rna_Lamp_update");
 
 	prop = RNA_def_property(srna, "use_auto_clip_start", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "bufflag", LA_SHADBUF_AUTO_START);

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -613,6 +613,12 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	RNA_def_property_ui_text(prop, "Shadow Buffer Soft", "Size of shadow buffer sampling area");
 	RNA_def_property_update(prop, 0, "rna_Lamp_update");
 
+	prop = RNA_def_property(srna, "shadow_buffer_sharp", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "bufsharp");
+	RNA_def_property_range(prop, -1.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Shadow Buffer Sharpness", "Sharpness of buffer sampling");
+	RNA_def_property_update(prop, 0, "rna_Lamp_update");
+
 	prop = RNA_def_property(srna, "shadow_buffer_samples", PROP_INT, PROP_NONE);
 	RNA_def_property_int_sdna(prop, NULL, "samp");
 	RNA_def_property_range(prop, 1, 16);

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -548,7 +548,7 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	static EnumPropertyItem prop_shadow_filter_type_items[] = {
 		{LA_SHADOW_FILTER_NONE, "NONE", 0, "None", "None filtering"},
 		{LA_SHADOW_FILTER_PCF, "PCF", 0, "PCF", "Percentage Closer Filtering"},
-		{LA_SHADOW_FILTER_PCF_BAIL, "PCF_BAIL", 0, "PCF Early Bail", "Percentage Closer Filtering Eraly Bail"},
+		{LA_SHADOW_FILTER_PCF_BAIL, "PCF_BAIL", 0, "PCF Early Bail", "Percentage Closer Filtering Early Bail"},
 		{0, NULL, 0, NULL, NULL}
 	};
 


### PR DESCRIPTION
Commit message:

PCF is a shadow mapping technique used to create smooth shadow
edges by sampling multiple time in a small zone and mix the results.

Variance sharpness is a value representing the distance between samples
when blurring the color texture of the variance shadow.

PCF depends as for simple shadow of a depth texture with coparaison
enabled. The only difference are in the UI options showed and the shader
functions used.
For the UI the user can interact with the option "samples" for the root
squared number of sampler and the option soft for the distance between
samples. For the shader two functions are used for PCF: test_shadowbuf_pcf
and test_shadowbuf_pcf_early_bail.

The first do every samples and divide the summary. The second
functions test first if the fourth furthest samples, if the values are
the same (all 0.0 or 1.0), then we discard all other samples and use these
four values. It economize a lot of process but can create artifacts for
closest shadow edges.

As PCF introduced two new long functions, "shadows_only" is simplified to
reuse a shadow value computed from an other function described before
instead of calling itself these functions.

Variance sharpness is showed in the UI under the name of "Sharpness".
if it's value is close to -1 then the shadow edges are smooth else they are
hard.