### PR TITLE
Fix modifiers and geometry instancing.

### DIFF
--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -106,6 +106,7 @@ typedef enum GPUBuiltin {
 	GPU_INSTANCING_COLOR_ATTRIB    = (1 << 20),
 	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 21),
 	GPU_INSTANCING_POSITION_ATTRIB = (1 << 22),
+	GPU_INSTANCING_MODE            = (1 << 23),
 } GPUBuiltin;
 
 typedef enum GPUOpenGLBuiltin {
@@ -379,6 +380,7 @@ void GPU_material_update_fvar_offset(GPUMaterial *gpu_material,
 #endif
 
 /* Instancing material */
+void GPU_material_enable_instancing(GPUMaterial *material, bool enable);
 void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
 void GPU_material_unbind_instancing_attrib(GPUMaterial *material);
 

--- a/source/blender/gpu/intern/gpu_codegen.c
+++ b/source/blender/gpu/intern/gpu_codegen.c
@@ -426,6 +426,8 @@ const char *GPU_builtin_name(GPUBuiltin builtin)
 		return "ininstmatrix";
 	else if (builtin == GPU_INSTANCING_POSITION_ATTRIB)
 		return "ininstposition";
+	else if (builtin == GPU_INSTANCING_MODE)
+		return "unfinstmode";
 	else
 		return "";
 }
@@ -1741,6 +1743,10 @@ GPUPass *GPU_generate_pass(
 
 	gpu_nodes_get_vertex_attributes(nodes, attribs);
 	gpu_nodes_get_builtin_flag(nodes, builtins);
+	if (use_instancing) {
+		*builtins |= (GPU_OBJECT_MATRIX | GPU_INVERSE_OBJECT_MATRIX | GPU_LOC_TO_VIEW_MATRIX |
+					 GPU_INVERSE_LOC_TO_VIEW_MATRIX | GPU_OBCOLOR);
+	}
 
 	/* generate code and compile with opengl */
 	fragmentcode = code_generate_fragment(nodes, outlink->output);

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -125,6 +125,7 @@ struct GPUMaterial {
 	int ininstposloc;
 	int ininstmatloc;
 	int ininstcolloc;
+	int instmodeloc;
 
 	bool use_instancing;
 
@@ -251,6 +252,12 @@ static int GPU_material_construct_end(GPUMaterial *material, const char *passnam
 		
 		GPUShader *shader = GPU_pass_shader(material->pass);
 
+		if (material->use_instancing) {
+			material->ininstposloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_POSITION_ATTRIB));
+			material->ininstmatloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_MATRIX_ATTRIB));
+			material->ininstcolloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_COLOR_ATTRIB));
+			material->instmodeloc = GPU_shader_get_uniform(shader, GPU_builtin_name(GPU_INSTANCING_MODE));
+		}
 		if (material->builtins & GPU_VIEW_MATRIX)
 			material->viewmatloc = GPU_shader_get_uniform(shader, GPU_builtin_name(GPU_VIEW_MATRIX));
 		if (material->builtins & GPU_INVERSE_VIEW_MATRIX)
@@ -277,11 +284,6 @@ static int GPU_material_construct_end(GPUMaterial *material, const char *passnam
 			material->partvel = GPU_shader_get_uniform(shader, GPU_builtin_name(GPU_PARTICLE_VELOCITY));
 		if (material->builtins & GPU_PARTICLE_ANG_VELOCITY)
 			material->partangvel = GPU_shader_get_uniform(shader, GPU_builtin_name(GPU_PARTICLE_ANG_VELOCITY));
-		if (material->use_instancing) {
-			material->ininstposloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_POSITION_ATTRIB));
-			material->ininstmatloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_MATRIX_ATTRIB));
-			material->ininstcolloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_COLOR_ATTRIB));
-		}
 		return 1;
 	}
 	else {
@@ -330,6 +332,12 @@ bool GPU_lamp_override_visible(GPULamp *lamp, SceneRenderLayer *srl, Material *m
 		return BKE_group_object_exists(ma->group, lamp->ob);
 	else
 		return true;
+}
+
+void GPU_material_enable_instancing(GPUMaterial *material, bool enable)
+{
+	GPUShader *shader = GPU_pass_shader(material->pass);
+	GPU_shader_uniform_int(shader, material->instmodeloc, (enable) ? 1 : 0);
 }
 
 void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)

--- a/source/blender/gpu/shaders/gpu_shader_basic_instancing_vert.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_basic_instancing_vert.glsl
@@ -1,12 +1,18 @@
 in mat3 ininstmatrix;
 in vec3 ininstposition;
 
+uniform int unfinstmode;
+
 void main()
 {
-	mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
-						vec4(ininstmatrix[1], ininstposition.y),
-						vec4(ininstmatrix[2], ininstposition.z),
-						vec4(0.0, 0.0, 0.0, 1.0));
+	vec4 vertex = gl_Vertex;
+	if (unfinstmode == 1) {
+		mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
+							vec4(ininstmatrix[1], ininstposition.y),
+							vec4(ininstmatrix[2], ininstposition.z),
+							vec4(0.0, 0.0, 0.0, 1.0));
+		vertex *= instmat;
+	}
 
-	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * (gl_Vertex * instmat);
+	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vertex;
 }

--- a/source/blender/gpu/shaders/gpu_shader_vertex.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_vertex.glsl
@@ -19,6 +19,13 @@ varying mat4 varinstlocaltoviewmat;
 varying mat4 varinstinvlocaltoviewmat;
 
 uniform mat4 unfviewmat;
+uniform vec4 unfobcolor;
+uniform mat4 unfobmat;
+uniform mat4 unfinvobmat;
+uniform mat4 unflocaltoviewmat;
+uniform mat4 unfinvlocaltoviewmat;
+
+uniform int unfinstmode;
 #endif
 
 varying vec3 varposition;
@@ -104,18 +111,27 @@ void main()
 #endif
 
 #ifdef USE_INSTANCING
-	mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
-						vec4(ininstmatrix[1], ininstposition.y),
-						vec4(ininstmatrix[2], ininstposition.z),
-						vec4(0.0, 0.0, 0.0, 1.0));
-	varinstmat = transpose(instmat);
-	varinstinvmat = inverse(varinstmat);
-	varinstlocaltoviewmat = unfviewmat * varinstmat;
-	varinstinvlocaltoviewmat = inverse(varinstlocaltoviewmat);
-	varinstcolor = ininstcolor;
+	if (unfinstmode == 0) {
+		varinstcolor = unfobcolor;
+		varinstmat = unfobmat;
+		varinstinvmat = unfinvobmat;
+		varinstlocaltoviewmat = unflocaltoviewmat;
+		varinstinvlocaltoviewmat = unfinvlocaltoviewmat;
+	}
+	else {
+		mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
+							vec4(ininstmatrix[1], ininstposition.y),
+							vec4(ininstmatrix[2], ininstposition.z),
+							vec4(0.0, 0.0, 0.0, 1.0));
+		varinstmat = transpose(instmat);
+		varinstinvmat = inverse(varinstmat);
+		varinstlocaltoviewmat = unfviewmat * varinstmat;
+		varinstinvlocaltoviewmat = inverse(varinstlocaltoviewmat);
+		varinstcolor = ininstcolor;
 
-	position *= instmat;
-	normal *= ininstmatrix;
+		position *= instmat;
+		normal *= ininstmatrix;
+	}
 #endif
 
 	vec4 co = gl_ModelViewMatrix * position;

--- a/source/blender/gpu/shaders/gpu_shader_vsm_store_vert.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_vsm_store_vert.glsl
@@ -3,20 +3,23 @@ varying vec4 v_position;
 #ifdef USE_INSTANCING
 in mat3 ininstmatrix;
 in vec3 ininstposition;
+
+uniform int unfinstmode;
 #endif
 
 void main()
 {
+	vec4 vertex = gl_Vertex;
 #ifdef USE_INSTANCING
-	mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
-						vec4(ininstmatrix[1], ininstposition.y),
-						vec4(ininstmatrix[2], ininstposition.z),
-						vec4(0.0, 0.0, 0.0, 1.0));
-
-	v_position = gl_ProjectionMatrix * gl_ModelViewMatrix * (gl_Vertex * instmat);
-	gl_Position = v_position;
-#else
-	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
-	v_position = gl_Position;
+	if (unfinstmode == 1) {
+		mat4 instmat = mat4(vec4(ininstmatrix[0], ininstposition.x),
+							vec4(ininstmatrix[1], ininstposition.y),
+							vec4(ininstmatrix[2], ininstposition.z),
+							vec4(0.0, 0.0, 0.0, 1.0));
+		vertex *= instmat;
+	}
 #endif
+
+	v_position = gl_ProjectionMatrix * gl_ModelViewMatrix * vertex;
+	gl_Position = v_position;
 }

--- a/source/gameengine/Ketsji/BL_BlenderShader.cpp
+++ b/source/gameengine/Ketsji/BL_BlenderShader.cpp
@@ -205,6 +205,13 @@ bool BL_BlenderShader::UseInstancing() const
 	return (GPU_instanced_drawing_support() && (m_mat->shade_flag & MA_INSTANCING));
 }
 
+void BL_BlenderShader::EnableInstancing(bool enable)
+{
+	if (Ok()) {
+		GPU_material_enable_instancing(m_GPUMat, enable);
+	}
+}
+
 void BL_BlenderShader::ActivateInstancing(void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)
 {
 	if (Ok()) {

--- a/source/gameengine/Ketsji/BL_BlenderShader.h
+++ b/source/gameengine/Ketsji/BL_BlenderShader.h
@@ -79,6 +79,7 @@ public:
 
 	/// Return true if the shader uses a special vertex shader for geometry instancing.
 	bool UseInstancing() const;
+	void EnableInstancing(bool enable);
 	void ActivateInstancing(void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
 	void DesactivateInstancing();
 

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -383,6 +383,13 @@ bool KX_BlenderMaterial::UseInstancing() const
 	return m_material->shade_flag & MA_INSTANCING;
 }
 
+void KX_BlenderMaterial::EnableInstancing(bool enable)
+{
+	if (m_blenderShader) {
+		m_blenderShader->EnableInstancing(enable);
+	}
+}
+
 void KX_BlenderMaterial::ActivateInstancing(RAS_IRasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)
 {
 	if (m_blenderShader) {

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -46,6 +46,7 @@ public:
 
 	virtual void Activate(RAS_IRasterizer *rasty);
 	virtual void Desactivate(RAS_IRasterizer *rasty);
+	virtual void EnableInstancing(bool enable);
 	virtual void ActivateInstancing(RAS_IRasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
 	virtual void DesactivateInstancing();
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_IRasterizer *rasty);

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -55,6 +55,10 @@ void KX_TextMaterial::Desactivate(RAS_IRasterizer *rasty)
 {
 }
 
+void KX_TextMaterial::EnableInstancing(bool enable)
+{
+}
+
 void KX_TextMaterial::ActivateInstancing(RAS_IRasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)
 {
 }

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -38,6 +38,7 @@ public:
 
 	virtual void Activate(RAS_IRasterizer *rasty);
 	virtual void Desactivate(RAS_IRasterizer *rasty);
+	virtual void EnableInstancing(bool enable);
 	virtual void ActivateInstancing(RAS_IRasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
 	virtual void DesactivateInstancing();
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_IRasterizer *rasty);

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -174,6 +174,11 @@ bool RAS_DisplayArrayBucket::UseVao() const
 	return m_useVao;
 }
 
+bool RAS_DisplayArrayBucket::HasDeformer() const
+{
+	return m_deformerList.size() > 0;
+}
+
 bool RAS_DisplayArrayBucket::IsMeshModified() const
 {
 	return m_meshModified;
@@ -319,6 +324,7 @@ void RAS_DisplayArrayBucket::RenderMeshSlotsInstancing(const MT_Transform& camer
 
 	// Bind all vertex attributs for the used material and the given buffer offset.
 	if (rasty->GetOverrideShader() == RAS_IRasterizer::RAS_OVERRIDE_SHADER_NONE) {
+		material->EnableInstancing(true);
 		material->ActivateInstancing(
 			rasty,
 			m_instancingBuffer->GetMatrixOffset(),

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -333,6 +333,7 @@ void RAS_DisplayArrayBucket::RenderMeshSlotsInstancing(const MT_Transform& camer
 			m_instancingBuffer->GetStride());
 	}
 	else {
+		rasty->EnableOverrideShaderInstancing(true);
 		rasty->ActivateOverrideShaderInstancing(
 			m_instancingBuffer->GetMatrixOffset(),
 			m_instancingBuffer->GetPositionOffset(),

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
@@ -116,6 +116,7 @@ public:
 	/// \section Render Infos
 	bool UseDisplayList() const;
 	bool UseVao() const;
+	bool HasDeformer() const;
 	bool IsMeshModified() const;
 
 	/// Update render infos.

--- a/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
@@ -105,6 +105,7 @@ public:
 
 	virtual void Activate(RAS_IRasterizer *rasty) = 0;
 	virtual void Desactivate(RAS_IRasterizer *rasty) = 0;
+	virtual void EnableInstancing(bool enable) = 0;
 	virtual void ActivateInstancing(RAS_IRasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride) = 0;
 	virtual void DesactivateInstancing() = 0;
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_IRasterizer *rasty) = 0;

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -624,6 +624,7 @@ public:
 
 	virtual void SetOverrideShader(OverrideShaderType type) = 0;
 	virtual OverrideShaderType GetOverrideShader() = 0;
+	virtual void EnableOverrideShaderInstancing(bool enable) = 0;
 	virtual void ActivateOverrideShaderInstancing(void *matrixoffset, void *positionoffset, unsigned int stride) = 0;
 	virtual void DesactivateOverrideShaderInstancing() = 0;
 

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
@@ -220,7 +220,7 @@ void RAS_MaterialBucket::RenderMeshSlots(const MT_Transform& cameratrans, RAS_IR
 		}
 
 		// Choose the rendering mode : geometry instancing render / regular render.
-		if (UseInstancing()) {
+		if (UseInstancing() && !displayArrayBucket->HasDeformer()) {
 			displayArrayBucket->RenderMeshSlotsInstancing(cameratrans, rasty, IsAlpha());
 		}
 		else {

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1344,7 +1344,12 @@ void RAS_OpenGLRasterizer::DrawDerivedMesh(RAS_MeshSlot *ms)
 		SetLines(true);
 	}
 
-	current_polymat->EnableInstancing(false);
+	if (m_overrideShader != RAS_OVERRIDE_SHADER_NONE) {
+		EnableOverrideShaderInstancing(false);
+	}
+	else {
+		current_polymat->EnableInstancing(false);
+	}
 
 	bool wireframe = (m_drawingmode == RAS_WIREFRAME);
 	if (current_polymat->GetFlag() & RAS_BLENDERGLSL) {
@@ -1818,6 +1823,18 @@ void RAS_OpenGLRasterizer::SetOverrideShader(RAS_OpenGLRasterizer::OverrideShade
 RAS_IRasterizer::OverrideShaderType RAS_OpenGLRasterizer::GetOverrideShader()
 {
 	return m_overrideShader;
+}
+
+void RAS_OpenGLRasterizer::EnableOverrideShaderInstancing(bool enable)
+{
+	GPUShader *shader = GetOverrideGPUShader(m_overrideShader);
+	if (shader) {
+		// Same name than for GPU_INSTANCING_MODE.
+		const int loc = GPU_shader_get_uniform(shader, "unfinstmode");
+		if (loc != -1) {
+			GPU_shader_uniform_int(shader, loc, (enable) ? 1 : 0);
+		}
+	}
 }
 
 void RAS_OpenGLRasterizer::ActivateOverrideShaderInstancing(void *matrixoffset, void *positionoffset, unsigned int stride)

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1344,6 +1344,8 @@ void RAS_OpenGLRasterizer::DrawDerivedMesh(RAS_MeshSlot *ms)
 		SetLines(true);
 	}
 
+	current_polymat->EnableInstancing(false);
+
 	bool wireframe = (m_drawingmode == RAS_WIREFRAME);
 	if (current_polymat->GetFlag() & RAS_BLENDERGLSL) {
 		// GetMaterialIndex return the original mface material index,

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -367,6 +367,7 @@ public:
 
 	virtual void SetOverrideShader(OverrideShaderType type);
 	virtual OverrideShaderType GetOverrideShader();
+	virtual void EnableOverrideShaderInstancing(bool enable);
 	virtual void ActivateOverrideShaderInstancing(void *matrixoffset, void *positionoffset, unsigned int stride);
 	virtual void DesactivateOverrideShaderInstancing();
 


### PR DESCRIPTION
This branch fix modifier rendering with geometry instancing by disabling the instancing in the shader.

To disable the instancing an uniform named `unfinstmode` is instroduced. This uniform is either 0 or 1.
Then in shader we use uniforms passed to the shader or attributs from vertex arrays. Passing the uniform was an issue because material generation look at used uniform names in nodes, but the in our case the uniform are only assigned to a varying. To solve this we force the usage of the needed uniforms:
GPU_OBJECT_MATRIX
GPU_INVERSE_OBJECT_MATRIX
GPU_LOC_TO_VIEW_MATRIX
GPU_INVERSE_LOC_TO_VIEW_MATRIX
GPU_OBCOLOR

To setup the value of `unfinstmode` the function `GPU_material_enable_instancing` need to be called through `BL_BlenderMaterial::EnableInstancing` and `KX_BlenderMaterial::EnableInstancing`.

Instancing can be disabled in materials' shaders, but the similar case is reproduced for override shaders (shadow instancing, variance shadow instancing). Here we use a functions named `RAS_IRasterizer::EnableOverrideShaderInstancing` to disable the instancing of the current bound override shader.

The both functions `KX_BlenderMaterial::EnableInstancing` and `RAS_IRasterizer::EnableOverrideShaderInstancing` are called in `RAS_IRasterizer::DrawDerivedMesh` to disable and in `RAS_DisplayArrayBucket::RenderMeshSlotsInstancing` to enable instancing.

@lordloki, @DCubix, @youle31 : Could you review this branch please ?

Example file : http://pasteall.org/blend/index.php?id=43509