### PR TITLE
UPBGE: Add an API to access filter pass texture bindcode

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -31,3 +31,9 @@ base class --- :class:`BL_Shader`
       :type bindCode: integer
       :arg samplerName: The shader sampler name set to :data:`index` if :data:`samplerName` is passed in the function. (optional)
       :type samplerName: string
+
+   .. attribute:: colorBindCode
+
+      Get the bindcode of the texture rendered in this filter.
+
+      :type: integer

--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -535,7 +535,7 @@ void GPU_shader_free(GPUShader *shader)
 
 int GPU_shader_get_uniform(GPUShader *shader, const char *name)
 {
-	return glGetUniformLocation(shader->program, name);
+	return shader? glGetUniformLocation(shader->program, name) : -1;
 }
 
 void *GPU_shader_get_interface(GPUShader *shader)

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -71,6 +71,7 @@ PyMethodDef KX_2DFilter::Methods[] = {
 };
 
 PyAttributeDef KX_2DFilter::Attributes[] = {
+	KX_PYATTRIBUTE_RO_FUNCTION("colorBindCode", KX_2DFilter, pyattr_get_color_bind_code),
 	{NULL} // Sentinel
 };
 
@@ -103,6 +104,12 @@ KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode, sampler
 
 	m_textures[index] = bindCode;
 	Py_RETURN_NONE;
+}
+
+PyObject *KX_2DFilter::pyattr_get_color_bind_code(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_2DFilter *self = static_cast<KX_2DFilter *>(self_v);
+	return PyLong_FromLong(self->GetColorBindCode());
 }
 
 #endif  // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_2DFilter.h
+++ b/source/gameengine/Ketsji/KX_2DFilter.h
@@ -43,6 +43,8 @@ public:
 
 	KX_PYMETHOD_DOC(KX_2DFilter, setTexture);
 
+	static PyObject *pyattr_get_color_bind_code(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+
 #endif
 };
 

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -47,7 +47,8 @@ static char predefinedUniformsName[RAS_2DFilter::MAX_PREDEFINED_UNIFORM_TYPE][40
 RAS_2DFilter::RAS_2DFilter(RAS_2DFilterData& data)
 	:m_properties(data.propertyNames),
 	m_gameObject(data.gameObject),
-	m_uniformInitialized(false)
+	m_uniformInitialized(false),
+	m_colorBindCode(-1)
 {
 	for(unsigned int i = 0; i < TEXTURE_OFFSETS_SIZE; i++) {
 		m_textureOffsets[i] = 0;
@@ -82,9 +83,18 @@ void RAS_2DFilter::Initialize(RAS_ICanvas *canvas)
 	}
 }
 
+int RAS_2DFilter::GetColorBindCode()
+{
+	return m_colorBindCode;
+}
+
 void RAS_2DFilter::Start(RAS_IRasterizer *rasty, RAS_ICanvas *canvas, unsigned short depthfbo,
 						 unsigned short colorfbo, unsigned short outputfbo)
 {
+	if (m_colorBindCode == -1) {
+		m_colorBindCode = rasty->GetOffscreenColorBindCode(outputfbo);
+	}
+
 	rasty->BindOffScreen(outputfbo);
 
 	if (Ok()) {

--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -91,9 +91,7 @@ int RAS_2DFilter::GetColorBindCode()
 void RAS_2DFilter::Start(RAS_IRasterizer *rasty, RAS_ICanvas *canvas, unsigned short depthfbo,
 						 unsigned short colorfbo, unsigned short outputfbo)
 {
-	if (m_colorBindCode == -1) {
-		m_colorBindCode = rasty->GetOffscreenColorBindCode(outputfbo);
-	}
+	m_colorBindCode = rasty->GetOffscreenColorBindCode(outputfbo);
 
 	rasty->BindOffScreen(outputfbo);
 

--- a/source/gameengine/Rasterizer/RAS_2DFilter.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.h
@@ -50,6 +50,8 @@ protected:
 	std::vector<unsigned int> m_propertiesLoc;
 	CValue *m_gameObject;
 
+	int m_colorBindCode;
+
 	/// True if the uniform locations are updated with the current shader program/script.
 	bool m_uniformInitialized;
 
@@ -87,6 +89,8 @@ public:
 
 	/// Finalizes the execution stage of the filter.
 	void End();
+
+	int GetColorBindCode();
 };
 
 #endif // __RAS_2DFILTER_H__

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -394,6 +394,8 @@ public:
 	virtual short GetCurrentOffScreenIndex() const = 0;
 	/// Return the off screenn samples numbers at the given index.
 	virtual int GetOffScreenSamples(unsigned short index) = 0;
+	/// Return offscreen color texture bindcode
+	virtual int GetOffscreenColorBindCode(unsigned short offscreenindex) = 0;
 
 	/**
 	 * SetRenderArea sets the render area from the 2d canvas.

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1002,6 +1002,12 @@ int RAS_OpenGLRasterizer::GetOffScreenSamples(unsigned short index)
 	return m_offScreens.GetSamples(index);
 }
 
+int RAS_OpenGLRasterizer::GetOffscreenColorBindCode(unsigned short offscreenindex)
+{
+	GPUOffScreen *ofs = m_offScreens.GetOffScreen(offscreenindex);
+	return GPU_offscreen_color_texture(ofs);
+}
+
 void RAS_OpenGLRasterizer::SetRenderArea(RAS_ICanvas *canvas)
 {
 	if (canvas == NULL) {

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -98,9 +98,6 @@ private:
 		/// The HDR quality.
 		short m_hdr;
 
-		/// Return or create off screen for the given index.
-		GPUOffScreen *GetOffScreen(unsigned short index);
-
 	public:
 		OffScreens();
 		~OffScreens();
@@ -115,6 +112,9 @@ private:
 		short GetCurrentIndex() const;
 		int GetSamples(unsigned short index);
 		GPUTexture *GetDepthTexture(unsigned short index);
+
+		/// Return or create off screen for the given index.
+		GPUOffScreen *GetOffScreen(unsigned short index);
 	};
 
 	struct OglDebugShape
@@ -261,6 +261,7 @@ public:
 	virtual void UnbindOffScreenTexture(unsigned short index, OffScreen type);
 	virtual short GetCurrentOffScreenIndex() const;
 	virtual int GetOffScreenSamples(unsigned short index);
+	virtual int GetOffscreenColorBindCode(unsigned short offscreenindex);
 
 	virtual void SetRenderArea(RAS_ICanvas *canvas);
 


### PR DESCRIPTION
This allows us to get the render from GLSL 2D Filter pass 0 and add it as
input in the GLSL 2D Filter pass 1 for example etc...

test file: http://pasteall.org/blend/index.php?id=44021

It doesn't work well for now...