### PR TITLE
Material switching.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_MeshProxy.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_MeshProxy.rst
@@ -132,3 +132,16 @@ base class --- :class:`CValue`
       :arg uv_index_from: optional uv index to copy from, -1 to transform the current uv.
       :type uv_index_from: integer
 
+   .. method:: replaceMaterial(matid, material)
+
+      Replace the material in slot :data:`matid` by the material :data:`material`.
+
+      :arg matid: The material index.
+      :type matid: integer
+      :arg material: The material replacement.
+      :type material: :class:`KX_BlenderMaterial`
+
+      .. warning::
+
+         Changing the material of a mesh used by many objects can be slow. This function should be not called every frames
+

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -531,8 +531,6 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 		tangent = (float(*)[4])dm->getTessFaceDataArray(dm, CD_TANGENT);
 	}
 
-	meshobj = new RAS_MeshObject(mesh);
-
 	// Extract avaiable layers
 	MTF_localLayer *layers =  new MTF_localLayer[MAX_MTFACE];
 	for (int lay=0; lay<MAX_MTFACE; lay++) {
@@ -558,7 +556,16 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 		}
 	}
 
-	meshobj->SetName(mesh->id.name + 2);
+
+	STR_String uvsname[RAS_Texture::MaxUnits];
+	// foreach MTex
+	for (int i = 0; i < RAS_Texture::MaxUnits; i++) {
+		// Store the uv name for later find the UV layer cooresponding to the attrib name. See BL_BlenderShader::ParseAttribs.
+		uvsname[i] = STR_String(layers[i].name);
+	}
+
+	meshobj = new RAS_MeshObject(mesh, uvsname);
+
 	meshobj->m_sharedvertex_map.resize(totvert);
 
 	RAS_TexVertFormat vertformat;
@@ -727,15 +734,8 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 		}
 	}
 
-	STR_String uvsname[RAS_Texture::MaxUnits];
-	// foreach MTex
-	for (int i = 0; i < RAS_Texture::MaxUnits; i++) {
-		// Store the uv name for later find the UV layer cooresponding to the attrib name. See BL_BlenderShader::ParseAttribs.
-		uvsname[i] = STR_String(layers[i].name);
-	}
-
 	// Find attributes layer (currently only UVs) by materials for this mesh.
-	meshobj->GenerateAttribLayers(uvsname);
+	meshobj->GenerateAttribLayers();
 
 	if (layers)
 		delete []layers;

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -653,7 +653,7 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 		{
 
 			RAS_MaterialBucket* bucket = material_from_mesh(ma, mface, tface, mcol, layers, lightlayer, rgb, uvs, tfaceName, scene, converter);
-			meshobj->AddMaterial(bucket, mface->mat_nr, vertformat);
+			RAS_MeshMaterial *meshmat = meshobj->AddMaterial(bucket, mface->mat_nr, vertformat);
 
 			// set render flags
 			bool visible = ((ma->game.flag & GEMAT_INVISIBLE)==0);
@@ -667,12 +667,12 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 
 			unsigned int indices[4]; // all indices of the poly, can be a tri or quad.
 
-			indices[0] = meshobj->AddVertex(bucket, pt[0], uvs[0], tan[0], rgb[0], no[0], flat, mface->v1);
-			indices[1] = meshobj->AddVertex(bucket, pt[1], uvs[1], tan[1], rgb[1], no[1], flat, mface->v2);
-			indices[2] = meshobj->AddVertex(bucket, pt[2], uvs[2], tan[2], rgb[2], no[2], flat, mface->v3);
+			indices[0] = meshobj->AddVertex(meshmat, pt[0], uvs[0], tan[0], rgb[0], no[0], flat, mface->v1);
+			indices[1] = meshobj->AddVertex(meshmat, pt[1], uvs[1], tan[1], rgb[1], no[1], flat, mface->v2);
+			indices[2] = meshobj->AddVertex(meshmat, pt[2], uvs[2], tan[2], rgb[2], no[2], flat, mface->v3);
 
 			if (nverts == 4) {
-				indices[3] = meshobj->AddVertex(bucket, pt[3], uvs[3], tan[3], rgb[3], no[3], flat, mface->v4);
+				indices[3] = meshobj->AddVertex(meshmat, pt[3], uvs[3], tan[3], rgb[3], no[3], flat, mface->v4);
 			}
 
 			if (bucket->IsWire() && visible) {
@@ -691,13 +691,13 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 						// If 2 vertices are the same as an edge, we add a line in the mesh.
 						if (ELEM(medge->v1, mfaceindices[j], mfaceindices[k]) &&
 							ELEM(medge->v2, mfaceindices[j], mfaceindices[k])) {
-							meshobj->AddLine(bucket, indices[j], indices[k]);
+							meshobj->AddLine(meshmat, indices[j], indices[k]);
 							break;
 						}
 					}
 				}
 			}
-			meshobj->AddPolygon(bucket, nverts, indices, visible, collider, twoside);
+			meshobj->AddPolygon(meshmat, nverts, indices, visible, collider, twoside);
 		}
 
 		if (tface) 
@@ -721,9 +721,9 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	// pre calculate texture generation
 	// However, we want to delay this if we're libloading so we can make sure we have the right scene.
 	if (!libloading) {
-		for (list<RAS_MeshMaterial>::iterator mit = meshobj->GetFirstMaterial();
+		for (std::vector<RAS_MeshMaterial *>::iterator mit = meshobj->GetFirstMaterial();
 			mit != meshobj->GetLastMaterial(); ++ mit) {
-			mit->m_bucket->GetPolyMaterial()->OnConstruction();
+			(*mit)->m_bucket->GetPolyMaterial()->OnConstruction();
 		}
 	}
 

--- a/source/gameengine/Converter/BL_MeshDeformer.cpp
+++ b/source/gameengine/Converter/BL_MeshDeformer.cpp
@@ -47,17 +47,18 @@
 #include "STR_HashedString.h"
 #include "BLI_math.h"
 
-bool BL_MeshDeformer::Apply(RAS_IPolyMaterial *)
+bool BL_MeshDeformer::Apply(RAS_IPolyMaterial *UNUSED(polymat), RAS_MeshMaterial *UNUSED(meshmat))
 {
 	// only apply once per frame if the mesh is actually modified
 	if ((m_pMeshObject->GetModifiedFlag() & RAS_MeshObject::MESH_MODIFIED) &&
 		m_lastDeformUpdate != m_gameobj->GetLastFrame())
 	{
 		// For each material
-		for (list<RAS_MeshMaterial>::iterator mit = m_pMeshObject->GetFirstMaterial();
+		for (std::vector<RAS_MeshMaterial *>::iterator mit = m_pMeshObject->GetFirstMaterial();
 		     mit != m_pMeshObject->GetLastMaterial(); ++mit)
 		{
-			RAS_MeshSlot *slot = mit->m_slots[(void *)m_gameobj->getClientInfo()];
+			RAS_MeshMaterial *meshmat = *mit;
+			RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
 			if (!slot) {
 				continue;
 			}
@@ -116,7 +117,7 @@ void BL_MeshDeformer::RecalcNormals()
 	 * gives area-weight normals which often look better anyway, and use
 	 * GL_NORMALIZE so we don't have to do per vertex normalization either
 	 * since the GPU can do it faster */
-	list<RAS_MeshMaterial>::iterator mit;
+	std::vector<RAS_MeshMaterial *>::iterator mit;
 	size_t i;
 
 	/* set vertex normals to zero */
@@ -124,7 +125,8 @@ void BL_MeshDeformer::RecalcNormals()
 
 	/* add face normals to vertices. */
 	for (mit = m_pMeshObject->GetFirstMaterial(); mit != m_pMeshObject->GetLastMaterial(); ++mit) {
-		RAS_MeshSlot *slot = mit->m_slots[(void *)m_gameobj->getClientInfo()];
+		RAS_MeshMaterial *meshmat = *mit;
+		RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
 		if (!slot) {
 			continue;
 		}
@@ -181,7 +183,8 @@ void BL_MeshDeformer::RecalcNormals()
 
 	/* assign smooth vertex normals */
 	for (mit = m_pMeshObject->GetFirstMaterial(); mit != m_pMeshObject->GetLastMaterial(); ++mit) {
-		RAS_MeshSlot *slot = mit->m_slots[(void *)m_gameobj->getClientInfo()];
+		RAS_MeshMaterial *meshmat = *mit;
+		RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
 		if (!slot) {
 			continue;
 		}

--- a/source/gameengine/Converter/BL_MeshDeformer.h
+++ b/source/gameengine/Converter/BL_MeshDeformer.h
@@ -72,7 +72,7 @@ public:
 	virtual void SetSimulatedTime(double time)
 	{
 	}
-	virtual bool Apply(RAS_IPolyMaterial *mat);
+	virtual bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat);
 	virtual bool Update()
 	{
 		return false;

--- a/source/gameengine/Converter/BL_ModifierDeformer.cpp
+++ b/source/gameengine/Converter/BL_ModifierDeformer.cpp
@@ -221,7 +221,7 @@ bool BL_ModifierDeformer::Update(void)
 	return bShapeUpdate;
 }
 
-bool BL_ModifierDeformer::Apply(RAS_IPolyMaterial *mat)
+bool BL_ModifierDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat)
 {
 	if (!Update())
 		return false;

--- a/source/gameengine/Converter/BL_ModifierDeformer.h
+++ b/source/gameengine/Converter/BL_ModifierDeformer.h
@@ -86,7 +86,7 @@ public:
 	}
 
 	bool Update();
-	bool Apply(RAS_IPolyMaterial *mat);
+	virtual bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat);
 	void ForceUpdate()
 	{
 		m_lastModifierUpdate = -1.0;

--- a/source/gameengine/Converter/BL_SkinDeformer.cpp
+++ b/source/gameengine/Converter/BL_SkinDeformer.cpp
@@ -141,10 +141,10 @@ void BL_SkinDeformer::Relink(std::map<void *, void *>& map)
 	BL_MeshDeformer::Relink(map);
 }
 
-bool BL_SkinDeformer::Apply(RAS_IPolyMaterial *mat)
+bool BL_SkinDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat)
 {
 	// if we don't use a vertex array we does nothing.
-	if (!UseVertexArray() || !mat) {
+	if (!UseVertexArray() || !polymat || !meshmat) {
 		return false;
 	}
 
@@ -154,14 +154,13 @@ bool BL_SkinDeformer::Apply(RAS_IPolyMaterial *mat)
 		return false;
 	}
 
-	RAS_MeshMaterial *mmat = m_pMeshObject->GetMeshMaterial(mat);
-	RAS_MeshSlot *slot = mmat->m_slots[(void *)m_gameobj->getClientInfo()];
+	RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
 	if (!slot) {
 		return false;
 	}
 
 	RAS_IDisplayArray *array = slot->GetDisplayArray();
-	RAS_IDisplayArray *origarray = mmat->m_baseslot->GetDisplayArray();
+	RAS_IDisplayArray *origarray = meshmat->m_baseslot->GetDisplayArray();
 
 	/// Update vertex data from the original mesh.
 	array->UpdateFrom(origarray, modifiedFlag &

--- a/source/gameengine/Converter/BL_SkinDeformer.h
+++ b/source/gameengine/Converter/BL_SkinDeformer.h
@@ -77,11 +77,11 @@ public:
 	virtual ~BL_SkinDeformer();
 	bool Update();
 	bool UpdateInternal(bool shape_applied);
-	bool Apply(RAS_IPolyMaterial *polymat);
+	bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat);
 	bool UpdateBuckets()
 	{
 		// update the deformer and all the mesh slots; Apply() does it well, so just call it.
-		return Apply(NULL);
+		return Apply(NULL, NULL);
 	}
 	bool PoseUpdated()
 	{

--- a/source/gameengine/Converter/KX_BlenderSceneConverter.cpp
+++ b/source/gameengine/Converter/KX_BlenderSceneConverter.cpp
@@ -915,6 +915,11 @@ bool KX_BlenderSceneConverter::MergeScene(KX_Scene *to, KX_Scene *from)
 	std::map<KX_Scene *, std::vector<RAS_MeshObject *> >::iterator meshit = m_meshobjects.find(from);
 	if (meshit != m_meshobjects.end()) {
 		std::vector<RAS_MeshObject *> &meshlist = meshit->second;
+		// Generate mesh to material attribute's layers since the materials are constructed now.
+		for (std::vector<RAS_MeshObject *>::iterator it = meshlist.begin(), end = meshlist.end(); it != end; ++it) {
+			(*it)->GenerateAttribLayers();
+		}
+
 		std::vector<RAS_MeshObject *> &meshtolist = m_meshobjects[to];
 		meshtolist.insert(meshtolist.end(), meshlist.begin(), meshlist.end());
 		m_meshobjects.erase(meshit);

--- a/source/gameengine/Converter/KX_SoftBodyDeformer.cpp
+++ b/source/gameengine/Converter/KX_SoftBodyDeformer.cpp
@@ -62,7 +62,7 @@ void KX_SoftBodyDeformer::Relink(std::map<void *, void *>& map)
 	}
 }
 
-bool KX_SoftBodyDeformer::Apply(RAS_IPolyMaterial *polymat)
+bool KX_SoftBodyDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat)
 {
 	CcdPhysicsController *ctrl = (CcdPhysicsController *)m_gameobj->GetPhysicsController();
 	if (!ctrl)
@@ -72,24 +72,16 @@ bool KX_SoftBodyDeformer::Apply(RAS_IPolyMaterial *polymat)
 	if (!softBody)
 		return false;
 
-	//printf("apply\n");
-	RAS_MeshMaterial *mmat;
-	RAS_MeshSlot *slot;
-
 	// update the vertex in m_transverts
 	Update();
 
-	// The vertex cache can only be updated for this deformer:
-	// Duplicated objects with more than one ploymaterial (=multiple mesh slot per object)
-	// share the same mesh (=the same cache). As the rendering is done per polymaterial
-	// cycling through the objects, the entire mesh cache cannot be updated in one shot.
-	mmat = m_pMeshObject->GetMeshMaterial(polymat);
-	if (!mmat->m_slots[(void *)m_gameobj->getClientInfo()])
-		return true;
+	RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
+	if (!slot) {
+		return false;
+	}
 
-	slot = mmat->m_slots[(void *)m_gameobj->getClientInfo()];
 	RAS_IDisplayArray *array = slot->GetDisplayArray();
-	RAS_IDisplayArray *origarray = mmat->m_baseslot->GetDisplayArray();
+	RAS_IDisplayArray *origarray = meshmat->m_baseslot->GetDisplayArray();
 
 	btSoftBody::tNodeArray&   nodes(softBody->m_nodes);
 

--- a/source/gameengine/Converter/KX_SoftBodyDeformer.h
+++ b/source/gameengine/Converter/KX_SoftBodyDeformer.h
@@ -66,7 +66,7 @@ public:
 	}
 
 	virtual void Relink(std::map<void *, void *>& map);
-	virtual bool Apply(RAS_IPolyMaterial *polymat);
+	virtual bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat);
 	virtual bool Update()
 	{
 		m_bDynamic = true;

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -61,6 +61,7 @@ public:
 	virtual bool UsesLighting(RAS_IRasterizer *rasty) const;
 	virtual void GetRGBAColor(unsigned char *rgba) const;
 	virtual Scene *GetBlenderScene() const;
+	virtual SCA_IScene *GetScene() const;
 	virtual void ReleaseMaterial();
 
 	unsigned int *GetBlendFunc()
@@ -151,5 +152,7 @@ private:
 	// cleanup stuff
 	void OnExit();
 };
+
+bool ConvertPythonToMaterial(PyObject *value, KX_BlenderMaterial **material, bool py_none_ok, const char *error_prefix);
 
 #endif

--- a/source/gameengine/Ketsji/KX_MeshProxy.cpp
+++ b/source/gameengine/Ketsji/KX_MeshProxy.cpp
@@ -356,7 +356,7 @@ PyObject *KX_MeshProxy::PyReplaceMaterial(PyObject *args, PyObject *kwds)
 	PyObject *pymat;
 	KX_BlenderMaterial *mat;
 
-	if (!PyArg_ParseTuple(args, "iO:replaceMaterial", &matindex, &pymat) ||
+	if (!PyArg_ParseTuple(args, "hO:replaceMaterial", &matindex, &pymat) ||
 		!ConvertPythonToMaterial(pymat, &mat, false, "mesh.replaceMaterial(...): invalid material")) {
 		return NULL;
 	}

--- a/source/gameengine/Ketsji/KX_MeshProxy.cpp
+++ b/source/gameengine/Ketsji/KX_MeshProxy.cpp
@@ -154,9 +154,10 @@ PyObject *KX_MeshProxy::PyGetVertexArrayLength(PyObject *args, PyObject *kwds)
 	RAS_MeshMaterial *mmat = m_meshobj->GetMeshMaterial(matid); /* can be NULL*/
 
 	if (mmat) {
-		RAS_IPolyMaterial *mat = mmat->m_bucket->GetPolyMaterial();
-		if (mat)
-			length = m_meshobj->NumVertices(mat);
+		RAS_IDisplayArray *array = mmat->m_baseslot->GetDisplayArray();
+		if (array) {
+			length = array->GetVertexCount();
+		}
 	}
 
 	return PyLong_FromLong(length);
@@ -222,7 +223,7 @@ PyObject *KX_MeshProxy::PyTransform(PyObject *args, PyObject *kwds)
 
 	/* transform mesh verts */
 	unsigned int mit_index = 0;
-	for (list<RAS_MeshMaterial>::iterator mit = m_meshobj->GetFirstMaterial();
+	for (std::vector<RAS_MeshMaterial *>::iterator mit = m_meshobj->GetFirstMaterial();
 	     (mit != m_meshobj->GetLastMaterial());
 	     ++mit, ++mit_index)
 	{
@@ -236,7 +237,7 @@ PyObject *KX_MeshProxy::PyTransform(PyObject *args, PyObject *kwds)
 			continue;
 		}
 
-		RAS_MeshSlot *slot = mit->m_baseslot;
+		RAS_MeshSlot *slot = (*mit)->m_baseslot;
 		RAS_IDisplayArray *array = slot->GetDisplayArray();
 		ok = true;
 
@@ -296,7 +297,7 @@ PyObject *KX_MeshProxy::PyTransformUV(PyObject *args, PyObject *kwds)
 
 	/* transform mesh verts */
 	unsigned int mit_index = 0;
-	for (list<RAS_MeshMaterial>::iterator mit = m_meshobj->GetFirstMaterial();
+	for (std::vector<RAS_MeshMaterial *>::iterator mit = m_meshobj->GetFirstMaterial();
 	     (mit != m_meshobj->GetLastMaterial());
 	     ++mit, ++mit_index)
 	{
@@ -310,7 +311,7 @@ PyObject *KX_MeshProxy::PyTransformUV(PyObject *args, PyObject *kwds)
 			continue;
 		}
 
-		RAS_MeshSlot *slot = mit->m_baseslot;
+		RAS_MeshSlot *slot = (*mit)->m_baseslot;
 		RAS_IDisplayArray *array = slot->GetDisplayArray();
 		ok = true;
 
@@ -356,10 +357,10 @@ PyObject *KX_MeshProxy::pyattr_get_materials(void *self_v, const KX_PYATTRIBUTE_
 
 	PyObject *materials = PyList_New(tot);
 
-	list<RAS_MeshMaterial>::iterator mit = self->m_meshobj->GetFirstMaterial();
+	std::vector<RAS_MeshMaterial *>::iterator mit = self->m_meshobj->GetFirstMaterial();
 
 	for (i = 0; i < tot; mit++, i++) {
-		RAS_IPolyMaterial *polymat = mit->m_bucket->GetPolyMaterial();
+		RAS_IPolyMaterial *polymat = (*mit)->m_bucket->GetPolyMaterial();
 		KX_BlenderMaterial *mat = static_cast<KX_BlenderMaterial *>(polymat);
 		PyList_SET_ITEM(materials, i, mat->GetProxy());
 	}

--- a/source/gameengine/Ketsji/KX_MeshProxy.h
+++ b/source/gameengine/Ketsji/KX_MeshProxy.h
@@ -75,6 +75,7 @@ public:
 	KX_PYMETHOD(KX_MeshProxy, GetPolygon);
 	KX_PYMETHOD(KX_MeshProxy, Transform);
 	KX_PYMETHOD(KX_MeshProxy, TransformUV);
+	KX_PYMETHOD(KX_MeshProxy, ReplaceMaterial);
 
 	static PyObject *pyattr_get_materials(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_numMaterials(void *self, const KX_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -93,6 +93,11 @@ Scene *KX_TextMaterial::GetBlenderScene() const
 	return NULL;
 }
 
+SCA_IScene *KX_TextMaterial::GetScene() const
+{
+	return NULL;
+}
+
 bool KX_TextMaterial::UseInstancing() const
 {
 	return false;

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -47,6 +47,7 @@ public:
 	virtual Image *GetBlenderImage() const;
 	virtual MTexPoly *GetMTexPoly() const;
 	virtual Scene *GetBlenderScene() const;
+	virtual SCA_IScene *GetScene() const;
 	virtual bool UseInstancing() const;
 	virtual void ReleaseMaterial();
 

--- a/source/gameengine/Rasterizer/RAS_Deformer.h
+++ b/source/gameengine/Rasterizer/RAS_Deformer.h
@@ -46,6 +46,8 @@
 
 struct DerivedMesh;
 class RAS_MeshObject;
+class RAS_IPolyMaterial;
+class RAS_MeshMaterial;
 
 class RAS_Deformer
 {
@@ -60,7 +62,7 @@ public:
 
 	virtual ~RAS_Deformer() {}
 	virtual void Relink(std::map<void *, void *>& map) = 0;
-	virtual bool Apply(class RAS_IPolyMaterial *polymat)=0;
+	virtual bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat) = 0;
 	virtual bool Update(void)=0;
 	virtual bool UpdateBuckets(void)=0;
 	virtual RAS_Deformer *GetReplica()=0;

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -256,13 +256,20 @@ RAS_IRasterizer::StorageType RAS_DisplayArrayBucket::GetStorageType() const
 	return m_bucket->GetPolyMaterial()->GetStorageType();
 }
 
-void RAS_DisplayArrayBucket::SetAttribLayers(RAS_IRasterizer *rasty) const
+void RAS_DisplayArrayBucket::GenerateAttribLayers()
 {
-	if (!m_meshMaterial) {
+	if (!m_mesh) {
 		return;
 	}
 
-	rasty->SetAttribLayers(m_meshMaterial->m_attribLayers);
+	RAS_IPolyMaterial *polymat = m_bucket->GetPolyMaterial();
+	const STR_String *uvsname = m_mesh->GetUvsName();
+	m_attribLayers = polymat->GetAttribLayers(uvsname);
+}
+
+void RAS_DisplayArrayBucket::SetAttribLayers(RAS_IRasterizer *rasty) const
+{
+	rasty->SetAttribLayers(m_attribLayers);
 }
 
 void RAS_DisplayArrayBucket::RenderMeshSlots(const MT_Transform& cameratrans, RAS_IRasterizer *rasty)
@@ -370,3 +377,13 @@ void RAS_DisplayArrayBucket::RenderMeshSlotsInstancing(const MT_Transform& camer
 	rasty->UnbindPrimitives(storage, this);
 }
 
+void RAS_DisplayArrayBucket::ChangeMaterialBucket(RAS_MaterialBucket *bucket)
+{
+	m_bucket = bucket;
+
+	/// Regenerate the attribute's layers using the new material.
+	GenerateAttribLayers();
+
+	/// Free the storage info because the attribute's layer may changed.
+	DestructStorageInfo();
+}

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -206,7 +206,7 @@ void RAS_DisplayArrayBucket::UpdateActiveMeshSlots(RAS_IRasterizer *rasty)
 	for (RAS_DeformerList::iterator it = m_deformerList.begin(), end = m_deformerList.end(); it != end; ++it) {
 		RAS_Deformer *deformer = *it;
 
-		deformer->Apply(material);
+		deformer->Apply(material, m_meshMaterial);
 
 		// Test if one of deformers is dynamic.
 		if (deformer->IsDynamic()) {

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
@@ -33,7 +33,7 @@
 #define __RAS_DISPLAY_MATERIAL_BUCKET_H__
 
 #include "RAS_MeshSlot.h" // needed for RAS_MeshSlotList
-#include "RAS_IRasterizer.h" // needed for RAS_IRasterizer::StorageType
+#include "RAS_IRasterizer.h" // needed for RAS_IRasterizer::StorageType and RAS_IRasterizer::AttribLayerList
 
 #include "MT_Transform.h"
 
@@ -82,7 +82,11 @@ private:
 	 */
 	RAS_IStorageInfo *m_storageInfo;
 
+	/// The vertex buffer object containing all the datas used for the instancing rendering.
 	RAS_InstancingBuffer *m_instancingBuffer;
+
+	/// The attribute's layers used by the couple mesh material.
+	RAS_IRasterizer::AttribLayerList m_attribLayers;
 
 public:
 	RAS_DisplayArrayBucket(RAS_MaterialBucket *bucket, RAS_IDisplayArray *array, RAS_MeshObject *mesh, RAS_MeshMaterial *meshmat);
@@ -131,12 +135,20 @@ public:
 	void DestructStorageInfo();
 	RAS_IRasterizer::StorageType GetStorageType() const;
 
+	/** Generate the attribute's layers for the used mesh and material couple.
+	 * WARNING: Always call when shader in the material are valid.
+	 */
+	void GenerateAttribLayers();
+
 	void SetAttribLayers(RAS_IRasterizer *rasty) const;
 
 	/// Render all mesh slots for solid render.
 	void RenderMeshSlots(const MT_Transform& cameratrans, RAS_IRasterizer *rasty);
 	/// Render all mesh slots with geometry instancing render.
 	void RenderMeshSlotsInstancing(const MT_Transform& cameratrans, RAS_IRasterizer *rasty, bool alpha);
+
+	/// Replace the material bucket of this display array bucket by the one given.
+	void ChangeMaterialBucket(RAS_MaterialBucket *bucket);
 };
 
 typedef std::vector<RAS_DisplayArrayBucket *> RAS_DisplayArrayBucketList;

--- a/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
@@ -132,6 +132,7 @@ public:
 	virtual Image *GetBlenderImage() const = 0;
 	virtual MTexPoly *GetMTexPoly() const = 0;
 	virtual Scene *GetBlenderScene() const = 0;
+	virtual SCA_IScene *GetScene() const = 0;
 	virtual bool UseInstancing() const = 0;
 	virtual void ReleaseMaterial() = 0;
 	virtual void GetRGBAColor(unsigned char *rgba) const;

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
@@ -93,6 +93,11 @@ RAS_MeshSlot *RAS_MaterialBucket::AddMesh(RAS_MeshObject *mesh, RAS_MeshMaterial
 	return ms;
 }
 
+void RAS_MaterialBucket::AddMesh(RAS_MeshSlot *ms)
+{
+	m_meshSlots.push_back(ms);
+}
+
 RAS_MeshSlot *RAS_MaterialBucket::CopyMesh(RAS_MeshSlot *ms)
 {
 	RAS_MeshSlot *newMeshSlot = new RAS_MeshSlot(*ms);
@@ -273,4 +278,33 @@ void RAS_MaterialBucket::RemoveDisplayArrayBucket(RAS_DisplayArrayBucket *bucket
 RAS_DisplayArrayBucketList& RAS_MaterialBucket::GetDisplayArrayBucketList()
 {
 	return m_displayArrayBucketList;
+}
+
+void RAS_MaterialBucket::MoveDisplayArrayBucket(RAS_MeshMaterial *meshmat, RAS_MaterialBucket *bucket)
+{
+	for (RAS_DisplayArrayBucketList::iterator it = m_displayArrayBucketList.begin(), end = m_displayArrayBucketList.end();
+		it != end; ++it)
+	{
+		// In case of deformers, multiple display array bucket can use the same mesh and material.
+		RAS_DisplayArrayBucket *displayArrayBucket = *it;
+		if ((*it)->GetMeshMaterial() != meshmat) {
+			continue;
+		}
+
+		for (RAS_MeshSlotList::iterator it = m_meshSlots.begin(); it != m_meshSlots.end();) {
+			RAS_MeshSlot *ms = *it;
+			if (ms->m_displayArrayBucket == displayArrayBucket) {
+				ms->m_bucket = bucket;
+				bucket->AddMesh(ms);
+				it = m_meshSlots.erase(it);
+			}
+			else {
+				++it;
+			}
+		}
+
+		displayArrayBucket->ChangeMaterialBucket(bucket);
+		bucket->AddDisplayArrayBucket(displayArrayBucket);
+		RemoveDisplayArrayBucket(displayArrayBucket);
+	}
 }

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
@@ -282,29 +282,29 @@ RAS_DisplayArrayBucketList& RAS_MaterialBucket::GetDisplayArrayBucketList()
 
 void RAS_MaterialBucket::MoveDisplayArrayBucket(RAS_MeshMaterial *meshmat, RAS_MaterialBucket *bucket)
 {
-	for (RAS_DisplayArrayBucketList::iterator it = m_displayArrayBucketList.begin(); it != m_displayArrayBucketList.end();)
+	for (RAS_DisplayArrayBucketList::iterator dit = m_displayArrayBucketList.begin(); dit != m_displayArrayBucketList.end();)
 	{
 		// In case of deformers, multiple display array bucket can use the same mesh and material.
-		RAS_DisplayArrayBucket *displayArrayBucket = *it;
-		if ((*it)->GetMeshMaterial() != meshmat) {
-			++it;
+		RAS_DisplayArrayBucket *displayArrayBucket = *dit;
+		if (displayArrayBucket->GetMeshMaterial() != meshmat) {
+			++dit;
 			continue;
 		}
 
-		for (RAS_MeshSlotList::iterator it = m_meshSlots.begin(); it != m_meshSlots.end();) {
-			RAS_MeshSlot *ms = *it;
+		for (RAS_MeshSlotList::iterator mit = m_meshSlots.begin(); mit != m_meshSlots.end();) {
+			RAS_MeshSlot *ms = *mit;
 			if (ms->m_displayArrayBucket == displayArrayBucket) {
 				ms->m_bucket = bucket;
 				bucket->AddMesh(ms);
-				it = m_meshSlots.erase(it);
+				mit = m_meshSlots.erase(mit);
 			}
 			else {
-				++it;
+				++mit;
 			}
 		}
 
 		displayArrayBucket->ChangeMaterialBucket(bucket);
 		bucket->AddDisplayArrayBucket(displayArrayBucket);
-		it = m_displayArrayBucketList.erase(it);
+		dit = m_displayArrayBucketList.erase(dit);
 	}
 }

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
@@ -282,12 +282,12 @@ RAS_DisplayArrayBucketList& RAS_MaterialBucket::GetDisplayArrayBucketList()
 
 void RAS_MaterialBucket::MoveDisplayArrayBucket(RAS_MeshMaterial *meshmat, RAS_MaterialBucket *bucket)
 {
-	for (RAS_DisplayArrayBucketList::iterator it = m_displayArrayBucketList.begin(), end = m_displayArrayBucketList.end();
-		it != end; ++it)
+	for (RAS_DisplayArrayBucketList::iterator it = m_displayArrayBucketList.begin(); it != m_displayArrayBucketList.end();)
 	{
 		// In case of deformers, multiple display array bucket can use the same mesh and material.
 		RAS_DisplayArrayBucket *displayArrayBucket = *it;
 		if ((*it)->GetMeshMaterial() != meshmat) {
+			++it;
 			continue;
 		}
 
@@ -305,6 +305,6 @@ void RAS_MaterialBucket::MoveDisplayArrayBucket(RAS_MeshMaterial *meshmat, RAS_M
 
 		displayArrayBucket->ChangeMaterialBucket(bucket);
 		bucket->AddDisplayArrayBucket(displayArrayBucket);
-		RemoveDisplayArrayBucket(displayArrayBucket);
+		it = m_displayArrayBucketList.erase(it);
 	}
 }

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.h
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.h
@@ -68,6 +68,7 @@ public:
 
 	RAS_MeshSlot *AddMesh(RAS_MeshObject *mesh, RAS_MeshMaterial *meshmat, const RAS_TexVertFormat& format);
 	RAS_MeshSlot *CopyMesh(RAS_MeshSlot *ms);
+	void AddMesh(RAS_MeshSlot *ms);
 	void RemoveMesh(RAS_MeshSlot *ms);
 	/// Remove all mesh slot using the given mesh object.
 	void RemoveMeshObject(RAS_MeshObject *mesh);
@@ -81,6 +82,8 @@ public:
 	void RemoveDisplayArrayBucket(RAS_DisplayArrayBucket *bucket);
 
 	RAS_DisplayArrayBucketList& GetDisplayArrayBucketList();
+
+	void MoveDisplayArrayBucket(RAS_MeshMaterial *meshmat, RAS_MaterialBucket *bucket);
 
 private:
 	RAS_MeshSlotList m_meshSlots; // all the mesh slots

--- a/source/gameengine/Rasterizer/RAS_MeshMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_MeshMaterial.h
@@ -46,7 +46,7 @@ class RAS_MeshMaterial
 public:
 	RAS_MeshSlot *m_baseslot;
 	RAS_MaterialBucket *m_bucket;
-	/// The material index position in the mesh.
+	/// The blender material index position in the mesh.
 	unsigned int m_index;
 	RAS_IRasterizer::AttribLayerList m_attribLayers;
 

--- a/source/gameengine/Rasterizer/RAS_MeshMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_MeshMaterial.h
@@ -32,8 +32,6 @@
 #ifndef __RAS_MESH_MATERIAL_H__
 #define __RAS_MESH_MATERIAL_H__
 
-#include "RAS_IRasterizer.h" // For AttribLayerList.
-
 #include <map>
 #include <vector>
 
@@ -48,7 +46,6 @@ public:
 	RAS_MaterialBucket *m_bucket;
 	/// The blender material index position in the mesh.
 	unsigned int m_index;
-	RAS_IRasterizer::AttribLayerList m_attribLayers;
 
 	/// the KX_GameObject is used as a key here
 	std::map<void *, RAS_MeshSlot *> m_slots;

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -78,7 +78,7 @@ private:
 	void UpdateAabb();
 
 protected:
-	std::list<RAS_MeshMaterial> m_materials;
+	std::vector<RAS_MeshMaterial *> m_materials;
 	Mesh *m_mesh;
 
 public:
@@ -92,12 +92,10 @@ public:
 	const STR_String& GetTextureName(unsigned int matid);
 
 	RAS_MeshMaterial *GetMeshMaterial(unsigned int matid);
-	RAS_MeshMaterial *GetMeshMaterial(RAS_IPolyMaterial *mat);
-	/// Return the material position in the mesh, like in blender.
-	int GetBlenderMaterialId(RAS_IPolyMaterial *mat);
+	RAS_MeshMaterial *GetMeshMaterialBlenderIndex(unsigned int index);
 
-	std::list<RAS_MeshMaterial>::iterator GetFirstMaterial();
-	std::list<RAS_MeshMaterial>::iterator GetLastMaterial();
+	std::vector<RAS_MeshMaterial *>::iterator GetFirstMaterial();
+	std::vector<RAS_MeshMaterial *>::iterator GetLastMaterial();
 
 	// name
 	void SetName(const char *name);
@@ -131,12 +129,12 @@ public:
 	}
 
 	// mesh construction
-	void AddMaterial(RAS_MaterialBucket *bucket, unsigned int index, const RAS_TexVertFormat& format);
-	void AddLine(RAS_MaterialBucket *bucket, unsigned int v1, unsigned int v2);
-	virtual RAS_Polygon *AddPolygon(RAS_MaterialBucket *bucket, int numverts, unsigned int indices[4],
+	RAS_MeshMaterial *AddMaterial(RAS_MaterialBucket *bucket, unsigned int index, const RAS_TexVertFormat& format);
+	void AddLine(RAS_MeshMaterial *meshmat, unsigned int v1, unsigned int v2);
+	virtual RAS_Polygon *AddPolygon(RAS_MeshMaterial *meshmat, int numverts, unsigned int indices[4],
 									bool visible, bool collider, bool twoside);
 	virtual unsigned int AddVertex(
-				RAS_MaterialBucket *bucket,
+				RAS_MeshMaterial *meshmat,
 				const MT_Vector3& xyz,
 				const MT_Vector2 * const uvs,
 				const MT_Vector4& tangent,
@@ -146,7 +144,6 @@ public:
 				const unsigned int origindex);
 
 	// vertex and polygon acces
-	int NumVertices(RAS_IPolyMaterial *mat);
 	RAS_ITexVert *GetVertex(unsigned int matid, unsigned int index);
 	const float *GetVertexLocation(unsigned int orig_index);
 

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -68,6 +68,8 @@ private:
 	STR_String m_name;
 	static STR_String s_emptyname;
 
+	STR_String m_uvsName[RAS_Texture::MaxUnits];
+
 	std::vector<RAS_Polygon *> m_polygons;
 
 	/* polygon sorting */
@@ -83,7 +85,7 @@ protected:
 
 public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
-	RAS_MeshObject(Mesh *mesh);
+	RAS_MeshObject(Mesh *mesh, STR_String uvsname[RAS_Texture::MaxUnits]);
 	virtual ~RAS_MeshObject();
 
 	// materials
@@ -98,7 +100,6 @@ public:
 	std::vector<RAS_MeshMaterial *>::iterator GetLastMaterial();
 
 	// name
-	void SetName(const char *name);
 	STR_String& GetName();
 
 	/// Modification categories.
@@ -156,7 +157,13 @@ public:
 	void RemoveFromBuckets(void *clientobj);
 	void EndConversion();
 
-	void GenerateAttribLayers(const STR_String uvsname[RAS_Texture::MaxUnits]);
+	/// Return the list of Uvs names.
+	const STR_String *GetUvsName() const;
+
+	/** Generate attribute's layers for every material use by this mesh.
+	 * WARNING: Always call when shader in the material are valid.
+	 */
+	void GenerateAttribLayers();
 
 	// polygon sorting by Z for alpha
 	void SortPolygons(RAS_MeshSlot *ms, const MT_Transform &transform);

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1344,7 +1344,7 @@ void RAS_OpenGLRasterizer::DrawDerivedMesh(RAS_MeshSlot *ms)
 	if (current_polymat->GetFlag() & RAS_BLENDERGLSL) {
 		// GetMaterialIndex return the original mface material index,
 		// increment by 1 to match what derived mesh is doing
-		current_blmat_nr = current_mesh->GetBlenderMaterialId(current_bucket->GetPolyMaterial()) + 1;
+		current_blmat_nr = current_ms->m_meshMaterial->m_index + 1;
 		// For GLSL we need to retrieve the GPU material attribute
 		Material* blmat = current_polymat->GetBlenderMaterial();
 		Scene* blscene = current_polymat->GetBlenderScene();
@@ -1362,7 +1362,7 @@ void RAS_OpenGLRasterizer::DrawDerivedMesh(RAS_MeshSlot *ms)
 		GPU_set_material_alpha_blend(current_blend_mode);
 	} else {
 		//ms->m_pDerivedMesh->drawMappedFacesTex(ms->m_pDerivedMesh, CheckTexfaceDM, mcol);
-		current_blmat_nr = current_mesh->GetBlenderMaterialId(current_bucket->GetPolyMaterial());
+		current_blmat_nr = current_ms->m_meshMaterial->m_index;
 		current_image = current_polymat->GetBlenderImage();
 
 		if (wireframe) {


### PR DESCRIPTION
This branch allow the user to replace a material by calling in python:
```
mesh.replaceMaterial(index, material)
```

Then the material in the slot `index`will be replaced by the material `material`.

When the material is replaced the RAS_DisplayArrayBucket are moved to the RAS_BucketMaterial of the new material, all the mesh slot in this DAB reset their pointer to the material bucket and the attribute's layers are recomputed to follow the new material.

@lordloki, @DCubix, @sdfgeoff: Do you agree with the API and the patch ? Could you make some test to find any possible bugs ? Thanks in advance.