### PR TITLE
UPBGE: Implement python callbacks for custom shaders.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -22,6 +22,11 @@ base class --- :class:`PyObjectPlus`
       The list of python callbacks executed when the shader is used to render an object.
       All the functions can expect as argument the object currently rendered.
 
+      .. code-block:: python
+
+         def callback(object):
+             print("render object %r" % object.name)
+
       :type: list of functions and/or methods
 
    .. attribute:: bindCallbacks

--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -20,7 +20,15 @@ base class --- :class:`PyObjectPlus`
    .. attribute:: objectCallbacks
 
       The list of python callbacks executed when the shader is used to render an object.
-      All the functions 
+      All the functions can expect as argument the object currently rendered.
+
+      :type: list of functions and/or methods
+
+   .. attribute:: bindCallbacks
+
+      The list of python callbacks executed when the shader is begin used to render.
+
+      :type: list of functions and/or methods
 
    .. method:: setUniformfv(name, fList)
 

--- a/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Shader.rst
@@ -17,6 +17,11 @@ base class --- :class:`PyObjectPlus`
 
       :type: boolean
 
+   .. attribute:: objectCallbacks
+
+      The list of python callbacks executed when the shader is used to render an object.
+      All the functions 
+
    .. method:: setUniformfv(name, fList)
 
       Set a uniform with a list of float values

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -29,7 +29,11 @@ public:
 	void SetCallbacks(PyObject *callbacks);
 #endif // WITH_PYTHON
 
-	virtual void Update(RAS_IRasterizer *rasty, RAS_MeshSlot *ms);
+	/** Update the uniform shader for the current rendered mesh slot.
+	 * The python callbacks are executed in this function and at the end
+	 * RAS_Shader::Update(rasty, mat) is called.
+	 */
+	void Update(RAS_IRasterizer *rasty, RAS_MeshSlot *ms);
 
 	// Python interface
 #ifdef WITH_PYTHON

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -9,12 +9,27 @@
 #include "EXP_PyObjectPlus.h"
 #include "RAS_Shader.h"
 
+class RAS_MeshSlot;
+
 class BL_Shader : public PyObjectPlus, public virtual RAS_Shader
 {
+private:
 	Py_Header
+
+#ifdef WITH_PYTHON
+	PyObject *m_callbacks;
+#endif  // WITH_PYTHON
+
 public:
 	BL_Shader();
 	virtual ~BL_Shader();
+
+#ifdef WITH_PYTHON
+	PyObject *GetCallbacks();
+	void SetCallbacks(PyObject *callbacks);
+#endif // WITH_PYTHON
+
+	virtual void Update(RAS_IRasterizer *rasty, RAS_MeshSlot *ms);
 
 	// Python interface
 #ifdef WITH_PYTHON
@@ -25,6 +40,8 @@ public:
 
 	static PyObject *pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_bind_object_callback(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_bind_object_callback(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -13,11 +13,18 @@ class RAS_MeshSlot;
 
 class BL_Shader : public PyObjectPlus, public virtual RAS_Shader
 {
+public:
+	enum CallbacksType {
+		CALLBACKS_BIND = 0,
+		CALLBACKS_OBJECT,
+		CALLBACKS_MAX
+	};
+
 private:
 	Py_Header
 
 #ifdef WITH_PYTHON
-	PyObject *m_callbacks;
+	PyObject *m_callbacks[CALLBACKS_MAX];
 #endif  // WITH_PYTHON
 
 public:
@@ -25,9 +32,11 @@ public:
 	virtual ~BL_Shader();
 
 #ifdef WITH_PYTHON
-	PyObject *GetCallbacks();
-	void SetCallbacks(PyObject *callbacks);
+	PyObject *GetCallbacks(CallbacksType type);
+	void SetCallbacks(CallbacksType type, PyObject *callbacks);
 #endif // WITH_PYTHON
+
+	virtual void SetProg(bool enable);
 
 	/** Update the uniform shader for the current rendered mesh slot.
 	 * The python callbacks are executed in this function and at the end
@@ -44,8 +53,8 @@ public:
 
 	static PyObject *pyattr_get_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_enabled(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject *pyattr_get_bind_object_callback(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
-	static int pyattr_set_bind_object_callback(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_callbacks(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_callbacks(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	// -----------------------------------
 	KX_PYMETHOD_DOC(BL_Shader, setSource);

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -393,7 +393,8 @@ bool KX_BlenderMaterial::UsesLighting(RAS_IRasterizer *rasty) const
 void KX_BlenderMaterial::ActivateMeshSlot(RAS_MeshSlot *ms, RAS_IRasterizer *rasty)
 {
 	if (m_shader && m_shader->Ok()) {
-		m_shader->Update(rasty, MT_Matrix4x4(ms->m_meshUser->GetMatrix()));
+		m_shader->Update(rasty, ms);
+		m_shader->ApplyShader();
 	}
 	else if (m_blenderShader) {
 		m_blenderShader->Update(ms, rasty);

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -157,7 +157,7 @@ public:
 	bool Ok() const;
 	unsigned int GetProg();
 	GPUShader *GetGPUShader();
-	void SetProg(bool enable);
+	virtual void SetProg(bool enable);
 	void SetEnabled(bool enabled);
 	bool GetEnabled() const;
 	int GetAttribute();


### PR DESCRIPTION
Previously the user wasn't able to set uniform values per object
using a custom shader and not globally for all the shader.

To solve this lack the easiest way is to give the user the possibility
to use a python callback. This callback is called just before
rendering a mesh with the custom shader.

The callbacks executed receive as arguments the shader to alterate
and the game object to have an identifier.

The callbacks list is accessed under the name of BL_Shader.objectCallback.
###### 

I'm really not sure about the python attribute name, @DCubix, @youle31, @lordloki : Do you have a suggestion ?
