### PR TITLE
UPBGE: Makes distance and angle python attributes for Radar Sensor writables

### DIFF
--- a/extern/bullet2/patches/coneshape_setheight.patch
+++ b/extern/bullet2/patches/coneshape_setheight.patch
@@ -1,0 +1,26 @@
+diff --git a/extern/bullet2/patches/coneshape_setheight.patch b/extern/bullet2/patches/coneshape_setheight.patch
+new file mode 100644
+--- /dev/null
++++ b/extern/bullet2/patches/coneshape_setheight.patch
+@@ -0,0 +1,21 @@
++diff --git a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
++index 4a0df0d..41b5a13 100644
++--- a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
+++++ b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
++@@ -43,6 +43,16 @@ public:
++ 	btScalar getRadius() const { return m_radius;}
++ 	btScalar getHeight() const { return m_height;}
++ 
+++	virtual void setRadius(btScalar radius)
+++	{
+++		m_radius = radius;
+++	}
+++
+++	virtual void setHeight(btScalar height)
+++	{
+++		m_height = height;
+++	}
+++
++ 
++ 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const
++ 	{

--- a/extern/bullet2/readme.txt
+++ b/extern/bullet2/readme.txt
@@ -4,6 +4,9 @@ Questions? mail blender at erwincoumans.com, or check the bf-blender mailing lis
 Thanks,
 Erwin
 
+patches/coneshape_setheight.patch to add access to the posibility of
+modify cone's height and angle is already upstreamed from bullet 2.85.
+
 Apply patches/blender.patch to fix a few build errors and warnings and dd original
 vertex access for BMesh convex hull operator.
 

--- a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
+++ b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
@@ -43,6 +43,15 @@ public:
 	btScalar getRadius() const { return m_radius;}
 	btScalar getHeight() const { return m_height;}
 
+	virtual void setRadius(btScalar radius)
+	{
+		m_radius = radius;
+	}
+
+	virtual void setHeight(btScalar height)
+	{
+		m_height = height;
+	}
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const
 	{

--- a/source/gameengine/Ketsji/KX_RadarSensor.h
+++ b/source/gameengine/Ketsji/KX_RadarSensor.h
@@ -60,6 +60,8 @@ class KX_RadarSensor : public KX_NearSensor
 	 * The previous direction of the cone (origin to bottom plane).
 	 */
 	float       m_cone_target[3];
+
+	bool m_coneshape_modified;
 	
 public:
 
@@ -91,10 +93,13 @@ public:
 	};
 
 	virtual sensortype GetSensorType() { return ST_RADAR; }
+
 	/* python */
 #ifdef WITH_PYTHON
-	static PyObject*	pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject* pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject* pyattr_get_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 #endif
 };
 

--- a/source/gameengine/Ketsji/KX_RadarSensor.h
+++ b/source/gameengine/Ketsji/KX_RadarSensor.h
@@ -94,6 +94,7 @@ public:
 	/* python */
 #ifdef WITH_PYTHON
 	static PyObject*	pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 #endif
 };
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -768,6 +768,16 @@ public:
 		m_cci.m_radius = margin;
 	}
 
+	// Cone Shape (radius & height)
+	virtual void SetConeShape(float radius, float height)
+	{
+		if (m_collisionShape && (m_collisionShape->getShapeType() == CONE_SHAPE_PROXYTYPE)) {
+			btConeShape *coneShape = static_cast<btConeShape *>(m_collisionShape);
+			coneShape->setRadius(radius);
+			coneShape->setHeight(height);
+		}
+	}
+
 	/// velocity clamping
 	virtual void SetLinVelocityMin(float val)
 	{

--- a/source/gameengine/Physics/Common/PHY_IPhysicsController.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsController.h
@@ -128,6 +128,7 @@ public:
 	virtual float GetMargin() const = 0;
 	virtual float GetRadius() const = 0;
 	virtual void SetRadius(float margin) = 0;
+	virtual void SetConeShape(float radius, float height) = 0;
 
 	virtual float GetLinVelocityMin() const = 0;
 	virtual void SetLinVelocityMin(float val) = 0;


### PR DESCRIPTION
This patch adds the posibility to modify the radar cone's distance and angle attributes during the runtime through BGE python.

Credits for this patch goes to @Kseniya Halezova (blenderprowlee) too.

An example to can check the feature http://pasteall.org/blend/index.php?id=44156


