### PR TITLE
Remove UV shift parallax option.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_texture.py
+++ b/release/scripts/startup/bl_ui/properties_texture.py
@@ -1082,7 +1082,6 @@ class TEXTURE_PT_influence(TextureSlotPanel, Panel):
                 factor_but(col, "use_map_hardness", "hardness_factor", "Hardness")
 
                 col.label(text = "Parallax:")
-                factor_but(col, "use_parallax_uv", "parallax_uv_shift", "Height Scale")
                 factor_but(col, "use_map_parallax", "parallax_steps", "Steps")
                 factor_but(col, "use_map_parallax", "parallax_bump_scale", "Bump Scale")
                 col.prop(tex, "parallax_uv_discard", text = "Discard Edges")

--- a/source/blender/blenkernel/intern/texture.c
+++ b/source/blender/blenkernel/intern/texture.c
@@ -743,7 +743,6 @@ void BKE_texture_mtex_default(MTex *mtex)
 	mtex->blendtype = MTEX_BLEND;
 	mtex->colfac = 1.0;
 	mtex->norfac = 1.0;
-	mtex->parallaxuv = 0.0f;
 	mtex->parallaxbumpsc = 0.03f;
 	mtex->parallaxsteps = 10.0f;
 	mtex->varfac = 1.0;

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -1312,7 +1312,6 @@ static void do_material_tex(GPUShadeInput *shi)
 					GPU_builtin(GPU_VIEW_POSITION), GPU_attribute(CD_TANGENT, ""),
 					GPU_builtin(GPU_VIEW_NORMAL), GPU_uniform(mtex->size),
 					GPU_image(tex->ima, &tex->iuser, false), 
-					GPU_uniform(&mtex->parallaxuv),
 					GPU_select_uniform(&mtex->parallaxsteps, GPU_DYNAMIC_TEX_PARALLAXSTEP, NULL, ma),
 					GPU_select_uniform(&mtex->parallaxbumpsc, GPU_DYNAMIC_TEX_PARALLAXBUMP, NULL, ma),
 					GPU_uniform(&discard),

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -3733,13 +3733,13 @@ vec2 parallax_scale(vec2 texuv, vec2 size)
 	return (texuv * size) + (vec2(1.0) - size) / 2.0;
 }
 
-void parallax_out(vec3 texco, vec3 vp, vec4 tangent, vec3 vn, vec3 size, sampler2D ima, float scale, float numsteps, float bumpscale, float discarduv, out vec3 ptexcoord)
+void parallax_out(vec3 texco, vec3 vp, vec4 tangent, vec3 vn, vec3 size, sampler2D ima, float numsteps, float bumpscale, float discarduv, out vec3 ptexcoord)
 {
 	vec3 binormal = cross(-vn, tangent.xyz) * tangent.w;
 	vec3 vvec = vec3(dot(tangent.xyz, vp), dot(binormal, vp), dot(-vn, vp));
 	vec3 vv = normalize(vvec);
 	float height = texture2D(ima, parallax_scale(texco.xy, size.xy)).a;
-	vec2 texuv = texco.xy + height * scale * 0.005;
+	vec2 texuv = texco.xy;
 	float h = 1.0;
 	float numeyesteps = mix(numsteps * 2.0, numsteps, vv.z);
 	float step = 1.0 / numeyesteps;

--- a/source/blender/makesdna/DNA_texture_types.h
+++ b/source/blender/makesdna/DNA_texture_types.h
@@ -76,7 +76,7 @@ typedef struct MTex {
 	
 	/* material */
 	float norfac, dispfac, warpfac;
-	float parallaxuv, parallaxsteps, parallaxbumpsc, padpfac;
+	float parallaxsteps, parallaxbumpsc;
 	float colspecfac, mirrfac, alphafac;
 	float difffac, specfac, emitfac, hardfac;
 	float raymirrfac, translfac, ambfac;

--- a/source/blender/makesrna/intern/rna_material.c
+++ b/source/blender/makesrna/intern/rna_material.c
@@ -668,12 +668,6 @@ static void rna_def_material_mtex(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Warp Factor", "Amount texture affects texture coordinates of next channels");
 	RNA_def_property_update(prop, 0, "rna_Material_update");
 
-	prop = RNA_def_property(srna, "parallax_uv_shift", PROP_FLOAT, PROP_NONE);
-	RNA_def_property_float_sdna(prop, NULL, "parallaxuv");
-	RNA_def_property_ui_range(prop, 0.0, 2.0, 1.0, 3);
-	RNA_def_property_ui_text(prop, "UV Shift", "Amount texture is shifted");
-	RNA_def_property_update(prop, 0, "rna_Material_update");
-
 	prop = RNA_def_property(srna, "parallax_steps", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "parallaxsteps");
 	RNA_def_property_ui_range(prop, 0.0, 100.0, 1.0, 3);


### PR DESCRIPTION
I propose you to remove this option because none valid result are found when setting a value different to 0.0.

@youle31, @lordloki, @DCubix : Do you have a case showing the utility of this variable ? Else do you agree to remove it ?