### PR TITLE
UPBGE: Add objects LOD option while we render Cube Maps

### DIFF
--- a/release/scripts/startup/bl_operators/object.py
+++ b/release/scripts/startup/bl_operators/object.py
@@ -1034,3 +1034,159 @@ class LodGenerate(Operator):
         scene.objects.active = ob
 
         return {'FINISHED'}
+
+class CubeMapLodByName(Operator):
+    """Add levels of detail to this object based on object names"""
+    bl_idname = "object.lod_by_name"
+    bl_label = "Setup Levels of Detail By Name"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object is not None)
+
+    def execute(self, context):
+        ob = context.active_object
+
+        prefix = ""
+        suffix = ""
+        name = ""
+        if ob.name.lower().startswith("lod0"):
+            prefix = ob.name[:4]
+            name = ob.name[4:]
+        elif ob.name.lower().endswith("lod0"):
+            name = ob.name[:-4]
+            suffix = ob.name[-4:]
+        else:
+            return {'CANCELLED'}
+
+        level = 0
+        while True:
+            level += 1
+
+            if prefix:
+                prefix = prefix[:3] + str(level)
+            if suffix:
+                suffix = suffix[:3] + str(level)
+
+            lod = None
+            try:
+                lod = bpy.data.objects[prefix + name + suffix]
+            except KeyError:
+                break
+
+            try:
+                ob.cubemap_lod_levels[level]
+            except IndexError:
+                bpy.ops.object.cubemap_lod_add()
+
+            ob.cubemap_lod_levels[level].object = lod
+
+        return {'FINISHED'}
+
+
+class CubeMapLodClearAll(Operator):
+    """Remove all levels of detail from this object"""
+    bl_idname = "object.lod_clear_all"
+    bl_label = "Clear All Levels of Detail"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object is not None)
+
+    def execute(self, context):
+        ob = context.active_object
+
+        if ob.cubemap_lod_levels:
+            while 'CANCELLED' not in bpy.ops.object.cubemap_lod_remove():
+                pass
+
+        return {'FINISHED'}
+
+
+class CubeMapLodGenerate(Operator):
+    """Generate levels of detail using the decimate modifier"""
+    bl_idname = "object.lod_generate"
+    bl_label = "Generate Levels of Detail"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    count = IntProperty(
+            name="Count",
+            default=3,
+            )
+    target = FloatProperty(
+            name="Target Size",
+            min=0.0, max=1.0,
+            default=0.1,
+            )
+    package = BoolProperty(
+            name="Package into Group",
+            default=False,
+            )
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object is not None)
+
+    def execute(self, context):
+        scene = context.scene
+        ob = scene.objects.active
+
+        lod_name = ob.name
+        lod_suffix = "lod"
+        lod_prefix = ""
+        if lod_name.lower().endswith("lod0"):
+            lod_suffix = lod_name[-3:-1]
+            lod_name = lod_name[:-3]
+        elif lod_name.lower().startswith("lod0"):
+            lod_suffix = ""
+            lod_prefix = lod_name[:3]
+            lod_name = lod_name[4:]
+
+        group_name = lod_name.strip(' ._')
+        if self.package:
+            try:
+                bpy.ops.object.group_link(group=group_name)
+            except TypeError:
+                bpy.ops.group.create(name=group_name)
+
+        step = (1.0 - self.target) / (self.count - 1)
+        for i in range(1, self.count):
+            scene.objects.active = ob
+            bpy.ops.object.duplicate()
+            lod = context.selected_objects[0]
+
+            scene.objects.active = ob
+            bpy.ops.object.cubemap_lod_add()
+            scene.objects.active = lod
+
+            if lod_prefix:
+                lod.name = lod_prefix + str(i) + lod_name
+            else:
+                lod.name = lod_name + lod_suffix + str(i)
+
+            lod.location.y = ob.location.y + 3.0 * i
+
+            if i == 1:
+                modifier = lod.modifiers.new("lod_decimate", 'DECIMATE')
+            else:
+                modifier = lod.modifiers[-1]
+
+            modifier.ratio = 1.0 - step * i
+
+            ob.cubemap_lod_levels[i].object = lod
+
+            if self.package:
+                bpy.ops.object.group_link(group=group_name)
+                lod.parent = ob
+
+        if self.package:
+            for level in ob.cubemap_lod_levels[1:]:
+                level.object.hide = level.object.hide_render = True
+
+        lod.select = False
+        ob.select = True
+        scene.objects.active = ob
+
+        return {'FINISHED'}

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -917,6 +917,46 @@ class OBJECT_PT_levels_of_detail(ObjectButtonsPanel, Panel):
         row.operator("object.lod_add", text="Add", icon='ZOOMIN')
         row.menu("OBJECT_MT_lod_tools", text="", icon='TRIA_DOWN')
 
+class OBJECT_PT_levels_of_detail_cubemap(ObjectButtonsPanel, Panel):
+    bl_label = "Levels of Detail Cube Map"
+    COMPAT_ENGINES = {'BLENDER_GAME'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.render.engine in cls.COMPAT_ENGINES
+
+    def draw(self, context):
+        layout = self.layout
+        ob = context.object
+        gs = context.scene.game_settings
+
+        col = layout.column()
+
+        for i, level in enumerate(ob.cubemap_lod_levels):
+            if i == 0:
+                continue
+            box = col.box()
+            row = box.row()
+            row.prop(level, "object", text="")
+            row.operator("object.cubemap_lod_remove", text="", icon='PANEL_CLOSE').index = i
+
+            row = box.row()
+            row.prop(level, "distance")
+            row = row.row(align=True)
+            row.prop(level, "use_mesh", text="")
+            row.prop(level, "use_material", text="")
+
+            row = box.row()
+            row.active = gs.use_scene_hysteresis
+            row.prop(level, "use_object_hysteresis", text="Hysteresis Override")
+            row = box.row()
+            row.active = gs.use_scene_hysteresis and level.use_object_hysteresis
+            row.prop(level, "object_hysteresis_percentage", text="")
+
+        row = col.row(align=True)
+        row.operator("object.cubemap_lod_add", text="Add", icon='ZOOMIN')
+        row.menu("OBJECT_MT_lod_tools", text="", icon='TRIA_DOWN')
+
 
 if __name__ == "__main__":  # only for live edit.
     bpy.utils.register_module(__name__)

--- a/release/scripts/startup/bl_ui/properties_texture.py
+++ b/release/scripts/startup/bl_ui/properties_texture.py
@@ -648,6 +648,11 @@ class TEXTURE_PT_envmap(TextureTypePanel, Panel):
             if env.source == 'REALTIME':
                 row = layout.row()
                 row.prop(env, "filtering", expand=False)
+                row = layout.row()
+                row.prop(env, "use_lod")
+                sub = row.row(align=True)
+                sub.active = env.use_lod
+                sub.prop(env, "lod_factor")
 
 
 class TEXTURE_PT_envmap_sampling(TextureTypePanel, Panel):

--- a/source/blender/blenkernel/BKE_object.h
+++ b/source/blender/blenkernel/BKE_object.h
@@ -107,7 +107,10 @@ struct Object *BKE_object_lod_matob_get(struct Object *ob, struct Scene *scene);
 
 //CubeMap LOD
 void BKE_object_cubemap_lod_add(struct Object *ob);
+void BKE_object_cubemap_lod_sort(struct Object *ob);
 bool BKE_object_cubemap_lod_remove(struct Object *ob, int level);
+struct Object *BKE_object_cubemap_lod_meshob_get(struct Object *ob, struct Scene *scene);
+struct Object *BKE_object_cubemap_lod_matob_get(struct Object *ob, struct Scene *scene);
 
 struct Object *BKE_object_copy_ex(struct Main *bmain, struct Object *ob, bool copy_caches);
 struct Object *BKE_object_copy(struct Main *bmain, struct Object *ob);

--- a/source/blender/blenkernel/BKE_object.h
+++ b/source/blender/blenkernel/BKE_object.h
@@ -105,6 +105,13 @@ bool BKE_object_lod_is_usable(struct Object *ob, struct Scene *scene);
 struct Object *BKE_object_lod_meshob_get(struct Object *ob, struct Scene *scene);
 struct Object *BKE_object_lod_matob_get(struct Object *ob, struct Scene *scene);
 
+//CubeMap LOD
+void BKE_object_cubemap_lod_add(struct Object *ob);
+void BKE_object_cubemap_lod_sort(struct Object *ob);
+bool BKE_object_cubemap_lod_remove(struct Object *ob, int level);
+struct Object *BKE_object_cubemap_lod_meshob_get(struct Object *ob, struct Scene *scene);
+struct Object *BKE_object_cubemap_lod_matob_get(struct Object *ob, struct Scene *scene);
+
 struct Object *BKE_object_copy_ex(struct Main *bmain, struct Object *ob, bool copy_caches);
 struct Object *BKE_object_copy(struct Main *bmain, struct Object *ob);
 void BKE_object_make_local(struct Main *bmain, struct Object *ob, const bool lib_local);

--- a/source/blender/blenkernel/BKE_object.h
+++ b/source/blender/blenkernel/BKE_object.h
@@ -107,10 +107,7 @@ struct Object *BKE_object_lod_matob_get(struct Object *ob, struct Scene *scene);
 
 //CubeMap LOD
 void BKE_object_cubemap_lod_add(struct Object *ob);
-void BKE_object_cubemap_lod_sort(struct Object *ob);
 bool BKE_object_cubemap_lod_remove(struct Object *ob, int level);
-struct Object *BKE_object_cubemap_lod_meshob_get(struct Object *ob, struct Scene *scene);
-struct Object *BKE_object_cubemap_lod_matob_get(struct Object *ob, struct Scene *scene);
 
 struct Object *BKE_object_copy_ex(struct Main *bmain, struct Object *ob, bool copy_caches);
 struct Object *BKE_object_copy(struct Main *bmain, struct Object *ob);

--- a/source/blender/blenkernel/intern/library_query.c
+++ b/source/blender/blenkernel/intern/library_query.c
@@ -511,6 +511,13 @@ void BKE_library_foreach_ID_link(ID *id, LibraryIDLinkCallback callback, void *u
 					}
 				}
 
+				if (object->cubemaplodlevels.first) {
+					LodLevel *level;
+					for (level = object->cubemaplodlevels.first; level; level = level->next) {
+						CALLBACK_INVOKE(level->source, IDWALK_NOP);
+					}
+				}
+
 				modifiers_foreachIDLink(object, library_foreach_modifiersForeachIDLink, &data);
 				BKE_constraints_id_loop(&object->constraints, library_foreach_constraintObjectLooper, &data);
 

--- a/source/blender/blenkernel/intern/object.c
+++ b/source/blender/blenkernel/intern/object.c
@@ -1138,7 +1138,7 @@ static void copy_object_cubemap_lod(Object *obn, Object *ob)
 	if (obn->cubemaplodlevels.first)
 		((LodLevel *)obn->cubemaplodlevels.first)->source = obn;
 
-	obn->currentlod = (LodLevel *)obn->cubemaplodlevels.first;
+	obn->currentcubemaplod = (LodLevel *)obn->cubemaplodlevels.first;
 }
 
 bool BKE_object_pose_context_check(Object *ob)

--- a/source/blender/blenkernel/intern/object.c
+++ b/source/blender/blenkernel/intern/object.c
@@ -852,11 +852,6 @@ void BKE_object_cubemap_lod_add(Object *ob)
 	BLI_addtail(&ob->cubemaplodlevels, lod);
 }
 
-void BKE_object_cubemap_lod_sort(Object *ob)
-{
-	BLI_listbase_sort(&ob->cubemaplodlevels, lod_cmp);
-}
-
 bool BKE_object_cubemap_lod_remove(Object *ob, int level)
 {
 	LodLevel *rem;
@@ -882,30 +877,6 @@ bool BKE_object_cubemap_lod_remove(Object *ob, int level)
 	}
 
 	return true;
-}
-
-static Object *cubemap_lod_ob_get(Object *ob, Scene *scene, int flag)
-{
-	LodLevel *current = ob->currentcubemaplod;
-
-	if (!current || !BKE_object_lod_is_usable(ob, scene))
-		return ob;
-
-	while (current->prev && (!(current->flags & flag) || !current->source || current->source->type != OB_MESH)) {
-		current = current->prev;
-	}
-
-	return current->source;
-}
-
-struct Object *BKE_object_cubemap_lod_meshob_get(Object *ob, Scene *scene)
-{
-	return cubemap_lod_ob_get(ob, scene, OB_LOD_USE_MESH);
-}
-
-struct Object *BKE_object_cubemap_lod_matob_get(Object *ob, Scene *scene)
-{
-	return cubemap_lod_ob_get(ob, scene, OB_LOD_USE_MAT);
 }
 
 #endif  /* WITH_GAMEENGINE */
@@ -1131,16 +1102,6 @@ static void copy_object_lod(Object *obn, Object *ob)
 	obn->currentlod = (LodLevel *)obn->lodlevels.first;
 }
 
-static void copy_object_cubemap_lod(Object *obn, Object *ob)
-{
-	BLI_duplicatelist(&obn->cubemaplodlevels, &ob->cubemaplodlevels);
-
-	if (obn->cubemaplodlevels.first)
-		((LodLevel *)obn->cubemaplodlevels.first)->source = obn;
-
-	obn->currentlod = (LodLevel *)obn->cubemaplodlevels.first;
-}
-
 bool BKE_object_pose_context_check(Object *ob)
 {
 	if ((ob) &&
@@ -1258,7 +1219,6 @@ Object *BKE_object_copy_ex(Main *bmain, Object *ob, bool copy_caches)
 	obn->mpath = NULL;
 
 	copy_object_lod(obn, ob);
-	copy_object_cubemap_lod(obn, ob);
 	
 	/* Copy runtime surve data. */
 	obn->curve_cache = NULL;

--- a/source/blender/blenkernel/intern/object.c
+++ b/source/blender/blenkernel/intern/object.c
@@ -446,6 +446,8 @@ void BKE_object_free(Object *ob)
 
 	BLI_freelistN(&ob->lodlevels);
 
+	BLI_freelistN(&ob->cubemaplodlevels);
+
 	/* Free runtime curves data. */
 	if (ob->curve_cache) {
 		BKE_curve_bevelList_free(&ob->curve_cache->bev);
@@ -827,6 +829,85 @@ struct Object *BKE_object_lod_matob_get(Object *ob, Scene *scene)
 	return lod_ob_get(ob, scene, OB_LOD_USE_MAT);
 }
 
+// CubeMap LOD
+void BKE_object_cubemap_lod_add(Object *ob)
+{
+	LodLevel *lod = MEM_callocN(sizeof(LodLevel), "LoD Level");
+	LodLevel *last = ob->cubemaplodlevels.last;
+
+	/* If the lod list is empty, initialize it with the base lod level */
+	if (!last) {
+		LodLevel *base = MEM_callocN(sizeof(LodLevel), "Base LoD Level");
+		BLI_addtail(&ob->cubemaplodlevels, base);
+		base->flags = OB_LOD_USE_MESH | OB_LOD_USE_MAT;
+		base->source = ob;
+		base->obhysteresis = 10;
+		last = ob->currentcubemaplod = base;
+	}
+
+	lod->distance = last->distance + 25.0f;
+	lod->obhysteresis = 10;
+	lod->flags = OB_LOD_USE_MESH | OB_LOD_USE_MAT;
+
+	BLI_addtail(&ob->cubemaplodlevels, lod);
+}
+
+void BKE_object_cubemap_lod_sort(Object *ob)
+{
+	BLI_listbase_sort(&ob->cubemaplodlevels, lod_cmp);
+}
+
+bool BKE_object_cubemap_lod_remove(Object *ob, int level)
+{
+	LodLevel *rem;
+
+	if (level < 1 || level > BLI_listbase_count(&ob->cubemaplodlevels) - 1)
+		return false;
+
+	rem = BLI_findlink(&ob->cubemaplodlevels, level);
+
+	if (rem == ob->currentcubemaplod) {
+		ob->currentcubemaplod = rem->prev;
+	}
+
+	BLI_remlink(&ob->cubemaplodlevels, rem);
+	MEM_freeN(rem);
+
+	/* If there are no user defined lods, remove the base lod as well */
+	if (BLI_listbase_is_single(&ob->cubemaplodlevels)) {
+		LodLevel *base = ob->cubemaplodlevels.first;
+		BLI_remlink(&ob->cubemaplodlevels, base);
+		MEM_freeN(base);
+		ob->currentcubemaplod = NULL;
+	}
+
+	return true;
+}
+
+static Object *cubemap_lod_ob_get(Object *ob, Scene *scene, int flag)
+{
+	LodLevel *current = ob->currentcubemaplod;
+
+	if (!current || !BKE_object_lod_is_usable(ob, scene))
+		return ob;
+
+	while (current->prev && (!(current->flags & flag) || !current->source || current->source->type != OB_MESH)) {
+		current = current->prev;
+	}
+
+	return current->source;
+}
+
+struct Object *BKE_object_cubemap_lod_meshob_get(Object *ob, Scene *scene)
+{
+	return cubemap_lod_ob_get(ob, scene, OB_LOD_USE_MESH);
+}
+
+struct Object *BKE_object_cubemap_lod_matob_get(Object *ob, Scene *scene)
+{
+	return cubemap_lod_ob_get(ob, scene, OB_LOD_USE_MAT);
+}
+
 #endif  /* WITH_GAMEENGINE */
 
 
@@ -1050,6 +1131,16 @@ static void copy_object_lod(Object *obn, Object *ob)
 	obn->currentlod = (LodLevel *)obn->lodlevels.first;
 }
 
+static void copy_object_cubemap_lod(Object *obn, Object *ob)
+{
+	BLI_duplicatelist(&obn->cubemaplodlevels, &ob->cubemaplodlevels);
+
+	if (obn->cubemaplodlevels.first)
+		((LodLevel *)obn->cubemaplodlevels.first)->source = obn;
+
+	obn->currentlod = (LodLevel *)obn->cubemaplodlevels.first;
+}
+
 bool BKE_object_pose_context_check(Object *ob)
 {
 	if ((ob) &&
@@ -1167,6 +1258,7 @@ Object *BKE_object_copy_ex(Main *bmain, Object *ob, bool copy_caches)
 	obn->mpath = NULL;
 
 	copy_object_lod(obn, ob);
+	copy_object_cubemap_lod(obn, ob);
 	
 	/* Copy runtime surve data. */
 	obn->curve_cache = NULL;

--- a/source/blender/blenkernel/intern/texture.c
+++ b/source/blender/blenkernel/intern/texture.c
@@ -650,7 +650,8 @@ void BKE_texture_default(Tex *tex)
 		tex->env->clipend = 100;
 		tex->env->cuberes = 512;
 		tex->env->depth = 0;
-		tex->env->flag = ENVMAP_AUTO_UPDATE;
+		tex->env->flag |= ENVMAP_AUTO_UPDATE;
+		tex->env->flag |= ~ENVMAP_USE_LOD;
 	}
 
 	if (tex->pd) {
@@ -1263,7 +1264,8 @@ EnvMap *BKE_texture_envmap_add(void)
 	env->clipend = 100.0;
 	env->cuberes = 512;
 	env->viewscale = 0.5;
-	env->flag = ENVMAP_AUTO_UPDATE;
+	env->flag |= ENVMAP_AUTO_UPDATE;
+	env->flag |= ~ENVMAP_USE_LOD;
 
 	return env;
 } 

--- a/source/blender/blenloader/intern/readfile.c
+++ b/source/blender/blenloader/intern/readfile.c
@@ -4967,6 +4967,12 @@ static void lib_link_object(FileData *fd, Main *main)
 					if (!level->source && level == ob->lodlevels.first)
 						level->source = ob;
 				}
+				for (level = ob->cubemaplodlevels.first; level; level = level->next) {
+					level->source = newlibadr(fd, ob->id.lib, level->source);
+
+					if (!level->source && level == ob->cubemaplodlevels.first)
+						level->source = ob;
+				}
 			}
 		}
 	}
@@ -5570,6 +5576,9 @@ static void direct_link_object(FileData *fd, Object *ob)
 
 	link_list(fd, &ob->lodlevels);
 	ob->currentlod = ob->lodlevels.first;
+
+	link_list(fd, &ob->cubemaplodlevels);
+	ob->currentcubemaplod = ob->cubemaplodlevels.first;
 
 	ob->preview = direct_link_preview_image(fd, ob->preview);
 }
@@ -9459,6 +9468,13 @@ static void expand_object(FileData *fd, Main *mainvar, Object *ob)
 	if (ob->currentlod) {
 		LodLevel *level;
 		for (level = ob->lodlevels.first; level; level = level->next) {
+			expand_doit(fd, mainvar, level->source);
+		}
+	}
+
+	if (ob->currentcubemaplod) {
+		LodLevel *level;
+		for (level = ob->cubemaplodlevels.first; level; level = level->next) {
 			expand_doit(fd, mainvar, level->source);
 		}
 	}

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -128,5 +128,12 @@ void blo_do_versions_upbge(FileData *fd, Library *UNUSED(lib), Main *main)
 				}
 			}
 		}
+		if (!DNA_struct_elem_find(fd->filesdna, "EnvMap", "short", "flag")) {
+			for (Tex *tex = main->tex.first; tex; tex = tex->id.next) {
+				if (tex->env) {
+					tex->env->flag |= ~ENVMAP_USE_LOD;
+				}
+			}
+		}
 	}
 }

--- a/source/blender/blenloader/intern/writefile.c
+++ b/source/blender/blenloader/intern/writefile.c
@@ -1925,6 +1925,7 @@ static void write_objects(WriteData *wd, ListBase *idbase)
 
 			writelist(wd, DATA, LinkData, &ob->pc_ids);
 			writelist(wd, DATA, LodLevel, &ob->lodlevels);
+			writelist(wd, DATA, LodLevel, &ob->cubemaplodlevels);
 		}
 
 		write_previews(wd, ob->preview);

--- a/source/blender/editors/object/CMakeLists.txt
+++ b/source/blender/editors/object/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRC
 	object_bake.c
 	object_bake_api.c
 	object_constraint.c
+	object_cubemap_lod.c
 	object_edit.c
 	object_group.c
 	object_hook.c

--- a/source/blender/editors/object/object_cubemap_lod.c
+++ b/source/blender/editors/object/object_cubemap_lod.c
@@ -1,0 +1,114 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) Blender Foundation
+ * All rights reserved.
+ *
+ * The Original Code is: all of this file.
+ *
+ * Contributor(s): none yet.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file blender/editors/object/object_cubemap_lod.c
+ *  \ingroup edobj
+ */
+
+#include "DNA_object_types.h"
+
+#include "BKE_context.h"
+
+#include "WM_api.h"
+#include "WM_types.h"
+
+#include "RNA_access.h"
+#include "RNA_define.h"
+
+#include "ED_screen.h"
+#include "ED_object.h"
+
+#ifdef WITH_GAMEENGINE
+#  include "BKE_object.h"
+
+#  include "RNA_enum_types.h"
+#endif
+
+#include "object_intern.h"
+
+static int object_lod_add_exec(bContext *C, wmOperator *UNUSED(op))
+{
+	Object *ob = ED_object_context(C);
+
+#ifdef WITH_GAMEENGINE
+	BKE_object_cubemap_lod_add(ob);
+#else
+	(void)ob;
+#endif
+
+	return OPERATOR_FINISHED;
+}
+
+void OBJECT_OT_cubemap_lod_add(wmOperatorType *ot)
+{
+	/* identifiers */
+	ot->name = "Add Level of Detail for cubemap";
+	ot->description = "Add a level of detail to this object";
+	ot->idname = "OBJECT_OT_cubemap_lod_add";
+
+	/* api callbacks */
+	ot->exec = object_lod_add_exec;
+	ot->poll = ED_operator_object_active;
+
+	/* flags */
+	ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
+static int object_lod_remove_exec(bContext *C, wmOperator *op)
+{
+	Object *ob = ED_object_context(C);
+	int index = RNA_int_get(op->ptr, "index");
+
+#ifdef WITH_GAMEENGINE
+	if (!BKE_object_cubemap_lod_remove(ob, index))
+		return OPERATOR_CANCELLED;
+#else
+	(void)ob;
+	(void)index;
+#endif
+
+	WM_event_add_notifier(C, NC_OBJECT | ND_LOD, CTX_wm_view3d(C));
+	return OPERATOR_FINISHED;
+}
+
+void OBJECT_OT_cubemap_lod_remove(wmOperatorType *ot)
+{
+	/* identifiers */
+	ot->name = "Remove Level of Detail for cubemap";
+	ot->description = "Remove a level of detail from this object";
+	ot->idname = "OBJECT_OT_cubemap_lod_remove";
+
+	/* api callbacks */
+	ot->exec = object_lod_remove_exec;
+	ot->poll = ED_operator_object_active;
+
+	/* flags */
+	ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+
+	/* properties */
+	ot->prop = RNA_def_int(ot->srna, "index", 1, 1, INT_MAX, "Index", "", 1, INT_MAX);
+}

--- a/source/blender/editors/object/object_intern.h
+++ b/source/blender/editors/object/object_intern.h
@@ -272,6 +272,10 @@ void OBJECT_OT_bake(wmOperatorType *ot);
 void OBJECT_OT_lod_add(struct wmOperatorType *ot);
 void OBJECT_OT_lod_remove(struct wmOperatorType *ot);
 
+/* object_cubemap_lod.c */
+void OBJECT_OT_cubemap_lod_add(struct wmOperatorType *ot);
+void OBJECT_OT_cubemap_lod_remove(struct wmOperatorType *ot);
+
 /* object_random.c */
 void TRANSFORM_OT_vertex_random(struct wmOperatorType *ot);
 

--- a/source/blender/editors/object/object_ops.c
+++ b/source/blender/editors/object/object_ops.c
@@ -250,6 +250,8 @@ void ED_operatortypes_object(void)
 
 	WM_operatortype_append(OBJECT_OT_lod_add);
 	WM_operatortype_append(OBJECT_OT_lod_remove);
+	WM_operatortype_append(OBJECT_OT_cubemap_lod_add);
+	WM_operatortype_append(OBJECT_OT_cubemap_lod_remove);
 
 	WM_operatortype_append(TRANSFORM_OT_vertex_random);
 

--- a/source/blender/makesdna/DNA_object_types.h
+++ b/source/blender/makesdna/DNA_object_types.h
@@ -299,6 +299,9 @@ typedef struct Object {
 	ListBase lodlevels;		/* contains data for levels of detail */
 	LodLevel *currentlod;
 
+	ListBase cubemaplodlevels;		/* contains data for cubemap levels of detail */
+	LodLevel *currentcubemaplod;
+
 	struct PreviewImage *preview;
 
 	struct Mesh *gamePredefinedBound;

--- a/source/blender/makesdna/DNA_texture_types.h
+++ b/source/blender/makesdna/DNA_texture_types.h
@@ -142,6 +142,7 @@ typedef struct EnvMap {
 	int ok, lastframe;
 	short recalc, lastsize;
 	int flag, filtering;
+	float lodfactor, pad;
 } EnvMap;
 
 typedef struct PointDensity {
@@ -479,6 +480,7 @@ typedef struct ColorMapping {
 
 /* flag */
 #define ENVMAP_AUTO_UPDATE	(1 << 0)
+#define ENVMAP_USE_LOD	    (1 << 1)
 
 /* filtering */
 #define ENVMAP_MIPMAP_NONE		0

--- a/source/blender/makesrna/intern/rna_object.c
+++ b/source/blender/makesrna/intern/rna_object.c
@@ -2161,7 +2161,6 @@ static void rna_def_object_lodlevel(BlenderRNA *brna)
 	RNA_def_property_update(prop, NC_OBJECT | ND_LOD, NULL);
 }
 
-
 static void rna_def_object(BlenderRNA *brna)
 {
 	StructRNA *srna;
@@ -2840,6 +2839,13 @@ static void rna_def_object(BlenderRNA *brna)
 	/* Levels of Detail */
 	prop = RNA_def_property(srna, "lod_levels", PROP_COLLECTION, PROP_NONE);
 	RNA_def_property_collection_sdna(prop, NULL, "lodlevels", NULL);
+	RNA_def_property_struct_type(prop, "LodLevel");
+	RNA_def_property_ui_text(prop, "Level of Detail Levels", "A collection of detail levels to automatically switch between");
+	RNA_def_property_update(prop, NC_OBJECT | ND_LOD, NULL);
+
+	/* Levels of Detail Cube Maps*/
+	prop = RNA_def_property(srna, "cubemap_lod_levels", PROP_COLLECTION, PROP_NONE);
+	RNA_def_property_collection_sdna(prop, NULL, "cubemaplodlevels", NULL);
 	RNA_def_property_struct_type(prop, "LodLevel");
 	RNA_def_property_ui_text(prop, "Level of Detail Levels", "A collection of detail levels to automatically switch between");
 	RNA_def_property_update(prop, NC_OBJECT | ND_LOD, NULL);

--- a/source/blender/makesrna/intern/rna_texture.c
+++ b/source/blender/makesrna/intern/rna_texture.c
@@ -865,6 +865,17 @@ static void rna_def_environment_map(BlenderRNA *brna)
 	RNA_def_property_enum_items(prop, prop_filtering_items);
 	RNA_def_property_ui_text(prop, "Filtering", "Texture filtering method");
 
+	prop = RNA_def_property(srna, "use_lod", PROP_BOOLEAN, 0);
+	RNA_def_property_boolean_sdna(prop, NULL, "flag", ENVMAP_USE_LOD);
+	RNA_def_property_ui_text(prop, "Use LOD", "Use Objects Level of details when rendering cube maps");
+
+	prop = RNA_def_property(srna, "lod_factor", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "lodfactor");
+	RNA_def_property_range(prop, 0.0, FLT_MAX);
+	RNA_def_property_ui_range(prop, 0.0, FLT_MAX, 100, 2);
+	RNA_def_property_ui_text(prop, "", "LOD distance factor applied to objects while rendering cube maps");
+	RNA_def_property_update(prop, 0, "rna_Texture_update");
+
 	RNA_api_environment_map(srna);
 }
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -932,6 +932,22 @@ static KX_LodManager *lodmanager_from_blenderobject(Object *ob, KX_Scene *scene,
 	return lodManager;
 }
 
+static KX_LodManager *cubemap_lodmanager_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)
+{
+	if (BLI_listbase_count_ex(&ob->cubemaplodlevels, 2) <= 1) {
+		return NULL;
+	}
+
+	KX_LodManager *lodManager = new KX_LodManager(ob, scene, converter, libloading);
+	// The lod manager is useless ?
+	if (lodManager->GetLevelCount() <= 1) {
+		lodManager->Release();
+		return NULL;
+	}
+
+	return lodManager;
+}
+
 static KX_LightObject *gamelight_from_blamp(Object *ob, Lamp *la, unsigned int layerflag, KX_Scene *kxscene, RAS_IRasterizer *rasterizer, KX_BlenderSceneConverter *converter)
 {
 	RAS_ILightObject *lightobj = rasterizer->CreateLight();
@@ -1056,6 +1072,8 @@ static KX_GameObject *gameobject_from_blenderobject(
 		// gather levels of detail
 		KX_LodManager *lodManager = lodmanager_from_blenderobject(ob, kxscene, converter, libloading);
 		gameobj->SetLodManager(lodManager);
+		KX_LodManager *cubemaplodManager = cubemap_lodmanager_from_blenderobject(ob, kxscene, converter, libloading);
+		gameobj->SetCubeMapLodManager(cubemaplodManager);
 
 		// for all objects: check whether they want to
 		// respond to updates

--- a/source/gameengine/Ketsji/KX_CubeMap.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMap.cpp
@@ -39,9 +39,12 @@ KX_CubeMap::KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint)
 	m_clipStart(env->clipsta),
 	m_clipEnd(env->clipend),
 	m_autoUpdate(true),
-	m_forceUpdate(true)
+	m_forceUpdate(true),
+	m_useLod(false),
+	m_lodFactor(env->lodfactor)
 {
 	m_autoUpdate = (env->flag & ENVMAP_AUTO_UPDATE) != 0;
+	m_useLod = (env->flag & ENVMAP_USE_LOD) != 0;
 }
 
 KX_CubeMap::~KX_CubeMap()
@@ -112,6 +115,16 @@ void KX_CubeMap::SetClipStart(float start)
 void KX_CubeMap::SetClipEnd(float end)
 {
 	m_clipEnd = end;
+}
+
+bool KX_CubeMap::GetUseLod() const
+{
+	return m_useLod;
+}
+
+float KX_CubeMap::GetLodFactor() const
+{
+	return m_lodFactor;
 }
 
 bool KX_CubeMap::NeedUpdate()

--- a/source/gameengine/Ketsji/KX_CubeMap.h
+++ b/source/gameengine/Ketsji/KX_CubeMap.h
@@ -67,6 +67,11 @@ private:
 	 */
 	bool m_forceUpdate;
 
+	/// Use level of detail
+	bool m_useLod;
+	/// Level of detail distance factor
+	float m_lodFactor;
+
 public:
 	KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint);
 	virtual ~KX_CubeMap();
@@ -80,6 +85,8 @@ public:
 	float GetClipEnd() const;
 	void SetClipStart(float start);
 	void SetClipEnd(float end);
+	float GetLodFactor() const;
+	bool GetUseLod() const;
 
 	void SetInvalidProjectionMatrix(bool invalid);
 	bool GetInvalidProjectionMatrix() const;

--- a/source/gameengine/Ketsji/KX_CubeMapManager.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMapManager.cpp
@@ -137,6 +137,11 @@ void KX_CubeMapManager::RenderCubeMap(RAS_IRasterizer *rasty, KX_CubeMap *cubeMa
 
 		m_scene->CalculateVisibleMeshes(rasty, m_camera, ~cubeMap->GetIgnoreLayers());
 
+		/* Update objects LOD from cubemap camera position while rendering cube map */
+		if (cubeMap->GetUseLod()) {
+			m_scene->UpdateObjectLodsForCubeMapsRendering(position, cubeMap->GetLodFactor());
+		}
+
 		/* Update animations to use the culling of each faces, BL_ActionManager avoid redundants
 		 * updates internally. */
 		KX_GetActiveEngine()->UpdateAnimations(m_scene);
@@ -149,6 +154,9 @@ void KX_CubeMapManager::RenderCubeMap(RAS_IRasterizer *rasty, KX_CubeMap *cubeMa
 	cubeMap->EndRender();
 
 	viewpoint->SetVisible(true, true);
+	if (cubeMap->GetUseLod()) {
+		m_scene->ResetObjectLodsAfterCubeMapRendering();
+	}
 }
 
 void KX_CubeMapManager::Render(RAS_IRasterizer *rasty)

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -89,8 +89,11 @@ protected:
 	int									m_layer;
 	std::vector<RAS_MeshObject*>		m_meshes;
 	KX_LodManager						*m_lodManager;
+	KX_LodManager						*m_cubeMapsLodManager;
 	short								m_currentLodLevel;
 	short								m_previousLodLevel;
+	short								m_cubeMapPreviousLodLevel;
+	short								m_cubeMapCurrentLodLevel;
 	RAS_MeshUser						*m_meshUser;
 	struct Object*						m_pBlenderObject;
 	struct Object*						m_pBlenderGroupObject;
@@ -764,10 +767,22 @@ public:
 	/// Get current lod manager.
 	KX_LodManager *GetLodManager() const;
 
+	/** Set current cube map lod manager, can be NULL.
+	* If NULL the object's mesh backs to the mesh of the previous first lod level.
+	*/
+	void SetCubeMapLodManager(KX_LodManager *lodManager);
+	/// Get current cube map lod manager.
+	KX_LodManager *GetCubeMapLodManager() const;
+
 	/**
 	 * Updates the current lod level based on distance from camera.
 	 */
 	void UpdateLod(const MT_Vector3& cam_pos, float lodfactor);
+
+	/**
+	* Updates the current lod level based on distance from cube map camera.
+	*/
+	void UpdateCubeMapLod(const MT_Vector3& cam_pos, float lodfactor, bool reset);
 
 	/**
 	 * Pick out a mesh associated with the integer 'num'.

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1716,6 +1716,24 @@ void KX_Scene::UpdateObjectLods()
 	}
 }
 
+void KX_Scene::UpdateObjectLodsForCubeMapsRendering(const MT_Vector3 &camPos, float lodDistanceFactor)
+{
+	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
+		KX_GameObject *gameobj = (KX_GameObject *)*it;
+		if (!gameobj->GetCulled()) {
+			gameobj->UpdateCubeMapLod(camPos, lodDistanceFactor, false);
+		}
+	}
+}
+
+void KX_Scene::ResetObjectLodsAfterCubeMapRendering()
+{
+	for (CListValue::iterator it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
+		KX_GameObject *gameobj = (KX_GameObject *)*it;		
+		gameobj->UpdateCubeMapLod(gameobj->NodeGetWorldPosition(), 1.0f, true);
+	}
+}
+
 void KX_Scene::SetLodHysteresis(bool active)
 {
 	m_isActivedHysteresis = active;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -496,6 +496,8 @@ public:
 
 	/// Update the mesh for objects based on level of detail settings
 	void UpdateObjectLods();
+	void UpdateObjectLodsForCubeMapsRendering(const MT_Vector3 &camPos, float lodDistanceFactor);
+	void ResetObjectLodsAfterCubeMapRendering();
 
 	// LoD Hysteresis functions
 	void SetLodHysteresis(bool active);


### PR DESCRIPTION
This was not easy because I had to replicate all the existing LOD system
(except the viewport part) to create a new one because an object can have
LOD for normal render pass computed according to distance from the active
camera and another LOD while we render cubemaps computed according to the
distance from the cubemap rendering camera.

The patch might be simplified and cleaned up. This was just a test to
answer Maujoe feature request. A long copy/paste session.

I don't know if this patch is a good idea because this needs to replace
mesh when we begin cubemap rendering pass and restore mesh after rendering
pass. This might be costfull in terms of performances. I don't know.

But maybe in some cases it could be useful. The debate is opened.

I make a pull request but this is low priority. It's just to have better visibility of the code but the pull request can be removed if we estimate that this is not a good idea.

test file: http://pasteall.org/blend/index.php?id=43980

Perf test: http://pasteall.org/blend/index.php?id=43981 very weird behaviour (when the cubemap object is at the same position than the sphere)

video: https://www.youtube.com/watch?v=y12cKwfm5w0
