### PR TITLE
Pass rendered camera to scene.pre_draw/pre_draw_setup callbacks.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -127,7 +127,7 @@ base class --- :class:`PyObjectPlus`
 
    .. attribute:: pre_draw
 
-      A list of callables to be run before the render step.
+      A list of callables to be run before the render step. The callbacks can take as argument the rendered camera.
 
       :type: list
 
@@ -139,7 +139,8 @@ base class --- :class:`PyObjectPlus`
 
    .. attribute:: pre_draw_setup
 
-      A list of callables to be run before the drawing setup (i.e., before the model view and projection matrices are computed).
+      A list of callables to be run before the drawing setup (i.e., before the model view and projection matrices are computed). 
+      The callbacks can take as argument the rendered camera.
 
       :type: list
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -891,7 +891,7 @@ void KX_KetsjiEngine::RenderFrame(KX_Scene *scene, KX_Camera *cam, unsigned shor
 	KX_SetActiveScene(scene);
 
 #ifdef WITH_PYTHON
-	scene->RunDrawingCallbacks(scene->GetPreDrawSetupCB());
+	scene->RunDrawingCallbacks(KX_Scene::PRE_DRAW_SETUP, cam);
 #endif
 
 	GetSceneViewport(scene, cam, area, viewport);
@@ -1037,7 +1037,7 @@ void KX_KetsjiEngine::RenderFrame(KX_Scene *scene, KX_Camera *cam, unsigned shor
 #ifdef WITH_PYTHON
 	PHY_SetActiveEnvironment(scene->GetPhysicsEnvironment());
 	// Run any pre-drawing python callbacks
-	scene->RunDrawingCallbacks(scene->GetPreDrawCB());
+	scene->RunDrawingCallbacks(KX_Scene::PRE_DRAW, cam);
 #endif
 
 	scene->RenderBuckets(camtrans, m_rasterizer);
@@ -1065,7 +1065,10 @@ void KX_KetsjiEngine::PostRenderScene(KX_Scene *scene, unsigned short target)
 
 #ifdef WITH_PYTHON
 	PHY_SetActiveEnvironment(scene->GetPhysicsEnvironment());
-	scene->RunDrawingCallbacks(scene->GetPostDrawCB());
+	/* We can't deduce what camera should be passed to the python callbacks
+	 * because the post draw callbacks are per scenes and not per cameras.
+	 */
+	scene->RunDrawingCallbacks(KX_Scene::POST_DRAW, NULL);
 
 	// Python draw callback can also call debug draw functions, so we have to clear debug shapes.
 	m_rasterizer->FlushDebugShapes(scene);

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -100,13 +100,20 @@ class KX_ObstacleSimulation;
  * */
 class KX_Scene : public CValue, public SCA_IScene
 {
+public:
+	enum DrawingCallbackType {
+		PRE_DRAW = 0,
+		POST_DRAW,
+		PRE_DRAW_SETUP,
+		MAX_DRAW_CALLBACK
+	};
+
+private:
 	Py_Header
 
 #ifdef WITH_PYTHON
 	PyObject*	m_attr_dict;
-	PyObject*	m_draw_call_pre;
-	PyObject*	m_draw_call_post;
-	PyObject*	m_draw_setup_call_pre;
+	PyObject*	m_drawCallbacks[MAX_DRAW_CALLBACK];
 #endif
 
 	struct CullingInfo {
@@ -585,11 +592,7 @@ public:
 	/**
 	 * Run the registered python drawing functions.
 	 */
-	void RunDrawingCallbacks(PyObject *cb_list);
-	
-	PyObject *GetPreDrawCB() { return m_draw_call_pre; }
-	PyObject *GetPostDrawCB() { return m_draw_call_post; }
-	PyObject *GetPreDrawSetupCB() { return m_draw_setup_call_pre; }
+	void RunDrawingCallbacks(DrawingCallbackType callbackType, KX_Camera *camera);
 #endif
 
 	/**


### PR DESCRIPTION
Previously the user was able to altera	te rendering datas through
the callbacks scene.pre_draw/post_draw/pre_draw_setup. But he
wasn't able to know which camera was used when this callbacks
was called in case of multiple viewports.
Getting this info can help on setting an UI with a more modular
camera viewport management.

To solve this issue the scenes callbacks, exepted post_draw because
this one is not per camera, take as optional argument the current
rendered camera.

Internally the function KX_Scene::RunDrawingCallbacks takes
as first argument an enumeration coresponding to the callbacks list
instead of the callbacks list previously. This modification allow
to remove the two getter to the python callbacks list from
KX_Scene.

Example file: http://pasteall.org/blend/index.php?id=43884
In this file we can determine which viewport is currently rendered by the camera name and then decide of the world horizon color.