### PR TITLE
UPBGE: Optimize real-time mesh modification

### DIFF
--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.cpp
@@ -120,7 +120,7 @@ void VBO::AllocData()
 	glBindBufferARB(GL_ARRAY_BUFFER_ARB, 0);
 
 	glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, m_ibo);
-	glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER_ARB, m_indices * sizeof(GLuint), m_data->GetIndexPointer(), GL_STATIC_DRAW_ARB);
+	glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER_ARB, m_indices * sizeof(GLuint), m_data->GetIndexPointer(), GL_DYNAMIC_DRAW_ARB);
 	glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
 }
 

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.h
@@ -68,6 +68,9 @@ private:
 	/// Set to true when the VBO/VAO is bound.
 	bool m_bound;
 
+	/// Set to true when the data is pushed to the GPU for the first time
+	bool m_datainitialized;
+
 	void *m_vertex_offset;
 	void *m_normal_offset;
 	void *m_color_offset;

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_StorageVBO.h
@@ -68,14 +68,13 @@ private:
 	/// Set to true when the VBO/VAO is bound.
 	bool m_bound;
 
-	/// Set to true when the data is pushed to the GPU for the first time
-	bool m_datainitialized;
-
 	void *m_vertex_offset;
 	void *m_normal_offset;
 	void *m_color_offset;
 	void *m_tangent_offset;
 	void *m_uv_offset;
+
+	void AllocData();
 };
 
 class RAS_StorageVBO


### PR DESCRIPTION
By using glBufferSubData and GL_DYNAMIC_DRAW, I was able to optimize it (KX_MeshProxy) in almost 80%.
Previously, the mesh was reallocated in the GPU all the time, which is a terribly slow process. Now only the mesh data is updated instead of reallocating memory, making if a lot faster.

Demo: http://pasteall.org/blend/index.php?id=44237
(The plane has +/- 3000 vertices, the program modifies the vertex positions and recalculated the normals of the entire mesh, all with 60FPS)

![wow](https://sc-cdn.scaleengine.net/i/d2c0e45670335c5116247d3724e341e2.png)