### PR TITLE
Lordloki fix for python joysticks

### DIFF
--- a/source/gameengine/Device/DEV_Joystick.h
+++ b/source/gameengine/Device/DEV_Joystick.h
@@ -132,7 +132,7 @@ class DEV_Joystick
 public:
 
 	static DEV_Joystick *GetInstance(short joyindex);
-	static void HandleEvents(void);
+	static short HandleEvents(short (&index)[8], short (&addrem)[8]);
 	void ReleaseInstance(short joyindex);
 	static void Init();
 	static void Close();

--- a/source/gameengine/Device/DEV_JoystickEvents.cpp
+++ b/source/gameengine/Device/DEV_JoystickEvents.cpp
@@ -58,12 +58,13 @@ void DEV_Joystick::OnNothing(SDL_Event* sdl_event)
 	m_istrig_axis = m_istrig_button = 0;
 }
 
-void DEV_Joystick::HandleEvents(void)
+short DEV_Joystick::HandleEvents(short (&index)[8], short (&addrem)[8])
 {
 	SDL_Event		sdl_event;
+	short num_updateneeded = 0;
 
 	if (SDL_PollEvent == (void*)0) {
-		return;
+		return 0;
 	}
 
 	for (int i = 0; i < JOYINDEX_MAX; i++) {
@@ -91,6 +92,9 @@ void DEV_Joystick::HandleEvents(void)
 					if (!DEV_Joystick::m_instance[sdl_event.jdevice.which]) {
 						DEV_Joystick::m_instance[sdl_event.jdevice.which] = new DEV_Joystick(sdl_event.jdevice.which);
 						DEV_Joystick::m_instance[sdl_event.jdevice.which]->CreateJoystickDevice();
+						index[num_updateneeded] = sdl_event.jdevice.which;
+						addrem[num_updateneeded] = 1;
+						num_updateneeded++;
 						break;
 					}
 					else {
@@ -107,6 +111,9 @@ void DEV_Joystick::HandleEvents(void)
 					if (DEV_Joystick::m_instance[i]) {
 						if (sdl_event.cdevice.which == DEV_Joystick::m_instance[i]->m_private->m_instance_id) {
 							DEV_Joystick::m_instance[i]->ReleaseInstance(i);
+							index[num_updateneeded] = i;
+							addrem[num_updateneeded] = -1;
+							num_updateneeded++;
 							break;
 						}
 					}
@@ -138,5 +145,6 @@ void DEV_Joystick::HandleEvents(void)
 				break;
 		}
 	}
+	return num_updateneeded;
 }
 #endif /* WITH_SDL */

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -63,6 +63,7 @@
 #include "KX_NetworkMessageScene.h"
 
 #include "DEV_Joystick.h" // for DEV_Joystick::HandleEvents
+#include "KX_PythonInit.h" // for updatePythonJoysticks
 
 #include "KX_WorldInfo.h"
 #include "KX_ISceneConverter.h"
@@ -397,7 +398,18 @@ bool KX_KetsjiEngine::NextFrame()
 		}
 #ifdef WITH_SDL
 		// Handle all SDL Joystick events here to share they for all scenes proceed.
-		DEV_Joystick::HandleEvents();
+		short num_updateneeded, index[8], addrem[8];
+		num_updateneeded = DEV_Joystick::HandleEvents(index, addrem);
+		for (int i = 0; i < num_updateneeded; i++) {
+			if (addrem[i] =! 0) {
+				if (addrem[i] == 1) {
+					updatePythonJoysticks(index[i], true);
+				}
+				else {
+					updatePythonJoysticks(index[i], false);
+				}
+			}
+		}
 #endif
 
 		// for each scene, call the proceed functions

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2228,6 +2228,32 @@ void createPythonConsole()
 	PyRun_SimpleFile(fp, filepath);
 }
 
+void updatePythonJoysticks(short index, bool addrem)
+{
+	DEV_Joystick *joy = DEV_Joystick::GetInstance(index);
+	PyObject *gameLogic = PyImport_ImportModule("GameLogic");
+	PyObject *pythonJoyList = PyDict_GetItemString(PyModule_GetDict(gameLogic), "joysticks");
+	PyObject *item;
+
+	if (addrem) {
+		if (joy && joy->Connected()) {
+			gp_PythonJoysticks[index] = new SCA_PythonJoystick(joy, index);
+			item = gp_PythonJoysticks[index]->NewProxy(true);
+		}
+		else {
+			item = Py_None;
+		}
+	}
+	else {
+			if (joy) {
+				joy->ReleaseInstance(index);
+			}
+			item = Py_None;
+	}
+	Py_INCREF(item);
+	PyList_SET_ITEM(pythonJoyList, index, item);
+}
+
 static struct PyModuleDef Rasterizer_module_def = {
 	PyModuleDef_HEAD_INIT,
 	"Rasterizer",  /* m_name */

--- a/source/gameengine/Ketsji/KX_PythonInit.h
+++ b/source/gameengine/Ketsji/KX_PythonInit.h
@@ -58,6 +58,9 @@ void loadGamePythonConfig();
 
 /// Create a python interpreter and stop the engine until the interpreter is active.
 void createPythonConsole();
+
+// Update Python Joysticks
+void updatePythonJoysticks(short index, bool addrem);
 #endif
 
 void addImportMain(struct Main *maggie);


### PR DESCRIPTION
Lordloki fix for SCA_Python joysticks.

test file: http://pasteall.org/blend/index.php?id=43387

(When I begun my tests I had crashes because sometimes addrem[i] had not the right value after handleevents function (1 instead of -1)... I don't know why. Now I can't reproduce the bug but I don't know what was changed since I have not the bug anymore...)