### PR TITLE
KX_FontObject text measure

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
@@ -50,3 +50,10 @@ base class --- :class:`KX_GameObject`
 
       :type: float (0.0001 to 40.0)
 
+   .. method:: getTextSize()
+
+      Gets the size (width and height) of the current text in Blender Units.
+
+      :return: A tuple containing the width and the height.
+      :rtype: tuple(2)
+

--- a/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_FontObject.rst
@@ -50,10 +50,9 @@ base class --- :class:`KX_GameObject`
 
       :type: float (0.0001 to 40.0)
 
-   .. method:: getTextSize()
+   .. attribute:: textDimensions
 
       Gets the size (width and height) of the current text in Blender Units.
 
-      :return: A tuple containing the width and the height.
-      :rtype: tuple(2)
+      :type: :class:`mathutils.Vector`
 

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -108,28 +108,28 @@ KX_FontObject::~KX_FontObject()
 
 const MT_Vector2 KX_FontObject::GetTextDimensions()
 {
-	float width = 0, height = 0;
+	MT_Vector2 dimensions;
 
 	for (std::vector<STR_String>::iterator it = m_text.begin();
 		 it != m_text.end(); ++it)
 	{
-		float w = 0, h = 0;
+		float w = 0.0f, h = 0.0f;
 		STR_String text = (*it);
 
 		BLF_width_and_height(m_fontid, text.ReadPtr(), text.Length(), &w, &h);
-		width = std::max(width, w);
-		height += h + m_line_spacing;
+		dimensions.x() = std::max(dimensions.x(), w);
+		dimensions.y() += h + m_line_spacing;
 	}
 
 	// XXX: Quick hack to convert the size to BU
-	width /= 10;
-	height /= 10;
+	dimensions /= 10.0f;
 
 	// Scale the width and height by the object's scale
 	MT_Vector3 scale = NodeGetLocalScaling();
-	width *= scale.x();
-	height *= scale.y();
-	return MT_Vector2(width, height);
+	dimensions.x() *= scale.x();
+	dimensions.y() *= scale.y();
+
+	return dimensions;
 }
 
 CValue *KX_FontObject::GetReplica()

--- a/source/gameengine/Ketsji/KX_FontObject.h
+++ b/source/gameengine/Ketsji/KX_FontObject.h
@@ -45,6 +45,8 @@ public:
 
 	virtual ~KX_FontObject();
 
+	MT_Vector2 GetTextSize();
+
 	virtual void AddMeshUser();
 	virtual void UpdateBuckets();
 
@@ -79,6 +81,8 @@ protected:
 #ifdef WITH_PYTHON
 	static PyObject *pyattr_get_text(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_text(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+
+	KX_PYMETHOD_NOARGS(KX_FontObject, GetTextSize)
 #endif
 };
 

--- a/source/gameengine/Ketsji/KX_FontObject.h
+++ b/source/gameengine/Ketsji/KX_FontObject.h
@@ -45,7 +45,7 @@ public:
 
 	virtual ~KX_FontObject();
 
-	MT_Vector2 GetTextSize();
+	const MT_Vector2 GetTextDimensions();
 
 	virtual void AddMeshUser();
 	virtual void UpdateBuckets();
@@ -81,8 +81,7 @@ protected:
 #ifdef WITH_PYTHON
 	static PyObject *pyattr_get_text(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_text(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-
-	KX_PYMETHOD_NOARGS(KX_FontObject, GetTextSize)
+	static PyObject *pyattr_get_text_dimensions(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 #endif
 };
 


### PR DESCRIPTION
	Add the possibility to get the width and the height
	of the current text in a KX_FontObject in Blender Units.

This is useful for text alignment like centering, justifying, etc...
Just do `KX_FontObject.textDimensions` and it will return a Vector of size 2 containing the width and the height.

Demo: http://pasteall.org/blend/index.php?id=43868