### PR TITLE
Bounding box refactor and per array modification flag.

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -82,6 +82,7 @@
 #include "RAS_Polygon.h"
 #include "RAS_TexVert.h"
 #include "RAS_BucketManager.h"
+#include "RAS_BoundingBoxManager.h"
 #include "RAS_IPolygonMaterial.h"
 #include "KX_BlenderMaterial.h"
 #include "KX_CubeMapManager.h"
@@ -708,7 +709,7 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	// keep meshobj->m_sharedvertex_map for reinstance phys mesh.
 	// 2.49a and before it did: meshobj->m_sharedvertex_map.clear();
 	// but this didnt save much ram. - Campbell
-	meshobj->EndConversion();
+	meshobj->EndConversion(scene->GetBoundingBoxManager());
 
 	// pre calculate texture generation
 	// However, we want to delay this if we're libloading so we can make sure we have the right scene.
@@ -1793,8 +1794,10 @@ void BL_ConvertBlenderObjects(struct Main* maggie,
 			// AABB Box : min/max.
 			MT_Vector3 aabbMin;
 			MT_Vector3 aabbMax;
+			// Get the mesh bounding box for none deformer.
+			RAS_BoundingBox *boundingBox = meshobj->GetBoundingBox();
 			// Get the AABB.
-			meshobj->GetAabb(aabbMin, aabbMax);
+			boundingBox->GetAabb(aabbMin, aabbMax);
 			gameobj->SetBoundsAabb(aabbMin, aabbMax);
 		}
 		else if (gameobj->GetMeshCount() > 0) {

--- a/source/gameengine/Converter/BL_DeformableGameObject.cpp
+++ b/source/gameengine/Converter/BL_DeformableGameObject.cpp
@@ -32,8 +32,10 @@
 
 #include "BL_DeformableGameObject.h"
 #include "BL_ShapeDeformer.h"
+#include "RAS_MeshObject.h"
 #include "RAS_MeshUser.h"
 #include "RAS_MaterialBucket.h"
+#include "RAS_BoundingBoxManager.h"
 
 
 BL_DeformableGameObject::~BL_DeformableGameObject()
@@ -107,6 +109,8 @@ void BL_DeformableGameObject::SetDeformer(class RAS_Deformer* deformer)
 		for (RAS_MeshSlotList::iterator it = meshSlots.begin(), end = meshSlots.end(); it != end; ++it) {
 			(*it)->SetDeformer(deformer);
 		}
+		RAS_BoundingBox *boundingBox = (m_pDeformer) ? m_pDeformer->GetBoundingBox() : m_meshes[0]->GetBoundingBox();
+		m_meshUser->SetBoundingBox(boundingBox);
 	}
 }
 

--- a/source/gameengine/Converter/BL_DeformableGameObject.h
+++ b/source/gameengine/Converter/BL_DeformableGameObject.h
@@ -38,8 +38,7 @@
 
 #include "DNA_mesh_types.h"
 #include "KX_GameObject.h"
-#include "BL_MeshDeformer.h"
-#include "KX_SoftBodyDeformer.h"
+#include "RAS_Deformer.h"
 #include <vector>
 
 struct Key;

--- a/source/gameengine/Converter/BL_MeshDeformer.cpp
+++ b/source/gameengine/Converter/BL_MeshDeformer.cpp
@@ -50,9 +50,7 @@
 bool BL_MeshDeformer::Apply(RAS_IPolyMaterial *UNUSED(polymat), RAS_MeshMaterial *UNUSED(meshmat))
 {
 	// only apply once per frame if the mesh is actually modified
-	if ((m_pMeshObject->GetModifiedFlag() & RAS_MeshObject::MESH_MODIFIED) &&
-		m_lastDeformUpdate != m_gameobj->GetLastFrame())
-	{
+	if (m_lastDeformUpdate != m_gameobj->GetLastFrame()) {
 		// For each material
 		for (std::vector<RAS_MeshMaterial *>::iterator mit = m_pMeshObject->GetFirstMaterial();
 		     mit != m_pMeshObject->GetLastMaterial(); ++mit)
@@ -64,6 +62,9 @@ bool BL_MeshDeformer::Apply(RAS_IPolyMaterial *UNUSED(polymat), RAS_MeshMaterial
 			}
 
 			RAS_IDisplayArray *array = slot->GetDisplayArray();
+			if (array->GetModifiedFlag() == RAS_IDisplayArray::NONE_MODIFIED) {
+				continue;
+			}
 
 			//	For each vertex
 			for (unsigned int i = 0, size = array->GetVertexCount(); i < size; ++i) {

--- a/source/gameengine/Converter/BL_MeshDeformer.cpp
+++ b/source/gameengine/Converter/BL_MeshDeformer.cpp
@@ -92,6 +92,7 @@ BL_MeshDeformer::~BL_MeshDeformer()
 
 void BL_MeshDeformer::ProcessReplica()
 {
+	RAS_Deformer::ProcessReplica();
 	m_transverts = NULL;
 	m_transnors = NULL;
 	m_tvtot = 0;

--- a/source/gameengine/Converter/BL_MeshDeformer.h
+++ b/source/gameengine/Converter/BL_MeshDeformer.h
@@ -33,6 +33,8 @@
 #define __BL_MESHDEFORMER_H__
 
 #include "RAS_Deformer.h"
+#include "RAS_BoundingBoxManager.h"
+#include "BL_DeformableGameObject.h"
 #include "DNA_object_types.h"
 #include "DNA_key_types.h"
 #include "MT_Vector3.h"
@@ -66,6 +68,9 @@ public:
 		m_gameobj(gameobj),
 		m_lastDeformUpdate(-1.0)
 	{
+		KX_Scene *scene = m_gameobj->GetScene();
+		RAS_BoundingBoxManager *boundingBoxManager = scene->GetBoundingBoxManager();
+		m_boundingBox = boundingBoxManager->CreateBoundingBox();
 	}
 
 	virtual ~BL_MeshDeformer();

--- a/source/gameengine/Converter/BL_ModifierDeformer.cpp
+++ b/source/gameengine/Converter/BL_ModifierDeformer.cpp
@@ -38,6 +38,7 @@
 #include "STR_HashedString.h"
 #include "RAS_IPolygonMaterial.h"
 #include "RAS_MeshObject.h"
+#include "RAS_BoundingBox.h"
 #include "PHY_IGraphicController.h"
 
 #include "DNA_armature_types.h"
@@ -201,8 +202,7 @@ bool BL_ModifierDeformer::Update(void)
 				float min[3], max[3];
 				INIT_MINMAX(min, max);
 				m_dm->getMinMax(m_dm, min, max);
-				m_aabbMin = MT_Vector3(min);
-				m_aabbMax = MT_Vector3(max);
+				m_boundingBox->SetAabb(MT_Vector3(min), MT_Vector3(max));
 			}
 		}
 		m_lastModifierUpdate = m_gameobj->GetLastFrame();
@@ -218,6 +218,7 @@ bool BL_ModifierDeformer::Update(void)
 			slot->m_pDerivedMesh = m_dm;
 		}
 	}
+
 	return bShapeUpdate;
 }
 

--- a/source/gameengine/Converter/BL_SkinDeformer.cpp
+++ b/source/gameengine/Converter/BL_SkinDeformer.cpp
@@ -148,12 +148,6 @@ bool BL_SkinDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshma
 		return false;
 	}
 
-	const short modifiedFlag = m_pMeshObject->GetModifiedFlag();
-	// No modifications ?
-	if (modifiedFlag == 0) {
-		return false;
-	}
-
 	RAS_MeshSlot *slot = meshmat->m_slots[(void *)m_gameobj->getClientInfo()];
 	if (!slot) {
 		return false;
@@ -162,11 +156,17 @@ bool BL_SkinDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshma
 	RAS_IDisplayArray *array = slot->GetDisplayArray();
 	RAS_IDisplayArray *origarray = meshmat->m_baseslot->GetDisplayArray();
 
+	const short modifiedFlag = origarray->GetModifiedFlag();
+	// No modifications ?
+	if (modifiedFlag == RAS_IDisplayArray::NONE_MODIFIED) {
+		return false;
+	}
+
 	/// Update vertex data from the original mesh.
 	array->UpdateFrom(origarray, modifiedFlag &
-					 (RAS_MeshObject::TANGENT_MODIFIED |
-					  RAS_MeshObject::UVS_MODIFIED |
-					  RAS_MeshObject::COLORS_MODIFIED));
+					 (RAS_IDisplayArray::TANGENT_MODIFIED |
+					  RAS_IDisplayArray::UVS_MODIFIED |
+					  RAS_IDisplayArray::COLORS_MODIFIED));
 
 	// We do everything in UpdateInternal() now so we can thread it.
 	// All that is left is telling the rasterizer if we've changed the mesh

--- a/source/gameengine/Converter/BL_SkinDeformer.cpp
+++ b/source/gameengine/Converter/BL_SkinDeformer.cpp
@@ -42,6 +42,7 @@
 #include "RAS_IPolygonMaterial.h"
 #include "RAS_DisplayArray.h"
 #include "RAS_MeshObject.h"
+#include "RAS_BoundingBox.h"
 
 //#include "BL_ArmatureController.h"
 #include "BL_DeformableGameObject.h"
@@ -316,6 +317,10 @@ void BL_SkinDeformer::UpdateTransverts()
 	size_t nmat, imat;
 	bool first = true;
 	if (m_transverts) {
+		// AABB Box : min/max.
+		MT_Vector3 aabbMin;
+		MT_Vector3 aabbMax;
+
 		// the vertex cache is unique to this deformer, no need to update it
 		// if it wasn't updated! We must update all the materials at once
 		// because we will not get here again for the other material
@@ -346,19 +351,21 @@ void BL_SkinDeformer::UpdateTransverts()
 
 				// For the first vertex of the mesh, only initialize AABB.
 				if (first) {
-					m_aabbMin = m_aabbMax = vertpos;
+					aabbMin = aabbMax = vertpos;
 					first = false;
 				}
 				else {
-					m_aabbMin.x() = std::min(m_aabbMin.x(), vertpos.x());
-					m_aabbMin.y() = std::min(m_aabbMin.y(), vertpos.y());
-					m_aabbMin.z() = std::min(m_aabbMin.z(), vertpos.z());
-					m_aabbMax.x() = std::max(m_aabbMax.x(), vertpos.x());
-					m_aabbMax.y() = std::max(m_aabbMax.y(), vertpos.y());
-					m_aabbMax.z() = std::max(m_aabbMax.z(), vertpos.z());
+					aabbMin.x() = std::min(aabbMin.x(), vertpos.x());
+					aabbMin.y() = std::min(aabbMin.y(), vertpos.y());
+					aabbMin.z() = std::min(aabbMin.z(), vertpos.z());
+					aabbMax.x() = std::max(aabbMax.x(), vertpos.x());
+					aabbMax.y() = std::max(aabbMax.y(), vertpos.y());
+					aabbMax.z() = std::max(aabbMax.z(), vertpos.z());
 				}
 			}
 		}
+
+		m_boundingBox->SetAabb(aabbMin, aabbMax);
 
 		if (m_copyNormals)
 			m_copyNormals = false;

--- a/source/gameengine/Converter/KX_SoftBodyDeformer.cpp
+++ b/source/gameengine/Converter/KX_SoftBodyDeformer.cpp
@@ -134,10 +134,10 @@ bool KX_SoftBodyDeformer::Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *me
 		}
 	}
 
-	array->UpdateFrom(origarray, m_pMeshObject->GetModifiedFlag() &
-					 (RAS_MeshObject::TANGENT_MODIFIED |
-					  RAS_MeshObject::UVS_MODIFIED |
-					  RAS_MeshObject::COLORS_MODIFIED));
+	array->UpdateFrom(origarray, origarray->GetModifiedFlag() &
+					 (RAS_IDisplayArray::TANGENT_MODIFIED |
+					  RAS_IDisplayArray::UVS_MODIFIED |
+					  RAS_IDisplayArray::COLORS_MODIFIED));
 
 	return true;
 }

--- a/source/gameengine/Converter/KX_SoftBodyDeformer.h
+++ b/source/gameengine/Converter/KX_SoftBodyDeformer.h
@@ -37,10 +37,10 @@
 #endif
 
 #include "RAS_Deformer.h"
+#include "RAS_BoundingBoxManager.h"
 #include "BL_DeformableGameObject.h"
 #include <vector>
 
-class BL_DeformableGameObject;
 class RAS_MeshObject;
 class RAS_IPolyMaterial;
 
@@ -51,14 +51,17 @@ class KX_SoftBodyDeformer : public RAS_Deformer
 	/** Set to true to request an AABB update in Apply(mat).
 	 * Used to compute a fully AABB and not for only one material.
 	 */
-	bool m_needUpdateAABB;
+	bool m_needUpdateAabb;
 
 public:
 	KX_SoftBodyDeformer(RAS_MeshObject *pMeshObject, BL_DeformableGameObject *gameobj)
 		:m_pMeshObject(pMeshObject),
 		m_gameobj(gameobj),
-		m_needUpdateAABB(true)
+		m_needUpdateAabb(true)
 	{
+		KX_Scene *scene = m_gameobj->GetScene();
+		RAS_BoundingBoxManager *boundingBoxManager = scene->GetBoundingBoxManager();
+		m_boundingBox = boundingBoxManager->CreateBoundingBox();
 	}
 
 	virtual ~KX_SoftBodyDeformer()
@@ -75,7 +78,7 @@ public:
 	virtual bool UpdateBuckets()
 	{
 		// invalidate the AABB for each read acces.
-		m_needUpdateAABB = true;
+		m_needUpdateAabb = true;
 		// this is to update the mesh slots outside the rasterizer,
 		// no need to do it for this deformer, it's done in any case in Apply()
 		return false;
@@ -89,6 +92,7 @@ public:
 	}
 	virtual void ProcessReplica()
 	{
+		RAS_Deformer::ProcessReplica();
 		// we have two pointers to deal with but we cannot do it now, will be done in Relink
 		m_bDynamic = false;
 	}

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -44,6 +44,8 @@
 #include "RAS_MeshObject.h"
 #include "RAS_MeshUser.h"
 #include "RAS_Deformer.h"
+#include "RAS_IDisplayArray.h"
+#include "RAS_Polygon.h"
 #include "KX_NavMeshObject.h"
 #include "KX_MeshProxy.h"
 #include "KX_PolyProxy.h"
@@ -1428,7 +1430,7 @@ const MT_Vector3& KX_GameObject::NodeGetLocalPosition() const
 void KX_GameObject::UpdateBounds(bool force)
 {
 	RAS_Deformer *deformer = GetDeformer();
-	bool meshModified = ((m_meshes.size() > 0) && (m_meshes[0]->GetModifiedFlag() & RAS_MeshObject::AABB_MODIFIED)) ||
+	bool meshModified = ((m_meshes.size() > 0) && (m_meshes[0]->GetModifiedFlag() & RAS_IDisplayArray::AABB_MODIFIED)) ||
 						(deformer && deformer->IsDynamic());
 
 	if (!(m_autoUpdateBounds && meshModified) && !force) {
@@ -4019,7 +4021,7 @@ KX_PYMETHODDEF_DOC(KX_GameObject, rayCast,
 					KX_MeshProxy *meshProxy = new KX_MeshProxy(callback.m_hitMesh);
 					// if this field is set, then we can trust that m_hitPolygon is a valid polygon
 					RAS_Polygon* polygon = callback.m_hitMesh->GetPolygon(callback.m_hitPolygon);
-					KX_PolyProxy* polyproxy = new KX_PolyProxy(meshProxy, polygon);
+					KX_PolyProxy* polyproxy = new KX_PolyProxy(meshProxy, callback.m_hitMesh, polygon);
 					PyTuple_SET_ITEM(returnValue, 3, polyproxy->NewProxy(true));
 					if (poly == 2)
 					{

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -873,7 +873,7 @@ public:
 	 * \param force Force the AABB update even if the object doesn't allow auto update or if the mesh is
 	 * not modified like in the case of mesh replacement.
 	 */
-	void UpdateBounds(bool force = false);
+	void UpdateBounds(bool force);
 	void SetBoundsAabb(MT_Vector3 aabbMin, MT_Vector3 aabbMax);
 	void GetBoundsAabb(MT_Vector3 &aabbMin, MT_Vector3 &aabbMax) const;
 

--- a/source/gameengine/Ketsji/KX_MeshProxy.h
+++ b/source/gameengine/Ketsji/KX_MeshProxy.h
@@ -52,8 +52,6 @@ public:
 	KX_MeshProxy(RAS_MeshObject *mesh);
 	virtual ~KX_MeshProxy();
 
-	void AppendModifiedFlag(short flag);
-
 	virtual RAS_MeshObject *GetMesh()
 	{
 		return m_meshobj;

--- a/source/gameengine/Ketsji/KX_PolyProxy.cpp
+++ b/source/gameengine/Ketsji/KX_PolyProxy.cpp
@@ -103,10 +103,10 @@ PyAttributeDef KX_PolyProxy::Attributes[] = {
 	{ NULL }	//Sentinel
 };
 
-KX_PolyProxy::KX_PolyProxy(KX_MeshProxy *meshProxy, RAS_Polygon* polygon)
+KX_PolyProxy::KX_PolyProxy(KX_MeshProxy *meshProxy, RAS_MeshObject *mesh, RAS_Polygon* polygon)
 	:m_meshProxy(meshProxy),
 	m_polygon(polygon),
-	m_mesh(meshProxy->GetMesh())
+	m_mesh(mesh)
 {
 	Py_INCREF(m_meshProxy->GetProxy());
 }
@@ -202,10 +202,11 @@ static int kx_poly_proxy_get_vertices_size_cb(void *self_v)
 static PyObject *kx_poly_proxy_get_vertices_item_cb(void *self_v, int index)
 {
 	KX_PolyProxy *self = static_cast<KX_PolyProxy *>(self_v);
-	KX_MeshProxy *meshproxy = self->GetMeshProxy();
 	RAS_Polygon *polygon = self->GetPolygon();
 	int vertindex = polygon->GetVertexOffset(index);
-	KX_VertexProxy *vert = new KX_VertexProxy(meshproxy, polygon->GetDisplayArray()->GetVertex(vertindex));
+	RAS_IDisplayArray *array = polygon->GetDisplayArray();
+	KX_VertexProxy *vert = new KX_VertexProxy(array, array->GetVertex(vertindex));
+
 	return vert->GetProxy();
 }
 

--- a/source/gameengine/Ketsji/KX_PolyProxy.h
+++ b/source/gameengine/Ketsji/KX_PolyProxy.h
@@ -48,7 +48,7 @@ protected:
 	RAS_Polygon* m_polygon;
 	RAS_MeshObject*	m_mesh;
 public:
-	KX_PolyProxy(KX_MeshProxy *meshProxy, RAS_Polygon *polygon);
+	KX_PolyProxy(KX_MeshProxy *meshProxy, RAS_MeshObject *mesh, RAS_Polygon *polygon);
 	virtual ~KX_PolyProxy();
 
 	// stuff for cvalue related things

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -74,6 +74,7 @@ class KX_Camera;
 class KX_GameObject;
 class KX_LightObject;
 class KX_CubeMapManager;
+class RAS_BoundingBoxManager;
 class RAS_BucketManager;
 class RAS_MaterialBucket;
 class RAS_IPolyMaterial;
@@ -124,6 +125,10 @@ private:
 protected:
 	KX_CubeMapManager *m_cubeMapManager;
 	RAS_BucketManager*	m_bucketmanager;
+
+	/// Manager used to update all the mesh bounding box.
+	RAS_BoundingBoxManager *m_boundingBoxManager;
+
 	CListValue*			m_tempObjectList;
 
 	/**
@@ -311,6 +316,7 @@ public:
 
 	RAS_BucketManager* GetBucketManager();
 	KX_CubeMapManager *GetCubeMapManager();
+	RAS_BoundingBoxManager *GetBoundingBoxManager();
 	RAS_MaterialBucket*	FindBucket(RAS_IPolyMaterial* polymat, bool &bucketCreated);
 	void RenderBuckets(const MT_Transform& cameratransform,
 	                   RAS_IRasterizer* rasty);

--- a/source/gameengine/Ketsji/KX_VertexProxy.cpp
+++ b/source/gameengine/Ketsji/KX_VertexProxy.cpp
@@ -34,7 +34,7 @@
 #include "KX_VertexProxy.h"
 #include "KX_MeshProxy.h"
 #include "RAS_ITexVert.h"
-#include "RAS_MeshObject.h"
+#include "RAS_IDisplayArray.h"
 
 #include "KX_PyMath.h"
 
@@ -203,7 +203,7 @@ static bool kx_vertex_proxy_set_uvs_item_cb(void *self_v, int index, PyObject *i
 
 	KX_VertexProxy *self = ((KX_VertexProxy *)self_v);
 	self->GetVertex()->SetUV(index, uv);
-	self->GetMesh()->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+	self->GetDisplayArray()->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 
 	return true;
 }
@@ -240,7 +240,7 @@ static bool kx_vertex_proxy_set_colors_item_cb(void *self_v, int index, PyObject
 
 	KX_VertexProxy *self = ((KX_VertexProxy *)self_v);
 	self->GetVertex()->SetRGBA(index, color);
-	self->GetMesh()->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+	self->GetDisplayArray()->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 
 	return true;
 }
@@ -279,7 +279,7 @@ int KX_VertexProxy::pyattr_set_x(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		MT_Vector3 pos(self->m_vertex->getXYZ());
 		pos.x() = val;
 		self->m_vertex->SetXYZ(pos);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::POSITION_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::POSITION_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -293,7 +293,7 @@ int KX_VertexProxy::pyattr_set_y(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		MT_Vector3 pos(self->m_vertex->getXYZ());
 		pos.y() = val;
 		self->m_vertex->SetXYZ(pos);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::POSITION_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::POSITION_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -307,7 +307,7 @@ int KX_VertexProxy::pyattr_set_z(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		MT_Vector3 pos(self->m_vertex->getXYZ());
 		pos.z() = val;
 		self->m_vertex->SetXYZ(pos);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::POSITION_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::POSITION_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -321,7 +321,7 @@ int KX_VertexProxy::pyattr_set_u(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		MT_Vector2 uv = MT_Vector2(self->m_vertex->getUV(0));
 		uv[0] = val;
 		self->m_vertex->SetUV(0, uv);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -335,7 +335,7 @@ int KX_VertexProxy::pyattr_set_v(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		MT_Vector2 uv = MT_Vector2(self->m_vertex->getUV(0));
 		uv[1] = val;
 		self->m_vertex->SetUV(0, uv);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -350,7 +350,7 @@ int KX_VertexProxy::pyattr_set_u2(void *self_v, const struct KX_PYATTRIBUTE_DEF 
 			MT_Vector2 uv = MT_Vector2(self->m_vertex->getUV(1));
 			uv[0] = val;
 			self->m_vertex->SetUV(1, uv);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 		}
 		return PY_SET_ATTR_SUCCESS;
 	}
@@ -366,7 +366,7 @@ int KX_VertexProxy::pyattr_set_v2(void *self_v, const struct KX_PYATTRIBUTE_DEF 
 			MT_Vector2 uv = MT_Vector2(self->m_vertex->getUV(1));
 			uv[1] = val;
 			self->m_vertex->SetUV(1, uv);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 		}
 		return PY_SET_ATTR_SUCCESS;
 	}
@@ -383,7 +383,7 @@ int KX_VertexProxy::pyattr_set_r(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		val *= 255.0f;
 		cp[0] = (unsigned char)val;
 		self->m_vertex->SetRGBA(0, icol);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -399,7 +399,7 @@ int KX_VertexProxy::pyattr_set_g(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		val *= 255.0f;
 		cp[1] = (unsigned char)val;
 		self->m_vertex->SetRGBA(0, icol);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -415,7 +415,7 @@ int KX_VertexProxy::pyattr_set_b(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		val *= 255.0f;
 		cp[2] = (unsigned char)val;
 		self->m_vertex->SetRGBA(0, icol);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -431,7 +431,7 @@ int KX_VertexProxy::pyattr_set_a(void *self_v, const struct KX_PYATTRIBUTE_DEF *
 		val *= 255.0f;
 		cp[3] = (unsigned char)val;
 		self->m_vertex->SetRGBA(0, icol);
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -444,7 +444,7 @@ int KX_VertexProxy::pyattr_set_XYZ(void *self_v, const struct KX_PYATTRIBUTE_DEF
 		MT_Vector3 vec;
 		if (PyVecTo(value, vec)) {
 			self->m_vertex->SetXYZ(vec);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::POSITION_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::POSITION_MODIFIED);
 			return PY_SET_ATTR_SUCCESS;
 		}
 	}
@@ -458,7 +458,7 @@ int KX_VertexProxy::pyattr_set_UV(void *self_v, const struct KX_PYATTRIBUTE_DEF 
 		MT_Vector2 vec;
 		if (PyVecTo(value, vec)) {
 			self->m_vertex->SetUV(0, vec);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 			return PY_SET_ATTR_SUCCESS;
 		}
 	}
@@ -480,7 +480,7 @@ int KX_VertexProxy::pyattr_set_uvs(void *self_v, const struct KX_PYATTRIBUTE_DEF
 			}
 		}
 
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -493,7 +493,7 @@ int KX_VertexProxy::pyattr_set_color(void *self_v, const struct KX_PYATTRIBUTE_D
 		MT_Vector4 vec;
 		if (PyVecTo(value, vec)) {
 			self->m_vertex->SetRGBA(0, vec);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 			return PY_SET_ATTR_SUCCESS;
 		}
 	}
@@ -515,7 +515,7 @@ int KX_VertexProxy::pyattr_set_colors(void *self_v, const struct KX_PYATTRIBUTE_
 			}
 		}
 
-		self->m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+		self->m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 		return PY_SET_ATTR_SUCCESS;
 	}
 	return PY_SET_ATTR_FAIL;
@@ -528,25 +528,21 @@ int KX_VertexProxy::pyattr_set_normal(void *self_v, const struct KX_PYATTRIBUTE_
 		MT_Vector3 vec;
 		if (PyVecTo(value, vec)) {
 			self->m_vertex->SetNormal(vec);
-			self->m_mesh->AppendModifiedFlag(RAS_MeshObject::NORMAL_MODIFIED);
+			self->m_array->AppendModifiedFlag(RAS_IDisplayArray::NORMAL_MODIFIED);
 			return PY_SET_ATTR_SUCCESS;
 		}
 	}
 	return PY_SET_ATTR_FAIL;
 }
 
-KX_VertexProxy::KX_VertexProxy(KX_MeshProxy *mesh, RAS_ITexVert *vertex)
+KX_VertexProxy::KX_VertexProxy(RAS_IDisplayArray *array, RAS_ITexVert *vertex)
 	:m_vertex(vertex),
-	m_mesh(mesh)
+	m_array(array)
 {
-	/* see bug [#27071] */
-	Py_INCREF(m_mesh->GetProxy());
 }
 
 KX_VertexProxy::~KX_VertexProxy()
 {
-	/* see bug [#27071] */
-	Py_DECREF(m_mesh->GetProxy());
 }
 
 RAS_ITexVert *KX_VertexProxy::GetVertex()
@@ -554,9 +550,9 @@ RAS_ITexVert *KX_VertexProxy::GetVertex()
 	return m_vertex;
 }
 
-KX_MeshProxy *KX_VertexProxy::GetMesh()
+RAS_IDisplayArray *KX_VertexProxy::GetDisplayArray()
 {
-	return m_mesh;
+	return m_array;
 }
 
 // stuff for cvalue related things
@@ -580,7 +576,7 @@ PyObject *KX_VertexProxy::PySetXYZ(PyObject *value)
 		return NULL;
 
 	m_vertex->SetXYZ(vec);
-	m_mesh->AppendModifiedFlag(RAS_MeshObject::POSITION_MODIFIED);
+	m_array->AppendModifiedFlag(RAS_IDisplayArray::POSITION_MODIFIED);
 	Py_RETURN_NONE;
 }
 
@@ -596,7 +592,7 @@ PyObject *KX_VertexProxy::PySetNormal(PyObject *value)
 		return NULL;
 
 	m_vertex->SetNormal(vec);
-	m_mesh->AppendModifiedFlag(RAS_MeshObject::NORMAL_MODIFIED);
+	m_array->AppendModifiedFlag(RAS_IDisplayArray::NORMAL_MODIFIED);
 	Py_RETURN_NONE;
 }
 
@@ -611,14 +607,14 @@ PyObject *KX_VertexProxy::PySetRGBA(PyObject *value)
 	if (PyLong_Check(value)) {
 		int rgba = PyLong_AsLong(value);
 		m_vertex->SetRGBA(0, rgba);
-		m_mesh->AppendModifiedFlag(true);
+		m_array->AppendModifiedFlag(true);
 		Py_RETURN_NONE;
 	}
 	else {
 		MT_Vector4 vec;
 		if (PyVecTo(value, vec)) {
 			m_vertex->SetRGBA(0, vec);
-			m_mesh->AppendModifiedFlag(RAS_MeshObject::COLORS_MODIFIED);
+			m_array->AppendModifiedFlag(RAS_IDisplayArray::COLORS_MODIFIED);
 			Py_RETURN_NONE;
 		}
 	}
@@ -639,7 +635,7 @@ PyObject *KX_VertexProxy::PySetUV1(PyObject *value)
 		return NULL;
 
 	m_vertex->SetUV(0, vec);
-	m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+	m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 	Py_RETURN_NONE;
 }
 
@@ -656,7 +652,7 @@ PyObject *KX_VertexProxy::PySetUV2(PyObject *args)
 
 	if (m_vertex->getUvSize() > 1) {
 		m_vertex->SetUV(1, vec);
-		m_mesh->AppendModifiedFlag(RAS_MeshObject::UVS_MODIFIED);
+		m_array->AppendModifiedFlag(RAS_IDisplayArray::UVS_MODIFIED);
 	}
 	Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_VertexProxy.h
+++ b/source/gameengine/Ketsji/KX_VertexProxy.h
@@ -34,25 +34,25 @@
 
 #ifdef WITH_PYTHON
 
-#include "SCA_IObject.h"
+#include "EXP_Value.h"
 
 class RAS_ITexVert;
-class KX_MeshProxy;
+class RAS_IDisplayArray;
 
 class KX_VertexProxy : public CValue
 {
 	Py_Header
-protected:
 
+protected:
 	RAS_ITexVert *m_vertex;
-	KX_MeshProxy *m_mesh;
+	RAS_IDisplayArray *m_array;
 
 public:
-	KX_VertexProxy(KX_MeshProxy *mesh, RAS_ITexVert *vertex);
+	KX_VertexProxy(RAS_IDisplayArray *array, RAS_ITexVert *vertex);
 	virtual ~KX_VertexProxy();
 
 	RAS_ITexVert *GetVertex();
-	KX_MeshProxy *GetMesh();
+	RAS_IDisplayArray *GetDisplayArray();
 
 	// stuff for cvalue related things
 	STR_String& GetName();

--- a/source/gameengine/Rasterizer/CMakeLists.txt
+++ b/source/gameengine/Rasterizer/CMakeLists.txt
@@ -57,6 +57,8 @@ set(SRC
 	RAS_IPolygonMaterial.cpp
 	RAS_InstancingBuffer.cpp
 	RAS_MaterialBucket.cpp
+	RAS_BoundingBox.cpp
+	RAS_BoundingBoxManager.cpp
 	RAS_MeshObject.cpp
 	RAS_MeshSlot.cpp
 	RAS_MeshUser.cpp
@@ -90,6 +92,8 @@ set(SRC
 	RAS_ISync.h
 	RAS_ITexVert.h
 	RAS_MaterialBucket.h
+	RAS_BoundingBox.h
+	RAS_BoundingBoxManager.h
 	RAS_MeshMaterial.h
 	RAS_MeshObject.h
 	RAS_MeshSlot.h

--- a/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
+++ b/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
@@ -1,0 +1,173 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file RAS_BoundingBox.cpp
+ *  \ingroup bgerast
+ */
+
+#include "RAS_BoundingBox.h"
+#include "RAS_BoundingBoxManager.h"
+#include <algorithm>
+
+RAS_BoundingBox::RAS_BoundingBox(RAS_BoundingBoxManager *manager)
+	:m_modified(false),
+	m_aabbMin(0.0f, 0.0f, 0.0f),
+	m_aabbMax(0.0f, 0.0f, 0.0f),
+	m_users(0),
+	m_manager(manager)
+{
+}
+
+RAS_BoundingBox::~RAS_BoundingBox()
+{
+}
+
+RAS_BoundingBox *RAS_BoundingBox::GetReplica()
+{
+	RAS_BoundingBox *boundingBox = new RAS_BoundingBox(*this);
+	boundingBox->m_users = 0;
+	return boundingBox;
+}
+
+void RAS_BoundingBox::AddUser()
+{
+	++m_users;
+	/* No one was using this bounding box previously. Then add it to the active
+	 * bounding box list in the manager.*/
+	if (m_users == 1) {
+		m_manager->AddActiveBoundingBox(this);
+	}
+}
+
+void RAS_BoundingBox::RemoveUser()
+{
+	--m_users;
+	BLI_assert(m_users >= 0);
+
+	/* Some one was using this bounding box previously. Then remove it from the
+	 * active bounding box list. */
+	if (m_users == 0) {
+		m_manager->RemoveActiveBoundingBox(this);
+	}
+}
+
+void RAS_BoundingBox::SetManager(RAS_BoundingBoxManager *manager)
+{
+	m_manager = manager;
+}
+
+bool RAS_BoundingBox::GetModified() const
+{
+	return m_modified;
+}
+
+void RAS_BoundingBox::ClearModified()
+{
+	m_modified = false;
+}
+
+void RAS_BoundingBox::GetAabb(MT_Vector3& aabbMin, MT_Vector3& aabbMax) const
+{
+	aabbMin = m_aabbMin;
+	aabbMax = m_aabbMax;
+}
+
+void RAS_BoundingBox::SetAabb(const MT_Vector3& aabbMin, const MT_Vector3& aabbMax)
+{
+	m_aabbMin = aabbMin;
+	m_aabbMax = aabbMax;
+	m_modified = true;
+}
+
+void RAS_BoundingBox::ExtendAabb(const MT_Vector3& aabbMin, const MT_Vector3& aabbMax)
+{
+	m_aabbMin.x() = std::min(m_aabbMin.x(), aabbMin.x());
+	m_aabbMin.y() = std::min(m_aabbMin.y(), aabbMin.y());
+	m_aabbMin.z() = std::min(m_aabbMin.z(), aabbMin.z());
+	m_aabbMax.x() = std::max(m_aabbMax.x(), aabbMax.x());
+	m_aabbMax.y() = std::max(m_aabbMax.y(), aabbMax.y());
+	m_aabbMax.z() = std::max(m_aabbMax.z(), aabbMax.z());
+	m_modified = true;
+}
+
+void RAS_BoundingBox::Update(bool force)
+{
+}
+
+RAS_MeshBoundingBox::RAS_MeshBoundingBox(RAS_BoundingBoxManager *manager, const RAS_IDisplayArrayList displayArrayList)
+	:RAS_BoundingBox(manager),
+	m_displayArrayList(displayArrayList)
+{
+}
+
+RAS_MeshBoundingBox::~RAS_MeshBoundingBox()
+{
+}
+
+RAS_BoundingBox *RAS_MeshBoundingBox::GetReplica()
+{
+	RAS_MeshBoundingBox *boundingBox = new RAS_MeshBoundingBox(*this);
+	boundingBox->m_users = 0;
+	return boundingBox;
+}
+
+void RAS_MeshBoundingBox::Update(bool force)
+{
+	bool modified = false;
+	// Detect if a display array was modified.
+	for (RAS_IDisplayArrayList::iterator it = m_displayArrayList.begin(), end = m_displayArrayList.end(); it != end; ++it) {
+		if ((*it)->GetModifiedFlag() & RAS_IDisplayArray::AABB_MODIFIED) {
+			modified = true;
+			break;
+		}
+	}
+
+	if (!modified && !force) {
+		return;
+	}
+
+	/* Initialize AABB to first vertex position. We do it here instead that inside a condition
+	 * in the loop to optimize the AABB computation, even if the first vertex is used to initialize
+	 * and to extend the AABB.
+	 */
+	RAS_ITexVert *firstVert = m_displayArrayList[0]->GetVertex(0);
+	const MT_Vector3 firstVertPos = firstVert->xyz();
+	m_aabbMin = m_aabbMax = firstVertPos;
+
+	for (unsigned short i = 0, size = m_displayArrayList.size(); i < size; ++i) {
+		RAS_IDisplayArray *displayArray = m_displayArrayList[i];
+		// For each vertex.
+		for (unsigned int j = 0, size = displayArray->GetVertexCount(); j < size; ++j) {
+			RAS_ITexVert *vert = displayArray->GetVertex(j);
+			const MT_Vector3 vertPos = vert->xyz();
+
+			m_aabbMin.x() = std::min(m_aabbMin.x(), vertPos.x());
+			m_aabbMin.y() = std::min(m_aabbMin.y(), vertPos.y());
+			m_aabbMin.z() = std::min(m_aabbMin.z(), vertPos.z());
+			m_aabbMax.x() = std::max(m_aabbMax.x(), vertPos.x());
+			m_aabbMax.y() = std::max(m_aabbMax.y(), vertPos.y());
+			m_aabbMax.z() = std::max(m_aabbMax.z(), vertPos.z());
+		}
+	}
+
+	m_modified = true;
+}

--- a/source/gameengine/Rasterizer/RAS_BoundingBox.h
+++ b/source/gameengine/Rasterizer/RAS_BoundingBox.h
@@ -1,0 +1,100 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file RAS_BoundingBox.h
+ *  \ingroup bgerast
+ */
+
+#ifndef __RAS_BOUNDING_BOX_H__
+#define __RAS_BOUNDING_BOX_H__
+
+#include "RAS_IDisplayArray.h"
+#include "MT_Vector3.h"
+
+class RAS_BoundingBoxManager;
+
+class RAS_BoundingBox
+{
+protected:
+	/// True when the bounding box is modified.
+	bool m_modified;
+
+	/// The AABB minimum.
+	MT_Vector3 m_aabbMin;
+	/// The AABB maximum.
+	MT_Vector3 m_aabbMax;
+
+	/// The number of mesh user using this bounding box.
+	int m_users;
+	/// The manager of all the bounding boxes of a scene.
+	RAS_BoundingBoxManager *m_manager;
+
+public:
+	RAS_BoundingBox(RAS_BoundingBoxManager *manager);
+	virtual ~RAS_BoundingBox();
+
+	virtual RAS_BoundingBox *GetReplica();
+
+	/// Notice that the bounding box is used by one more mesh user.
+	void AddUser();
+	/// Notice that the bounding box is left by one mesh user.
+	void RemoveUser();
+
+	/// Change the bounding box manager. Used only for the libloading scene merge.
+	void SetManager(RAS_BoundingBoxManager *manager);
+
+	/** Return true when the bounding box AABB was set or when the display
+	 * array were modified in case of RAS_MeshBoundingBox instance.
+	 */
+	bool GetModified() const;
+	/// Set the bounding box unmodified.
+	void ClearModified();
+
+	void GetAabb(MT_Vector3& aabbMin, MT_Vector3& aabbMax) const;
+	void SetAabb(const MT_Vector3& aabbMin, const MT_Vector3& aabbMax);
+	/// Compute the AABB of the bounding box AABB mixed with the passed AABB.
+	void ExtendAabb(const MT_Vector3& aabbMin, const MT_Vector3& aabbMax);
+
+	virtual void Update(bool force);
+};
+
+class RAS_MeshBoundingBox : public RAS_BoundingBox
+{
+private:
+	/// The display arrays used to compute the AABB.
+	RAS_IDisplayArrayList m_displayArrayList;
+
+public:
+	RAS_MeshBoundingBox(RAS_BoundingBoxManager *manager, const RAS_IDisplayArrayList displayArrayList);
+	virtual ~RAS_MeshBoundingBox();
+
+	virtual RAS_BoundingBox *GetReplica();
+
+	/** Check if one of the display array was modified, and then recompute the AABB.
+	 * \param force Force the AABB computation even if none display arrays are modified.
+	 */
+	virtual void Update(bool force);
+};
+
+typedef std::vector<RAS_BoundingBox *> RAS_BoundingBoxList;
+
+#endif  // __RAS_BOUNDING_BOX_H__

--- a/source/gameengine/Rasterizer/RAS_BoundingBoxManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_BoundingBoxManager.cpp
@@ -1,0 +1,102 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file RAS_BoundingBoxManager.cpp
+ *  \ingroup bgerast
+ */
+
+#include "RAS_BoundingBoxManager.h"
+
+#include <algorithm>
+
+RAS_BoundingBoxManager::RAS_BoundingBoxManager()
+{
+}
+
+RAS_BoundingBoxManager::~RAS_BoundingBoxManager()
+{
+	for (RAS_BoundingBoxList::iterator it = m_boundingBoxList.begin(), end = m_boundingBoxList.end(); it != end; ++it) {
+		delete *it;
+	}
+
+	BLI_assert(m_activeBoundingBoxList.size() == 0);
+}
+
+RAS_BoundingBox *RAS_BoundingBoxManager::CreateBoundingBox()
+{
+	RAS_BoundingBox *boundingBox = new RAS_BoundingBox(this);
+	m_boundingBoxList.push_back(boundingBox);
+
+	return boundingBox;
+}
+
+RAS_BoundingBox *RAS_BoundingBoxManager::CreateMeshBoundingBox(const RAS_IDisplayArrayList& arrayList)
+{
+	RAS_BoundingBox *boundingBox = new RAS_MeshBoundingBox(this, arrayList);
+	m_boundingBoxList.push_back(boundingBox);
+
+	return boundingBox;
+}
+
+void RAS_BoundingBoxManager::AddActiveBoundingBox(RAS_BoundingBox *boundingBox)
+{
+	m_activeBoundingBoxList.push_back(boundingBox);
+}
+
+void RAS_BoundingBoxManager::RemoveActiveBoundingBox(RAS_BoundingBox *boundingBox)
+{
+	RAS_BoundingBoxList::iterator it = std::find(m_activeBoundingBoxList.begin(), m_activeBoundingBoxList.end(), boundingBox);
+	if (it != m_activeBoundingBoxList.end()) {
+		m_activeBoundingBoxList.erase(it);
+	}
+}
+
+void RAS_BoundingBoxManager::Update(bool force)
+{
+	for (RAS_BoundingBoxList::iterator it = m_activeBoundingBoxList.begin(), end = m_activeBoundingBoxList.end(); it != end; ++it) {
+		(*it)->Update(force);
+	}
+}
+
+void RAS_BoundingBoxManager::ClearModified()
+{
+	for (RAS_BoundingBoxList::iterator it = m_activeBoundingBoxList.begin(), end = m_activeBoundingBoxList.end(); it != end; ++it) {
+		(*it)->ClearModified();
+	}
+}
+
+void RAS_BoundingBoxManager::Merge(RAS_BoundingBoxManager *other)
+{
+	for (RAS_BoundingBoxList::iterator it = other->m_boundingBoxList.begin(), end = other->m_boundingBoxList.end(); it != end; ++it) {
+		RAS_BoundingBox *boundingBox = *it;
+		boundingBox->SetManager(this);
+		m_boundingBoxList.push_back(boundingBox);
+	}
+
+	other->m_boundingBoxList.clear();
+
+	for (RAS_BoundingBoxList::iterator it = other->m_activeBoundingBoxList.begin(), end = other->m_activeBoundingBoxList.end(); it != end; ++it) {
+		m_activeBoundingBoxList.push_back(*it);
+	}
+
+	other->m_activeBoundingBoxList.clear();
+}

--- a/source/gameengine/Rasterizer/RAS_BoundingBoxManager.h
+++ b/source/gameengine/Rasterizer/RAS_BoundingBoxManager.h
@@ -1,0 +1,75 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file RAS_BoundingBoxManager.h
+ *  \ingroup bgerast
+ */
+
+#ifndef __RAS_BOUNDING_BOX_MANAGER_H__
+#define __RAS_BOUNDING_BOX_MANAGER_H__
+
+#include "RAS_BoundingBox.h"
+
+class RAS_BoundingBoxManager
+{
+private:
+	/// All the existing bounding boxes for this manager.
+	RAS_BoundingBoxList m_boundingBoxList;
+	/** All the bounding boxes used by at least one mesh user.
+	 * These bounding boxes will be updated each frames.
+	 */
+	RAS_BoundingBoxList m_activeBoundingBoxList;
+
+public:
+	RAS_BoundingBoxManager();
+	~RAS_BoundingBoxManager();
+
+	/** Create the bounding box from the bounding box manager. The reason to
+	 * do that is that the scene owning the bounding box manager will be freed
+	 * before the deformers and meshes.
+	 */
+	RAS_BoundingBox *CreateBoundingBox();
+	/** Create mesh bounding box.
+	 * \param arrayList The display arrays composing the mesh.
+	 * \see CreateBoundingBox.
+	 */
+	RAS_BoundingBox *CreateMeshBoundingBox(const RAS_IDisplayArrayList& arrayList);
+
+	/// Add a bounding in the active bounding box list.
+	void AddActiveBoundingBox(RAS_BoundingBox *boundingBox);
+	/// Remove a bounding from the active bounding box list.
+	void RemoveActiveBoundingBox(RAS_BoundingBox *boundingBox);
+
+	/** Update all the active bounding boxes.
+	 * \param force Force updating bounding box even if the display arrays are not modified.
+	 */
+	void Update(bool force);
+	/// Set all the active bounding box unmodified.
+	void ClearModified();
+
+	/** Merge an other bounding box manager.
+	 * \param other The bounding box manager to merge data from. This manager is empty after the merge.
+	 */
+	void Merge(RAS_BoundingBoxManager *other);
+};
+
+#endif  // __RAS_MESH_BOUNDING_BOX_MANAGER_H__

--- a/source/gameengine/Rasterizer/RAS_BucketManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.cpp
@@ -393,7 +393,7 @@ void RAS_BucketManager::Renderbuckets(const MT_Transform& cameratrans, RAS_IRast
 		/* Don't do this while processing buckets because some meshes are split between buckets */
 		BucketList& buckets = m_buckets[ALL_BUCKET];
 		for (BucketList::iterator it = buckets.begin(), end = buckets.end(); it != end; ++it) {
-			(*it)->SetMeshUnmodified();
+			(*it)->SetDisplayArrayUnmodified();
 		}
 	}
 

--- a/source/gameengine/Rasterizer/RAS_Deformer.h
+++ b/source/gameengine/Rasterizer/RAS_Deformer.h
@@ -44,6 +44,8 @@
 #include "MEM_guardedalloc.h"
 #endif
 
+#include "RAS_BoundingBox.h"
+
 struct DerivedMesh;
 class RAS_MeshObject;
 class RAS_IPolyMaterial;
@@ -55,18 +57,23 @@ public:
 	RAS_Deformer()
 		:m_pMesh(NULL),
 		m_bDynamic(false),
-		m_aabbMin(0.0f, 0.0f, 0.0f),
-		m_aabbMax(0.0f, 0.0f, 0.0f)
+		m_boundingBox(NULL)
 	{
 	}
 
-	virtual ~RAS_Deformer() {}
+	virtual ~RAS_Deformer()
+	{
+	}
+
 	virtual void Relink(std::map<void *, void *>& map) = 0;
 	virtual bool Apply(RAS_IPolyMaterial *polymat, RAS_MeshMaterial *meshmat) = 0;
 	virtual bool Update(void)=0;
 	virtual bool UpdateBuckets(void)=0;
 	virtual RAS_Deformer *GetReplica()=0;
-	virtual void ProcessReplica()=0;
+	virtual void ProcessReplica()
+	{
+		m_boundingBox = m_boundingBox->GetReplica();
+	}
 	virtual bool SkipVertexTransform()
 	{
 		return false;
@@ -99,18 +106,17 @@ public:
 	}
 	virtual float (* GetTransVerts(int *tot))[3]	{	*tot= 0; return NULL; }
 
-	virtual void GetAabb(MT_Vector3 &aabbMin, MT_Vector3 &aabbMax) const
+	RAS_BoundingBox *GetBoundingBox() const
 	{
-		aabbMin = m_aabbMin;
-		aabbMax = m_aabbMax;
+		return m_boundingBox;
 	}
 
 protected:
 	class RAS_MeshObject	*m_pMesh;
 	bool  m_bDynamic;
 
-	MT_Vector3 m_aabbMin;
-	MT_Vector3 m_aabbMax;
+	/// Deformer bounding box.
+	RAS_BoundingBox *m_boundingBox;
 
 #ifdef WITH_CXX_GUARDEDALLOC
 	MEM_CXX_CLASS_ALLOC_FUNCS("GE:RAS_Deformer")

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -209,7 +209,7 @@ void RAS_DisplayArrayBucket::UpdateActiveMeshSlots(RAS_IRasterizer *rasty)
 		}
 	}
 
-	if (m_mesh && m_mesh->GetModifiedFlag() & RAS_MeshObject::MESH_MODIFIED) {
+	if (m_displayArray && m_displayArray->GetModifiedFlag() & RAS_IDisplayArray::MESH_MODIFIED) {
 		meshModified = true;
 	}
 
@@ -221,8 +221,8 @@ void RAS_DisplayArrayBucket::UpdateActiveMeshSlots(RAS_IRasterizer *rasty)
 
 void RAS_DisplayArrayBucket::SetMeshUnmodified()
 {
-	if (m_mesh) {
-		m_mesh->SetModifiedFlag(0);
+	if (m_displayArray) {
+		m_displayArray->SetModifiedFlag(RAS_IDisplayArray::NONE_MODIFIED);
 	}
 }
 

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -184,7 +184,7 @@ void RAS_DisplayArrayBucket::UpdateActiveMeshSlots(RAS_IRasterizer *rasty)
 	// Reset values to default.
 	m_useDisplayList = true;
 	m_useVao = true;
-	bool meshModified = false;
+	bool arrayModified = false;
 
 	RAS_IPolyMaterial *material = m_bucket->GetPolyMaterial();
 
@@ -205,21 +205,22 @@ void RAS_DisplayArrayBucket::UpdateActiveMeshSlots(RAS_IRasterizer *rasty)
 		// Test if one of deformers is dynamic.
 		if (deformer->IsDynamic()) {
 			m_useDisplayList = false;
-			meshModified = true;
+			arrayModified = true;
 		}
 	}
 
 	if (m_displayArray && m_displayArray->GetModifiedFlag() & RAS_IDisplayArray::MESH_MODIFIED) {
-		meshModified = true;
+		arrayModified = true;
 	}
 
 	// Set the storage info modified if the mesh is modified.
-	if (m_storageInfo && meshModified) {
+	if (arrayModified && m_storageInfo) {
+		std::cout << "modified" << std::endl;
 		m_storageInfo->SetDataModified(rasty->GetDrawingMode(), RAS_IStorageInfo::VERTEX_DATA);
 	}
 }
 
-void RAS_DisplayArrayBucket::SetMeshUnmodified()
+void RAS_DisplayArrayBucket::SetDisplayArrayUnmodified()
 {
 	if (m_displayArray) {
 		m_displayArray->SetModifiedFlag(RAS_IDisplayArray::NONE_MODIFIED);

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
@@ -127,7 +127,7 @@ public:
 	/// Update render infos.
 	void UpdateActiveMeshSlots(RAS_IRasterizer *rasty);
 	/// Set the mesh object as unmodified flag.
-	void SetMeshUnmodified();
+	void SetDisplayArrayUnmodified();
 	/// Notice the storage info that the indices list (polygons) changed.
 	void SetPolygonsModified(RAS_IRasterizer *rasty);
 

--- a/source/gameengine/Rasterizer/RAS_IDisplayArray.cpp
+++ b/source/gameengine/Rasterizer/RAS_IDisplayArray.cpp
@@ -30,7 +30,8 @@
 #include "glew-mx.h"
 
 RAS_IDisplayArray::RAS_IDisplayArray(PrimitiveType type)
-	:m_type(type)
+	:m_type(type),
+	m_modifiedFlag(NONE_MODIFIED)
 {
 }
 
@@ -86,12 +87,12 @@ int RAS_IDisplayArray::GetOpenGLPrimitiveType() const
 
 void RAS_IDisplayArray::UpdateFrom(RAS_IDisplayArray *other, int flag)
 {
-	if (flag & RAS_MeshObject::TANGENT_MODIFIED) {
+	if (flag & TANGENT_MODIFIED) {
 		for (unsigned int i = 0, size = other->GetVertexCount(); i < size; ++i) {
 			GetVertex(i)->SetTangent(MT_Vector4(other->GetVertex(i)->getTangent()));
 		}
 	}
-	if (flag & RAS_MeshObject::UVS_MODIFIED) {
+	if (flag & UVS_MODIFIED) {
 		const unsigned short uvSize = min_ii(GetVertexUvSize(), other->GetVertexUvSize());
 		for (unsigned int i = 0, size = other->GetVertexCount(); i < size; ++i) {
 			for (unsigned int uv = 0; uv < uvSize; ++uv) {
@@ -99,17 +100,17 @@ void RAS_IDisplayArray::UpdateFrom(RAS_IDisplayArray *other, int flag)
 			}
 		}
 	}
-	if (flag & RAS_MeshObject::POSITION_MODIFIED) {
+	if (flag & POSITION_MODIFIED) {
 		for (unsigned int i = 0, size = other->GetVertexCount(); i < size; ++i) {
 			GetVertex(i)->SetXYZ(MT_Vector3(other->GetVertex(i)->getXYZ()));
 		}
 	}
-	if (flag & RAS_MeshObject::NORMAL_MODIFIED) {
+	if (flag & NORMAL_MODIFIED) {
 		for (unsigned int i = 0, size = other->GetVertexCount(); i < size; ++i) {
 			GetVertex(i)->SetNormal(MT_Vector3(other->GetVertex(i)->getNormal()));
 		}
 	}
-	if (flag & RAS_MeshObject::COLORS_MODIFIED) {
+	if (flag & COLORS_MODIFIED) {
 		const unsigned short colorSize = min_ii(GetVertexColorSize(), other->GetVertexColorSize());
 		for (unsigned int i = 0, size = other->GetVertexCount(); i < size; ++i) {
 			for (unsigned int color = 0; color < colorSize; ++color) {
@@ -117,4 +118,19 @@ void RAS_IDisplayArray::UpdateFrom(RAS_IDisplayArray *other, int flag)
 			}
 		}
 	}
+}
+
+unsigned short RAS_IDisplayArray::GetModifiedFlag() const
+{
+	return m_modifiedFlag;
+}
+
+void RAS_IDisplayArray::AppendModifiedFlag(unsigned short flag)
+{
+	SetModifiedFlag(m_modifiedFlag | flag);
+}
+
+void RAS_IDisplayArray::SetModifiedFlag(unsigned short flag)
+{
+	m_modifiedFlag = flag;
 }

--- a/source/gameengine/Rasterizer/RAS_IDisplayArray.h
+++ b/source/gameengine/Rasterizer/RAS_IDisplayArray.h
@@ -41,6 +41,8 @@ public:
 protected:
 	/// The display array primitive type.
 	PrimitiveType m_type;
+	/// Modification flag.
+	unsigned short m_modifiedFlag;
 
 	/// The vertex infos unused for rendering, e.g original or soft body index, flag.
 	std::vector<RAS_TexVertInfo> m_vertexInfos;
@@ -143,6 +145,28 @@ public:
 	virtual void UpdateCache() = 0;
 
 	int GetOpenGLPrimitiveType() const;
+
+	/// Modification categories.
+	enum {
+		NONE_MODIFIED = 0,
+		POSITION_MODIFIED = 1 << 0, // Vertex position modified.
+		NORMAL_MODIFIED = 1 << 1, // Vertex normal modified.
+		UVS_MODIFIED = 1 << 2, // Vertex UVs modified.
+		COLORS_MODIFIED = 1 << 3, // Vertex colors modified.
+		TANGENT_MODIFIED = 1 << 4, // Vertex tangent modified.
+		AABB_MODIFIED = POSITION_MODIFIED,
+		MESH_MODIFIED = POSITION_MODIFIED | NORMAL_MODIFIED | UVS_MODIFIED |
+						COLORS_MODIFIED | TANGENT_MODIFIED
+	};
+
+	/// Return display array modified flag.
+	unsigned short GetModifiedFlag() const;
+	/** Mix display array modified flag with a new flag.
+	 * \param flag The flag to mix.
+	 */
+	void AppendModifiedFlag(unsigned short flag);
+	/// Set the display array modified flag.
+	void SetModifiedFlag(unsigned short flag);
 };
 
 #endif  // __RAS_IDISPLAY_ARRAY_H__

--- a/source/gameengine/Rasterizer/RAS_IDisplayArray.h
+++ b/source/gameengine/Rasterizer/RAS_IDisplayArray.h
@@ -169,4 +169,6 @@ public:
 	void SetModifiedFlag(unsigned short flag);
 };
 
+typedef std::vector<RAS_IDisplayArray *> RAS_IDisplayArrayList;
+
 #endif  // __RAS_IDISPLAY_ARRAY_H__

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.cpp
@@ -240,13 +240,13 @@ void RAS_MaterialBucket::RenderMeshSlots(const MT_Transform& cameratrans, RAS_IR
 	}
 }
 
-void RAS_MaterialBucket::SetMeshUnmodified()
+void RAS_MaterialBucket::SetDisplayArrayUnmodified()
 {
 	for (RAS_DisplayArrayBucketList::iterator it = m_displayArrayBucketList.begin(), end = m_displayArrayBucketList.end();
 		it != end; ++it)
 	{
 		RAS_DisplayArrayBucket *displayArrayBucket = *it;
-		displayArrayBucket->SetMeshUnmodified();
+		displayArrayBucket->SetDisplayArrayUnmodified();
 	}
 }
 

--- a/source/gameengine/Rasterizer/RAS_MaterialBucket.h
+++ b/source/gameengine/Rasterizer/RAS_MaterialBucket.h
@@ -73,7 +73,7 @@ public:
 	/// Remove all mesh slot using the given mesh object.
 	void RemoveMeshObject(RAS_MeshObject *mesh);
 	/// Set the mesh object as unmodified flag.
-	void SetMeshUnmodified();
+	void SetDisplayArrayUnmodified();
 	unsigned int GetNumActiveMeshSlots();
 
 	/// Find a display array bucket for the given display array.

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -76,7 +76,6 @@ public:
 	typedef std::vector<Layer> LayerList;
 
 private:
-	short m_modifiedFlag;
 	bool m_needUpdateAabb;
 	MT_Vector3 m_aabbMax;
 	MT_Vector3 m_aabbMin;
@@ -109,7 +108,7 @@ public:
 	const STR_String& GetMaterialName(unsigned int matid);
 	const STR_String& GetTextureName(unsigned int matid);
 
-	RAS_MeshMaterial *GetMeshMaterial(unsigned int matid);
+	RAS_MeshMaterial *GetMeshMaterial(unsigned int matid) const;
 	RAS_MeshMaterial *GetMeshMaterialBlenderIndex(unsigned int index);
 
 	std::vector<RAS_MeshMaterial *>::iterator GetFirstMaterial();
@@ -118,26 +117,11 @@ public:
 	// name
 	STR_String& GetName();
 
-	/// Modification categories.
-	enum {
-		POSITION_MODIFIED = 1 << 0, // Vertex position modified.
-		NORMAL_MODIFIED = 1 << 1, // Vertex normal modified.
-		UVS_MODIFIED = 1 << 2, // Vertex UVs modified.
-		COLORS_MODIFIED = 1 << 3, // Vertex colors modified.
-		TANGENT_MODIFIED = 1 << 4, // Vertex tangent modified.
-		AABB_MODIFIED = POSITION_MODIFIED,
-		MESH_MODIFIED = POSITION_MODIFIED | NORMAL_MODIFIED | UVS_MODIFIED |
-						COLORS_MODIFIED | TANGENT_MODIFIED
-	};
-
 	/// Return mesh modified flag.
-	short GetModifiedFlag() const;
+	unsigned short GetModifiedFlag() const;
 	/** Mix mesh modified flag with a new flag.
 	 * \param flag The flag to mix.
 	 */
-	void AppendModifiedFlag(short flag);
-	/// Set the mesh modified flag.
-	void SetModifiedFlag(short flag);
 
 	// original blender mesh
 	Mesh *GetMesh()
@@ -161,6 +145,7 @@ public:
 				const unsigned int origindex);
 
 	// vertex and polygon acces
+	RAS_IDisplayArray *GetDisplayArray(unsigned int matid) const;
 	RAS_ITexVert *GetVertex(unsigned int matid, unsigned int index);
 	const float *GetVertexLocation(unsigned int orig_index);
 

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -51,6 +51,8 @@ class RAS_MeshUser;
 class RAS_Deformer;
 class RAS_Polygon;
 class RAS_ITexVert;
+class RAS_BoundingBox;
+class RAS_BoundingBoxManager;
 struct Mesh;
 struct MTFace;
 struct MCol;
@@ -76,10 +78,6 @@ public:
 	typedef std::vector<Layer> LayerList;
 
 private:
-	bool m_needUpdateAabb;
-	MT_Vector3 m_aabbMax;
-	MT_Vector3 m_aabbMin;
-
 	STR_String m_name;
 	static STR_String s_emptyname;
 
@@ -92,7 +90,8 @@ private:
 	struct backtofront;
 	struct fronttoback;
 
-	void UpdateAabb();
+	/// The mesh bounding box.
+	RAS_BoundingBox *m_boundingBox;
 
 protected:
 	std::vector<RAS_MeshMaterial *> m_materials;
@@ -116,12 +115,6 @@ public:
 
 	// name
 	STR_String& GetName();
-
-	/// Return mesh modified flag.
-	unsigned short GetModifiedFlag() const;
-	/** Mix mesh modified flag with a new flag.
-	 * \param flag The flag to mix.
-	 */
 
 	// original blender mesh
 	Mesh *GetMesh()
@@ -152,11 +145,12 @@ public:
 	int NumPolygons();
 	RAS_Polygon *GetPolygon(int num) const;
 
+	RAS_BoundingBox *GetBoundingBox() const;
 	// buckets
 	RAS_MeshUser *AddMeshUser(void *clientobj, RAS_Deformer *deformer);
 
 	void RemoveFromBuckets(void *clientobj);
-	void EndConversion();
+	void EndConversion(RAS_BoundingBoxManager *boundingBoxManager);
 
 	/// Return the list of blender's layers.
 	const LayerList& GetLayers() const;
@@ -170,8 +164,6 @@ public:
 	void SortPolygons(RAS_MeshSlot *ms, const MT_Transform &transform);
 
 	bool HasColliderPolygon();
-
-	void GetAabb(MT_Vector3 &aabbMin, MT_Vector3 &aabbMax);
 
 	// for construction to find shared vertices
 	struct SharedVertex

--- a/source/gameengine/Rasterizer/RAS_MeshUser.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.cpp
@@ -28,11 +28,13 @@
 
 #include "RAS_MeshUser.h"
 #include "RAS_DisplayArrayBucket.h"
+#include "RAS_BoundingBox.h"
 
 RAS_MeshUser::RAS_MeshUser(void *clientobj)
 	:m_frontFace(true),
 	m_color(MT_Vector4(0.0f, 0.0f, 0.0f, 0.0f)),
 	m_matrix(NULL),
+	m_boundingBox(NULL),
 	m_clientObject(clientobj)
 {
 }
@@ -40,6 +42,10 @@ RAS_MeshUser::RAS_MeshUser(void *clientobj)
 RAS_MeshUser::~RAS_MeshUser()
 {
 	m_meshSlots.clear();
+
+	if (m_boundingBox) {
+		m_boundingBox->RemoveUser();
+	}
 }
 
 void RAS_MeshUser::AddMeshSlot(RAS_MeshSlot *meshSlot)
@@ -60,6 +66,11 @@ const MT_Vector4& RAS_MeshUser::GetColor() const
 float *RAS_MeshUser::GetMatrix() const
 {
 	return m_matrix;
+}
+
+RAS_BoundingBox *RAS_MeshUser::GetBoundingBox() const
+{
+	return m_boundingBox;
 }
 
 void *RAS_MeshUser::GetClientObject() const
@@ -85,6 +96,19 @@ void RAS_MeshUser::SetColor(const MT_Vector4& color)
 void RAS_MeshUser::SetMatrix(float *matrix)
 {
 	m_matrix = matrix;
+}
+
+void RAS_MeshUser::SetBoundingBox(RAS_BoundingBox *boundingBox)
+{
+	if (m_boundingBox) {
+		m_boundingBox->RemoveUser();
+	}
+
+	m_boundingBox = boundingBox;
+
+	if (m_boundingBox) {
+		m_boundingBox->AddUser();
+	}
 }
 
 void RAS_MeshUser::ActivateMeshSlots()

--- a/source/gameengine/Rasterizer/RAS_MeshUser.h
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.h
@@ -32,6 +32,8 @@
 #include "RAS_MeshSlot.h"
 #include "MT_Vector4.h"
 
+class RAS_BoundingBox;
+
 class RAS_MeshUser
 {
 private:
@@ -41,7 +43,9 @@ private:
 	MT_Vector4 m_color;
 	/// Object transformation matrix.
 	float *m_matrix;
-	/// CLient object owner of this mesh user.
+	/// Bounding box corresponding to a mesh or deformer.
+	RAS_BoundingBox *m_boundingBox;
+	/// Client object owner of this mesh user.
 	void *m_clientObject;
 	/// Unique mesh slots used for render of this object.
 	RAS_MeshSlotList m_meshSlots;
@@ -54,12 +58,14 @@ public:
 	bool GetFrontFace() const;
 	const MT_Vector4& GetColor() const;
 	float *GetMatrix() const;
+	RAS_BoundingBox *GetBoundingBox() const;
 	void *GetClientObject() const;
 	RAS_MeshSlotList& GetMeshSlots();
 
 	void SetFrontFace(bool frontFace);
 	void SetColor(const MT_Vector4& color);
 	void SetMatrix(float *matrix);
+	void SetBoundingBox(RAS_BoundingBox *boundingBox);
 
 	void ActivateMeshSlots();
 };


### PR DESCRIPTION
`RAS_IDisplayArray` contains now the modification flag instead of `RAS_MeshObject` previously. It allow to reduce updating all the display array when only one is modified.

About bounding boxes, a manager containing all the bounding box of a scene is added. This manager ask to update the bounding box before each culling test. A bounding box is created by a modifier or by a mesh. The one created by the modifier contains an AABB directly set by the deformer. The other for the mesh contains a list of display array, it detect and update the AABB at the update time.

Why ?

Previously all the object tested if the mesh changed or if there's dynamic deformer and then tested to update the AABB. Which mean that if we have 10000 objects we will run 10000 times the complex condition:

```
bool meshModified = ((m_meshes.size() > 0) && (m_meshes[0]->GetModifiedFlag() & RAS_MeshObject::AABB_MODIFIED)) ||
-                       (deformer && deformer->IsDynamic());
```

Now as the bounding box is shared between objects, then the condition is made only one time and all the objects can reuse its value.
