### PR TITLE
UPBGE: Add support of rolling friction.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_material.py
+++ b/release/scripts/startup/bl_ui/properties_material.py
@@ -712,9 +712,12 @@ class MATERIAL_PT_physics(MaterialButtonsPanel, Panel):
         phys = context.material.physics  # don't use node material
 
         split = layout.split()
-        row = split.row()
-        row.prop(phys, "friction")
-        row.prop(phys, "elasticity", slider=True)
+        col = split.column()
+        col.prop(phys, "friction")
+        col.prop(phys, "rolling_friction")
+
+        col = split.column()
+        col.prop(phys, "elasticity", slider=True)
 
         row = layout.row()
         row.label(text="Force Field:")

--- a/source/blender/makesdna/DNA_material_types.h
+++ b/source/blender/makesdna/DNA_material_types.h
@@ -172,9 +172,9 @@ typedef struct Material {
 	struct PreviewImage *preview;
 
 	/* dynamic properties */
-	float friction, fh, reflect;
+	float friction, rolling_friction, fh, reflect;
 	float fhdist, xyfrict;
-	short dynamode, pad2;
+	short dynamode, pad2[3];
 
 	/* subsurface scattering */
 	float sss_radius[3], sss_col[3];

--- a/source/blender/makesrna/intern/rna_material.c
+++ b/source/blender/makesrna/intern/rna_material.c
@@ -1783,11 +1783,16 @@ static void rna_def_material_physics(BlenderRNA *brna)
 	RNA_def_struct_sdna(srna, "Material");
 	RNA_def_struct_nested(brna, srna, "Material");
 	RNA_def_struct_ui_text(srna, "Material Physics", "Physics settings for a Material data-block");
-	
+
 	prop = RNA_def_property(srna, "friction", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "friction");
 	RNA_def_property_range(prop, 0, 100);
 	RNA_def_property_ui_text(prop, "Friction", "Coulomb friction coefficient, when inside the physics distance area");
+
+	prop = RNA_def_property(srna, "rolling_friction", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "rolling_friction");
+	RNA_def_property_range(prop, 0, 100);
+	RNA_def_property_ui_text(prop, "Rolling Friction", "Coulomb friction coefficient of rounded shapes");
 
 	prop = RNA_def_property(srna, "elasticity", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "reflect");

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -761,7 +761,8 @@ static PHY_MaterialProps *CreateMaterialFromBlenderObject(struct Object* blender
 		BLI_assert(0.0f <= blendermat->reflect && blendermat->reflect <= 1.0f);
 	
 		materialProps->m_restitution = blendermat->reflect;
-		materialProps->m_friction = blendermat->friction;
+		materialProps->m_friction = blendermat->friction; 
+		materialProps->m_rollingFriction = blendermat->rolling_friction;
 		materialProps->m_fh_spring = blendermat->fh;
 		materialProps->m_fh_damping = blendermat->xyfrict;
 		materialProps->m_fh_distance = blendermat->fhdist;
@@ -771,6 +772,7 @@ static PHY_MaterialProps *CreateMaterialFromBlenderObject(struct Object* blender
 		//give some defaults
 		materialProps->m_restitution = 0.f;
 		materialProps->m_friction = 0.5;
+		materialProps->m_rollingFriction = 0.0f;
 		materialProps->m_fh_spring = 0.f;
 		materialProps->m_fh_damping = 0.f;
 		materialProps->m_fh_distance = 0.f;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -529,6 +529,7 @@ void CcdPhysicsController::CreateRigidbody()
 	rbci.m_linearDamping = m_cci.m_linearDamping;
 	rbci.m_angularDamping = m_cci.m_angularDamping;
 	rbci.m_friction = m_cci.m_friction;
+	rbci.m_rollingFriction = m_cci.m_rollingFriction;
 	rbci.m_restitution = m_cci.m_restitution;
 	m_object = new btRigidBody(rbci);
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -252,6 +252,7 @@ struct CcdConstructionInfo {
 		m_clamp_angvel_max(0.0f),
 		m_restitution(0.1f),
 		m_friction(0.5f),
+		m_rollingFriction(0.0f),
 		m_linearDamping(0.1f),
 		m_angularDamping(0.1f),
 		m_margin(0.06f),
@@ -321,6 +322,7 @@ struct CcdConstructionInfo {
 	btScalar m_clamp_angvel_max;
 	btScalar m_restitution;
 	btScalar m_friction;
+	btScalar m_rollingFriction;
 	btScalar m_linearDamping;
 	btScalar m_angularDamping;
 	btScalar m_margin;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -3285,6 +3285,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 	ci.m_collisionShape = bm;
 	ci.m_shapeInfo = shapeInfo;
 	ci.m_friction = smmaterial->m_friction;//tweak the friction a bit, so the default 0.5 works nice
+	ci.m_rollingFriction = smmaterial->m_rollingFriction;
 	ci.m_restitution = smmaterial->m_restitution;
 	ci.m_physicsEnv = this;
 	// drag / damping is inverted

--- a/source/gameengine/Physics/Common/PHY_Pro.h
+++ b/source/gameengine/Physics/Common/PHY_Pro.h
@@ -58,6 +58,7 @@ struct PHY_ShapeProps {
 struct PHY_MaterialProps {
 	MT_Scalar m_restitution; // restitution of energie after a collision 0 = inelastic, 1 = elastic
 	MT_Scalar m_friction; // Coulomb friction (= ratio between the normal en maximum friction force)
+	MT_Scalar m_rollingFriction; // Frction used for rounded shapes.
 	MT_Scalar m_fh_spring; // Spring constant (both linear and angular)
 	MT_Scalar m_fh_damping; // Damping factor (linear and angular) in range [0, 1]
 	MT_Scalar m_fh_distance; // The range above the surface where Fh is active.


### PR DESCRIPTION
Rolling friction is a friction value used of rounded shapes
when only one collision contact point exists.
It slowdown the rotation of a sphere rolling in a plane.

This value is exposed in the UI under the name "Rolling Friction"
between 0 and 100.

Test file: http://pasteall.org/blend/index.php?id=43841