### PR TITLE
Fix crash when calling setTexture in KX_2DFilter

### DIFF
--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -90,6 +90,9 @@ KX_PYMETHODDEF_DOC(KX_2DFilter, setTexture, "setTexture(index, bindCode, sampler
 	}
 
 	if (samplerName) {
+		if (GetError()) {
+			Py_RETURN_NONE;
+		}
 		int loc = GetUniformLocation(samplerName);
 
 		if (loc != -1) {


### PR DESCRIPTION
I just added a check in GetUniformLocation to see if there is an error and
return if yes because it caused a crash calling KX_2DFilter::setTexture

test file: http://pasteall.org/blend/index.php?id=44069

If there is an error in the fragment shader it seems m_shader is removed so we can't access it anymore. So we can fix by avoid removing m_shader if there is an error in the shader or do what I choose to do: the simplest way (but not necessarly the better) -> just add a check in the function that caused the crash.