### PR TITLE
UPBGE: Allow accessing the vehicle speed from python

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_VehicleWrapper.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_VehicleWrapper.rst
@@ -169,3 +169,9 @@ base class --- :class:`PyObjectPlus`
       Set ray cast mask.
 
       :type: bitfield
+
+   .. attribute:: speed
+   
+      Get the current vehicle speed in meters per seconds (m/s)
+      
+      :type: float

--- a/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
+++ b/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
@@ -47,7 +47,7 @@ m_pitchControl(btScalar(0.))
 void btRaycastVehicle::defaultInit(const btVehicleTuning& tuning)
 {
 	(void)tuning;
-	m_currentVehicleSpeedKmHour = btScalar(0.);
+	m_currentVehicleSpeedMetersPerSec = btScalar(0.);
 	m_steeringValue = btScalar(0.);
 	
 }
@@ -274,9 +274,6 @@ void btRaycastVehicle::updateVehicle( btScalar step )
 		}
 	}
 
-
-	m_currentVehicleSpeedKmHour = btScalar(3.6) * getRigidBody()->getLinearVelocity().length();
-	
 	const btTransform& chassisTrans = getChassisWorldTransform();
 
 	btVector3 forwardW (
@@ -284,9 +281,13 @@ void btRaycastVehicle::updateVehicle( btScalar step )
 		chassisTrans.getBasis()[1][m_indexForwardAxis],
 		chassisTrans.getBasis()[2][m_indexForwardAxis]);
 
-	if (forwardW.dot(getRigidBody()->getLinearVelocity()) < btScalar(0.))
+	btScalar linDotFwd = getRigidBody()->getLinearVelocity().dot(forwardW);
+	btVector3 fwdSpeed = forwardW * linDotFwd;
+	m_currentVehicleSpeedMetersPerSec = fwdSpeed.length();
+
+	if (linDotFwd < btScalar(0.))
 	{
-		m_currentVehicleSpeedKmHour *= btScalar(-1.);
+		m_currentVehicleSpeedMetersPerSec *= btScalar(-1.);
 	}
 
 	//

--- a/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.h
+++ b/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.h
@@ -61,7 +61,7 @@ private:
 	btVehicleRaycaster*	m_vehicleRaycaster;
 	btScalar		m_pitchControl;
 	btScalar	m_steeringValue; 
-	btScalar m_currentVehicleSpeedKmHour;
+	btScalar m_currentVehicleSpeedMetersPerSec;
 
 	btRigidBody* m_chassisBody;
 
@@ -180,9 +180,9 @@ public:
 	}
 
 	///Velocity of vehicle (positive if velocity vector has same direction as foward vector)
-	btScalar	getCurrentSpeedKmHour() const
+	btScalar	getCurrentSpeedMetersSec() const
 	{
-		return m_currentVehicleSpeedKmHour;
+		return m_currentVehicleSpeedMetersPerSec;
 	}
 
 	virtual void	setCoordinateSystem(int rightIndex,int upIndex,int forwardIndex)

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
@@ -27,6 +27,7 @@
 #include "KX_VehicleWrapper.h"
 #include "PHY_IPhysicsEnvironment.h"
 #include "PHY_IVehicle.h"
+#include "CcdPhysicsEnvironment.h"
 #include "KX_PyMath.h"
 #include "KX_GameObject.h"
 #include "KX_MotionState.h"
@@ -377,6 +378,7 @@ PyMethodDef KX_VehicleWrapper::Methods[] = {
 
 PyAttributeDef KX_VehicleWrapper::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("rayMask", KX_VehicleWrapper, pyattr_get_ray_mask, pyattr_set_ray_mask),
+	KX_PYATTRIBUTE_RO_FUNCTION("speed", KX_VehicleWrapper, pyattr_get_khspeed),
 	{ NULL }	//Sentinel
 };
 
@@ -405,6 +407,13 @@ int KX_VehicleWrapper::pyattr_set_ray_mask(void *self, const struct KX_PYATTRIBU
 	wrapper->m_vehicle->SetRayCastMask(mask);
 
 	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_VehicleWrapper::pyattr_get_khspeed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_VehicleWrapper *wrapper = static_cast<KX_VehicleWrapper*>(self);
+	MT_Scalar speed = std::abs(wrapper->m_vehicle->GetCurrentSpeed()); // No negative speeds
+	return PyFloat_FromDouble(speed);
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
@@ -378,7 +378,7 @@ PyMethodDef KX_VehicleWrapper::Methods[] = {
 
 PyAttributeDef KX_VehicleWrapper::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("rayMask", KX_VehicleWrapper, pyattr_get_ray_mask, pyattr_set_ray_mask),
-	KX_PYATTRIBUTE_RO_FUNCTION("speed", KX_VehicleWrapper, pyattr_get_khspeed),
+	KX_PYATTRIBUTE_RO_FUNCTION("speed", KX_VehicleWrapper, pyattr_get_speed),
 	{ NULL }	//Sentinel
 };
 
@@ -409,7 +409,7 @@ int KX_VehicleWrapper::pyattr_set_ray_mask(void *self, const struct KX_PYATTRIBU
 	return PY_SET_ATTR_SUCCESS;
 }
 
-PyObject *KX_VehicleWrapper::pyattr_get_khspeed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef)
+PyObject *KX_VehicleWrapper::pyattr_get_speed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_VehicleWrapper *wrapper = static_cast<KX_VehicleWrapper*>(self);
 	MT_Scalar speed = std::abs(wrapper->m_vehicle->GetCurrentSpeed()); // No negative speeds

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.h
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.h
@@ -55,7 +55,7 @@ public:
 
 	static PyObject *pyattr_get_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
-	static PyObject *pyattr_get_khspeed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_speed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
 
 #endif  /* WITH_PYTHON */
 

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.h
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.h
@@ -7,6 +7,7 @@
 #define __KX_VEHICLEWRAPPER_H__
 
 #include "EXP_Value.h"
+
 class PHY_IVehicle;
 class PHY_IMotionState;
 
@@ -54,6 +55,7 @@ public:
 
 	static PyObject *pyattr_get_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_ray_mask(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_khspeed(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
 
 #endif  /* WITH_PYTHON */
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -217,20 +217,20 @@ public:
 	}
 
 	virtual void AddWheel(
-	    PHY_IMotionState *motionState,
-	    MT_Vector3 connectionPoint,
-	    MT_Vector3 downDirection,
-	    MT_Vector3 axleDirection,
-	    float suspensionRestLength,
-	    float wheelRadius,
-	    bool hasSteering)
+		PHY_IMotionState *motionState,
+		MT_Vector3 connectionPoint,
+		MT_Vector3 downDirection,
+		MT_Vector3 axleDirection,
+		float suspensionRestLength,
+		float wheelRadius,
+		bool hasSteering)
 	{
 		btVector3 connectionPointCS0(connectionPoint[0], connectionPoint[1], connectionPoint[2]);
 		btVector3 wheelDirectionCS0(downDirection[0], downDirection[1], downDirection[2]);
 		btVector3 wheelAxle(axleDirection[0], axleDirection[1], axleDirection[2]);
 
 		btWheelInfo& info = m_vehicle->addWheel(connectionPointCS0, wheelDirectionCS0, wheelAxle,
-		                                        suspensionRestLength, wheelRadius, gTuning, hasSteering);
+												suspensionRestLength, wheelRadius, gTuning, hasSteering);
 		info.m_clientInfo = motionState;
 	}
 
@@ -375,6 +375,10 @@ public:
 	virtual short GetRayCastMask() const
 	{
 		return m_raycaster->GetRayCastMask();
+	}
+
+	virtual MT_Scalar GetCurrentSpeed() const {
+		return m_vehicle->getCurrentSpeedMetersSec();
 	}
 };
 

--- a/source/gameengine/Physics/Common/PHY_IVehicle.h
+++ b/source/gameengine/Physics/Common/PHY_IVehicle.h
@@ -63,6 +63,8 @@ public:
 	virtual void SetRayCastMask(short mask) = 0;
 	virtual short GetRayCastMask() const = 0;
 
+	virtual MT_Scalar GetCurrentSpeed() const = 0;
+
 #ifdef WITH_CXX_GUARDEDALLOC
 	MEM_CXX_CLASS_ALLOC_FUNCS("GE:PHY_IVehicle")
 #endif


### PR DESCRIPTION
From the commit message:
> This commit exposes to Python the vehicle speed in meters per
second. You can convert the value to Km/h by multiplying by 3.6
 and to Mph by dividing by 0.44704.
	Given the vehicleID, you can access the speed by simply calling
"vehicleID.speed".

Example: http://pasteall.org/blend/index.php?id=44151