### PR TITLE
UPBGE: Prevent cubemap rendering if the cubemap object is culled at previous frame

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1800,7 +1800,7 @@ void BL_ConvertBlenderObjects(struct Main* maggie,
 							}
 						}
 
-						kxscene->GetCubeMapManager()->AddCubeMap(tex, viewpoint);
+						kxscene->GetCubeMapManager()->AddCubeMap(tex, viewpoint, gameobj);
 					}
 				}
 			}

--- a/source/gameengine/Ketsji/KX_CubeMap.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMap.cpp
@@ -123,9 +123,9 @@ bool KX_CubeMap::NeedUpdate()
 	return result;
 }
 
-bool KX_CubeMap::ViewPointObjIsCubeMapObj()
+KX_GameObject *KX_CubeMap::GetGameObject()
 {
-	return m_viewpointObject == m_cubeMapObject;
+	return m_cubeMapObject;
 }
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_CubeMap.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMap.cpp
@@ -30,7 +30,7 @@
 
 #include "DNA_texture_types.h"
 
-KX_CubeMap::KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint)
+KX_CubeMap::KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint, KX_GameObject *cubemapobj)
 	:RAS_CubeMap(),
 	m_viewpointObject(viewpoint),
 	m_invalidProjection(true),
@@ -39,7 +39,8 @@ KX_CubeMap::KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint)
 	m_clipStart(env->clipsta),
 	m_clipEnd(env->clipend),
 	m_autoUpdate(true),
-	m_forceUpdate(true)
+	m_forceUpdate(true),
+	m_cubeMapObject(cubemapobj)
 {
 	m_autoUpdate = (env->flag & ENVMAP_AUTO_UPDATE) != 0;
 }
@@ -120,6 +121,11 @@ bool KX_CubeMap::NeedUpdate()
 	m_forceUpdate = false;
 
 	return result;
+}
+
+bool KX_CubeMap::ViewPointObjIsCubeMapObj()
+{
+	return m_viewpointObject == m_cubeMapObject;
 }
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_CubeMap.h
+++ b/source/gameengine/Ketsji/KX_CubeMap.h
@@ -92,7 +92,7 @@ public:
 	bool GetEnabled() const;
 	int GetIgnoreLayers() const;
 
-	bool ViewPointObjIsCubeMapObj();
+	KX_GameObject *GetGameObject();
 
 	// Return true when this cube map need to be updated.
 	bool NeedUpdate();

--- a/source/gameengine/Ketsji/KX_CubeMap.h
+++ b/source/gameengine/Ketsji/KX_CubeMap.h
@@ -44,6 +44,9 @@ private:
 	/// The object used to render from its position.
 	KX_GameObject *m_viewpointObject;
 
+	/// Object which has the cubemap texture
+	KX_GameObject *m_cubeMapObject;
+
 	/// The camera projection matrix depending on clip start/end.
 	MT_Matrix4x4 m_projection;
 
@@ -68,7 +71,7 @@ private:
 	bool m_forceUpdate;
 
 public:
-	KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint);
+	KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint, KX_GameObject *cubemapobj);
 	virtual ~KX_CubeMap();
 
 	virtual STR_String& GetName();
@@ -88,6 +91,8 @@ public:
 
 	bool GetEnabled() const;
 	int GetIgnoreLayers() const;
+
+	bool ViewPointObjIsCubeMapObj();
 
 	// Return true when this cube map need to be updated.
 	bool NeedUpdate();

--- a/source/gameengine/Ketsji/KX_CubeMapManager.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMapManager.cpp
@@ -89,14 +89,12 @@ void KX_CubeMapManager::RenderCubeMap(RAS_IRasterizer *rasty, KX_CubeMap *cubeMa
 	KX_GameObject *viewpoint = cubeMap->GetViewpointObject();
 
 	/* Doesn't need (or can) update.
-	 * About viewpoint->GetCulled() -> If the viewpoint object is the cubemap object: Cubemaps are rendered before
-	 * scene->CalculateVisibleMeshes() so we can't really prevent cubemap rendering (if the viewpoint object is
-	 * the cubemap object and) if this object is Culled. However, we can get previous frame culling state of this
+	 * About cubemapobj->GetCulled() -> Cubemaps are rendered before
+	 * scene->CalculateVisibleMeshes() so we can't really prevent cubemap rendering if
+	 * cubemap object is culled. However, we can get previous frame culling state of this
 	 * object and prevent cubemap rendering if this object was culled at the previous frame.
-	 * But if the viewpoint object is not the cubemap object, we can't prevent cubemap rendering because the
-	 * cubemap texture has to be rendered even if the viewpoint object is outside frustum.
 	 */
-	if (!cubeMap->NeedUpdate() || !cubeMap->GetEnabled() || !viewpoint || (viewpoint->GetCulled() && cubeMap->ViewPointObjIsCubeMapObj())) {
+	if (!cubeMap->NeedUpdate() || !cubeMap->GetEnabled() || !viewpoint || cubeMap->GetGameObject()->GetCulled()) {
 		return;
 	}
 

--- a/source/gameengine/Ketsji/KX_CubeMapManager.cpp
+++ b/source/gameengine/Ketsji/KX_CubeMapManager.cpp
@@ -54,7 +54,7 @@ KX_CubeMapManager::~KX_CubeMapManager()
 	m_camera->Release();
 }
 
-void KX_CubeMapManager::AddCubeMap(RAS_Texture *texture, KX_GameObject *gameobj)
+void KX_CubeMapManager::AddCubeMap(RAS_Texture *texture, KX_GameObject *viewpoint, KX_GameObject *cubemapobj)
 {
 	for (std::vector<KX_CubeMap *>::iterator it = m_cubeMaps.begin(), end = m_cubeMaps.end(); it != end; ++it) {
 		KX_CubeMap *cubeMap = *it;
@@ -68,7 +68,7 @@ void KX_CubeMapManager::AddCubeMap(RAS_Texture *texture, KX_GameObject *gameobj)
 	}
 
 	EnvMap *env = texture->GetTex()->env;
-	KX_CubeMap *cubeMap = new KX_CubeMap(env, gameobj);
+	KX_CubeMap *cubeMap = new KX_CubeMap(env, viewpoint, cubemapobj);
 	cubeMap->AddTextureUser(texture);
 	texture->SetCubeMap(cubeMap);
 	m_cubeMaps.push_back(cubeMap);
@@ -88,8 +88,15 @@ void KX_CubeMapManager::RenderCubeMap(RAS_IRasterizer *rasty, KX_CubeMap *cubeMa
 {
 	KX_GameObject *viewpoint = cubeMap->GetViewpointObject();
 
-	// Doesn't need (or can) update.
-	if (!cubeMap->NeedUpdate() || !cubeMap->GetEnabled() || !viewpoint) {
+	/* Doesn't need (or can) update.
+	 * About viewpoint->GetCulled() -> If the viewpoint object is the cubemap object: Cubemaps are rendered before
+	 * scene->CalculateVisibleMeshes() so we can't really prevent cubemap rendering (if the viewpoint object is
+	 * the cubemap object and) if this object is Culled. However, we can get previous frame culling state of this
+	 * object and prevent cubemap rendering if this object was culled at the previous frame.
+	 * But if the viewpoint object is not the cubemap object, we can't prevent cubemap rendering because the
+	 * cubemap texture has to be rendered even if the viewpoint object is outside frustum.
+	 */
+	if (!cubeMap->NeedUpdate() || !cubeMap->GetEnabled() || !viewpoint || (viewpoint->GetCulled() && cubeMap->ViewPointObjIsCubeMapObj())) {
 		return;
 	}
 

--- a/source/gameengine/Ketsji/KX_CubeMapManager.h
+++ b/source/gameengine/Ketsji/KX_CubeMapManager.h
@@ -60,7 +60,7 @@ public:
 	/** Add and create a cube map if none existing cube map was using the same
 	 * texture containing in the material texture passed.
 	 */
-	void AddCubeMap(RAS_Texture *texture, KX_GameObject *gameobj);
+	void AddCubeMap(RAS_Texture *texture, KX_GameObject *viewpoint, KX_GameObject *cubemapobj);
 	/// Invalidate cube map using the given game object as viewpoint object.
 	void InvalidateCubeMapViewpoint(KX_GameObject *gameobj);
 


### PR DESCRIPTION
See comments in KX_CubeMapManager.cpp

Test file: http://pasteall.org/blend/index.php?id=43999
