### PR TITLE
UPBGE: Fix bug with ImageMirror

### DIFF
--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -288,7 +288,7 @@ bool ImageRender::Render()
 		frustum.x2 = mirrorOffset[0]+width;
 		frustum.y1 = mirrorOffset[1]-height;
 		frustum.y2 = mirrorOffset[1]+height;
-		frustum.camnear = -mirrorOffset[2];
+		frustum.camnear = -mirrorOffset[2] + m_camera->GetCameraNear();
 		frustum.camfar = -mirrorOffset[2]+m_clip;
 	}
 	// Store settings to be restored later


### PR DESCRIPTION
I can't explain mathematically why this is working but what I can say is
that each time frustum is computed, frustum.camnear takes into account
camera->GetCameraNear(). We have a bug with the file I share in pull
request. Adding camera->GetCameraNear() to frustum.camnear
solves the bug.

test file: http://pasteall.org/blend/index.php?id=43311

remark: frustum.camfar takes into account clipend value (m_clip set by default to 100.0f)
