### PR TITLE
UPBGE: Vibration Actuator improvement

### DIFF
--- a/build_files/cmake/macros.cmake
+++ b/build_files/cmake/macros.cmake
@@ -637,8 +637,8 @@ function(SETUP_BLENDER_SORTED_LIBS)
 		extern_curve_fit_nd
 		ge_logic_ketsji
 		extern_recastnavigation
-		ge_device
 		ge_logic
+		ge_device
 		ge_oglrasterizer
 		ge_rasterizer
 		ge_common

--- a/doc/python_api/rst/bge_types/bge.types.SCA_VibrationActuator.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_VibrationActuator.rst
@@ -9,9 +9,21 @@ base class --- :class:`SCA_IActuator`
 
    Vibration Actuator.
 
-   .. attribute:: strength
+   .. attribute:: joyindex
 
-      Strength of the joystick vibration.
+      Joystick index.
+
+      :type: integer (0 to 7)
+
+   .. attribute:: strengthLeft
+
+      Strength of the Low frequency joystick's motor (placed at left position usually).
+
+      :type: float (0.0 to 1.0)
+
+   .. attribute:: strengthRight
+
+      Strength of the High frequency joystick's motor (placed at right position usually).
 
       :type: float (0.0 to 1.0)
 
@@ -21,9 +33,28 @@ base class --- :class:`SCA_IActuator`
 
       :type: integer (0 to infinite)
 
-   .. attribute:: joyindex
+   .. attribute:: isVibrating
 
-      Joystick index.
+      Check status of joystick vibration
 
-      :type: integer (0 to 7)
+      :type: bool (true vibrating and false stopped)
+
+   .. attribute:: hasVibration
+
+      Check if the joystick supports vibration
+
+      :type: bool (true supported and false not supported)
+
+   .. method:: startVibration()
+
+      Starts the vibration.
+
+      :return: None
+
+   .. method:: stopVibration()
+
+      Stops the vibration.
+
+      :return: None
+
 

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -419,6 +419,7 @@ void init_actuator(bActuator *act)
 	bArmatureActuator *arma;
 	bMouseActuator *ma;
 	bEditObjectActuator *eoa;
+	bVibrationActuator *via;
 	
 	if (act->data) MEM_freeN(act->data);
 	act->data= NULL;
@@ -479,6 +480,9 @@ void init_actuator(bActuator *act)
 		break;
 	case ACT_VIBRATION:
 		act->data = MEM_callocN(sizeof(bVibrationActuator), "vibration act");
+		via = act->data;
+		via->duration = 500; //milliseconds
+		via->strength = 0.4;
 		break;
 	case ACT_VISIBILITY:
 		act->data= MEM_callocN(sizeof(bVisibilityActuator), "visibility act");

--- a/source/blender/editors/space_logic/logic_window.c
+++ b/source/blender/editors/space_logic/logic_window.c
@@ -2038,10 +2038,25 @@ static void draw_actuator_vibration(uiLayout *layout, PointerRNA *ptr)
 	uiLayout *row;
 	row = uiLayoutRow(layout, false);
 
-	uiItemR(row, ptr, "joy_strength", 0, NULL, ICON_NONE);
-	uiItemR(row, ptr, "joy_duration", 0, NULL, ICON_NONE);
-	row = uiLayoutRow(layout, false);
-	uiItemR(row, ptr, "joy_index", 0, NULL, ICON_NONE);
+	uiItemR(layout, ptr, "mode", 0, NULL, 0);
+ 
+ 	switch (RNA_enum_get(ptr, "mode")) {
+ 		case ACT_VIBRATION_PLAY:
+ 		{
+ 			uiItemR(row, ptr, "joy_index", 0, NULL, ICON_NONE);
+ 			row = uiLayoutRow(layout, false);
+ 			uiItemR(row, ptr, "joy_strength_left", 0, NULL, ICON_NONE);
+ 			uiItemR(row, ptr, "joy_strength_right", 0, NULL, ICON_NONE);
+ 			row = uiLayoutRow(layout, false);
+ 			uiItemR(row, ptr, "joy_duration", 0, NULL, ICON_NONE);
+ 			break;
+ 		}
+ 		case ACT_VIBRATION_STOP:
+ 		{
+ 			uiItemR(row, ptr, "joy_index", 0, NULL, ICON_NONE);
+ 			break;
+ 		}
+ 	}
 }
 
 static void draw_actuator_visibility(uiLayout *layout, PointerRNA *ptr)

--- a/source/blender/makesdna/DNA_actuator_types.h
+++ b/source/blender/makesdna/DNA_actuator_types.h
@@ -192,7 +192,8 @@ typedef struct bGameActuator {
 
 typedef struct bVibrationActuator {
 	int joyindex;
-	float strength;
+	short mode, pad1; /* mode: 0 = Play, 1 = Stop */
+ 	float strength, strength_right; /* strength --> low frequency motor, strength_right --> high frequency motor */
 	int duration;
 } bVibrationActuator;
 
@@ -587,5 +588,9 @@ typedef struct bActuator {
 #define ACT_MOUSE_OBJECT_AXIS_X	0
 #define ACT_MOUSE_OBJECT_AXIS_Y	1
 #define ACT_MOUSE_OBJECT_AXIS_Z	2
+
+/* vibrationactuator->mode */
+#define ACT_VIBRATION_PLAY		0
+#define ACT_VIBRATION_STOP		1
 
 #endif  /* __DNA_ACTUATOR_TYPES_H__ */

--- a/source/blender/makesrna/intern/rna_actuator.c
+++ b/source/blender/makesrna/intern/rna_actuator.c
@@ -1740,15 +1740,27 @@ static void rna_def_vibration_actuator(BlenderRNA *brna)
 	StructRNA *srna;
 	PropertyRNA *prop;
 
+	static EnumPropertyItem prop_mode_items[] = {
+		{ACT_VIBRATION_PLAY, "PLAY", 0, "Play", ""},
+		{ACT_VIBRATION_STOP, "STOP", 0, "Stop", ""},
+ 		{0, NULL, 0, NULL, NULL}
+ 	};
+
 	srna = RNA_def_struct(brna, "VibrationActuator", "Actuator");
 	RNA_def_struct_ui_text(srna, "Vibration Actuator", "Actuator to set vibration of a joystick");
 	RNA_def_struct_sdna_from(srna, "bVibrationActuator", "data");
 
-	prop = RNA_def_property(srna, "joy_strength", PROP_FLOAT, PROP_NONE);
-	RNA_def_property_float_sdna(prop, NULL, "strength");
-	RNA_def_property_range(prop, 0.0, 1.0);
-	RNA_def_property_ui_text(prop, "Strength", "Joystick vibration strength");
+	prop = RNA_def_property(srna, "mode", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_sdna(prop, NULL, "mode");
+	RNA_def_property_enum_items(prop, prop_mode_items);
+	RNA_def_property_ui_text(prop, "Vibration Mode", "");
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+	prop = RNA_def_property(srna, "joy_index", PROP_INT, PROP_NONE);
+	RNA_def_property_int_sdna(prop, NULL, "joyindex");
+	RNA_def_property_range(prop, 0, 7);
+	RNA_def_property_ui_text(prop, "JoyIndex", "Joystick index");
+ 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 
 	prop = RNA_def_property(srna, "joy_duration", PROP_INT, PROP_NONE);
 	RNA_def_property_int_sdna(prop, NULL, "duration");
@@ -1756,10 +1768,16 @@ static void rna_def_vibration_actuator(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Duration", "Joystick vibration duration");
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 
-	prop = RNA_def_property(srna, "joy_index", PROP_INT, PROP_NONE);
-	RNA_def_property_int_sdna(prop, NULL, "joyindex");
-	RNA_def_property_range(prop, 0, 7);
-	RNA_def_property_ui_text(prop, "JoyIndex", "Joystick index");
+	prop = RNA_def_property(srna, "joy_strength_left", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "strength");
+	RNA_def_property_range(prop, 0.0, 1.0);
+	RNA_def_property_ui_text(prop, "Strength Low Freq", "Joystick vibration strength for low frequency motor");
+	RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+	prop = RNA_def_property(srna, "joy_strength_right", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "strength_right");
+	RNA_def_property_range(prop, 0.0, 1.0);
+	RNA_def_property_ui_text(prop, "Strength High Freq", "Joystick vibration strength for high frequency motor");
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 }
 

--- a/source/blenderplayer/CMakeLists.txt
+++ b/source/blenderplayer/CMakeLists.txt
@@ -123,10 +123,10 @@ endif()
 		ge_player
 		ge_converter 
 		ge_logic_ketsji 
-		ge_device
 		ge_phys_bullet 
 		ge_phys_dummy
-		ge_logic 
+		ge_logic
+		ge_device
 		ge_oglrasterizer
 		ge_rasterizer
 		ge_logic_expressions

--- a/source/gameengine/Converter/KX_ConvertActuators.cpp
+++ b/source/gameengine/Converter/KX_ConvertActuators.cpp
@@ -868,12 +868,27 @@ void BL_ConvertActuators(const char* maggiename,
 		{
 			bVibrationActuator *vib_act = (bVibrationActuator *)bact->data;
 			SCA_VibrationActuator * tmp_vib_act = NULL;
+			short mode = SCA_VibrationActuator::KX_ACT_VIBRATION_NONE;
+ 
+ 			switch (vib_act->mode) {
+ 				case ACT_VIBRATION_PLAY:
+ 				{
+ 					mode = SCA_VibrationActuator::KX_ACT_VIBRATION_PLAY;
+					break;
+				}
+				case ACT_VIBRATION_STOP:
+				{
+ 					mode = SCA_VibrationActuator::KX_ACT_VIBRATION_STOP;
+					break;
+				}
+			}
 
 			int joyindex = vib_act->joyindex;
-			float strength = vib_act->strength;
+			float strength_left = vib_act->strength;
+			float strength_right = vib_act->strength_right;
 			int duration = vib_act->duration;
 
-			tmp_vib_act = new SCA_VibrationActuator(gameobj, joyindex, strength, duration);
+			tmp_vib_act = new SCA_VibrationActuator(gameobj, mode, joyindex, strength_left, strength_right, duration);
 
 			baseact = tmp_vib_act;
 		}

--- a/source/gameengine/Device/CMakeLists.txt
+++ b/source/gameengine/Device/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRC
 	DEV_InputDevice.cpp
 	DEV_Joystick.cpp
 	DEV_JoystickEvents.cpp
+	DEV_JoystickVibration.cpp
 
 	DEV_EventConsumer.h
 	DEV_InputDevice.h

--- a/source/gameengine/Device/DEV_Joystick.cpp
+++ b/source/gameengine/Device/DEV_Joystick.cpp
@@ -218,27 +218,6 @@ bool DEV_Joystick::aButtonReleaseIsPositive(int button)
 	return false;
 }
 
-bool DEV_Joystick::RumblePlay(float strength, int duration)
-{
-#ifdef WITH_SDL
-	if (m_private->m_haptic == NULL) {
-		return false;
-	}
-
-	// Initialize simple rumble
-	if (SDL_HapticRumbleInit(m_private->m_haptic) != 0) {
-		return false;
-	}
-
-	// Play effect at strength for m_duration milliseconds
-	if (SDL_HapticRumblePlay(m_private->m_haptic, strength, duration) != 0) {
-		return false;
-	}
-	return true;
-#endif // WITH_SDL
-	return false;
-}
-
 bool DEV_Joystick::CreateJoystickDevice(void)
 {
 	bool joy_error = false;

--- a/source/gameengine/Device/DEV_Joystick.h
+++ b/source/gameengine/Device/DEV_Joystick.h
@@ -172,13 +172,17 @@ public:
 	}
 	
 	/**
-	 * We could add many optionnal arguments to this function
-	 * to take into account different sort of vibrations. But I
-	 * propose to keep the UI simple with only force, duration,
-	 * and joyindex and make the other SDL options available
-	 * for rumble only via a python API.
+	 * Force Feedback - Vibration
+ 	 * We could add many optional arguments to these functions to take into account different sort of vibrations.
+	 * But we propose to keep the UI simple with only joyindex, force (in both motors) and duration.
+	 * As the vibration strength and duration can be updated on-fly it is possible to generate several types of vibration  
+	 * (sinus, periodic, custom, etc) using BGE python scripts for more advanced uses.
 	 */
-	bool RumblePlay(float strength, int duration);
+	bool RumblePlay(float strength_left, float strength_right, unsigned int duration);
+	bool RumbleStop(void);
+	bool GetRumbleStatus(void);
+	bool GetRumbleSupport(void);
+	
 	/**
 	 * Test if the joystick is connected
 	 */

--- a/source/gameengine/Device/DEV_JoystickDefines.h
+++ b/source/gameengine/Device/DEV_JoystickDefines.h
@@ -20,7 +20,7 @@
  *
  * The Original Code is: all of this file.
  *
- * Contributor(s): snailrose.
+ * Contributor(s): snailrose, lordloki.
  *
  * ***** END GPL LICENSE BLOCK *****
  */
@@ -44,5 +44,11 @@
 #define JOYAXIS_UP			1
 #define JOYAXIS_DOWN		3
 #define JOYAXIS_LEFT		2
+
+#define JOYHAPTIC_PLAYING_EFFECT    0
+#define JOYHAPTIC_PLAYING_RUMBLE    1
+#define JOYHAPTIC_UPDATING_EFFECT   2
+#define JOYHAPTIC_UPDATING_RUMBLE   3
+#define JOYHAPTIC_STOPPED           4
 
 #endif // __DEV_JOYSTICKDEFINES_H__

--- a/source/gameengine/Device/DEV_JoystickPrivate.h
+++ b/source/gameengine/Device/DEV_JoystickPrivate.h
@@ -20,7 +20,7 @@
  *
  * The Original Code is: all of this file.
  *
- * Contributor(s): snailrose.
+ * Contributor(s): snailrose, lordloki.
  *
  * ***** END GPL LICENSE BLOCK *****
  */
@@ -32,7 +32,7 @@
 #ifndef __DEV_JOYSTICKPRIVATE_H__
 #define __DEV_JOYSTICKPRIVATE_H__
 
-#include <memory> // We have to include that on Windows to make memset available
+#include "DEV_JoystickDefines.h"
 
 #ifdef WITH_SDL
 class DEV_Joystick::PrivateData
@@ -45,12 +45,14 @@ public:
 	SDL_JoystickID m_instance_id;
 	SDL_Haptic *m_haptic;
 	SDL_HapticEffect m_hapticeffect;
+	int m_hapticeffect_id, m_hapticeffect_status;
 
 	PrivateData()
 		:m_gamecontroller(NULL),
-		m_haptic(NULL)
+		m_haptic(NULL),
+		m_hapticeffect_status(JOYHAPTIC_STOPPED)
 	{
-		memset(&m_hapticeffect, 0, sizeof(SDL_HapticEffect));
+		
 	}
 };
 #endif // WITH_SDL

--- a/source/gameengine/Device/DEV_JoystickVibration.cpp
+++ b/source/gameengine/Device/DEV_JoystickVibration.cpp
@@ -1,0 +1,190 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ ** Contributor(s): youle, lordloki
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file gameengine/Device/DEV_JoystickVibration.cpp
+ *  \ingroup device
+ */
+
+#include "DEV_Joystick.h"
+#include "DEV_JoystickPrivate.h"
+#include "DEV_JoystickDefines.h"
+
+#include <memory> // We have to include that on Windows to make memset available
+
+bool DEV_Joystick::RumblePlay(float strength_left, float strength_right, unsigned int duration)
+{
+#ifdef WITH_SDL
+	unsigned int effects;
+	bool run_by_effect = false;
+	bool effects_issue = false;
+
+	if (m_private->m_haptic == NULL) {
+		return false;
+	}
+
+	// Managing vibration logic
+	if (m_private->m_hapticeffect_status == JOYHAPTIC_STOPPED) {
+		memset(&m_private->m_hapticeffect, 0, sizeof(SDL_HapticEffect)); // 0 is safe default
+	}
+	else if (m_private->m_hapticeffect_status == JOYHAPTIC_PLAYING_EFFECT) {
+		m_private->m_hapticeffect_status = JOYHAPTIC_UPDATING_EFFECT;
+	}
+	else if (m_private->m_hapticeffect_status == JOYHAPTIC_PLAYING_RUMBLE) {
+		m_private->m_hapticeffect_status = JOYHAPTIC_UPDATING_RUMBLE;
+	}
+
+	// Checking supported effects
+	effects = SDL_HapticQuery(m_private->m_haptic);
+
+	if ((effects & SDL_HAPTIC_LEFTRIGHT) && m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_RUMBLE) {
+		if (m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_EFFECT) {
+			m_private->m_hapticeffect.type = SDL_HAPTIC_LEFTRIGHT;
+		}
+
+		m_private->m_hapticeffect.leftright.length = duration;
+		m_private->m_hapticeffect.leftright.large_magnitude = (unsigned int) (strength_left * 0x7FFF);
+		m_private->m_hapticeffect.leftright.small_magnitude = (unsigned int) (strength_right * 0x7FFF);
+		run_by_effect = true;
+
+	}
+	// Some Game Controllers only supports large/small magnitude motors using a custom effect
+	else if ((effects & SDL_HAPTIC_CUSTOM) && m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_RUMBLE) {
+
+		Uint16 data[2]; // data = channels * samples
+		data[0] = (Uint16) (strength_left * 0x7FFF);
+		data[1] = (Uint16) (strength_right * 0x7FFF);
+
+		if (m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_EFFECT) {
+			m_private->m_hapticeffect.type = SDL_HAPTIC_CUSTOM;
+		}
+		m_private->m_hapticeffect.custom.length = duration;
+		m_private->m_hapticeffect.custom.channels = 2;
+		m_private->m_hapticeffect.custom.period = 1;
+		m_private->m_hapticeffect.custom.samples = 1;
+		m_private->m_hapticeffect.custom.data = data;
+
+		run_by_effect = true;
+	}
+
+	if (run_by_effect) {
+		bool new_effect = true;
+
+		if (m_private->m_hapticeffect_status == JOYHAPTIC_UPDATING_EFFECT) {
+			if (SDL_HapticUpdateEffect(m_private->m_haptic, m_private->m_hapticeffect_id, &m_private->m_hapticeffect) == 0) {
+				m_private->m_hapticeffect_status = JOYHAPTIC_PLAYING_EFFECT;
+				new_effect = false;
+			}
+			else {
+				SDL_HapticDestroyEffect(m_private->m_haptic, m_private->m_hapticeffect_id);
+				m_private->m_hapticeffect_id = -1;
+			}
+		}
+
+		if (new_effect) {
+			// Upload the effect
+			m_private->m_hapticeffect_id = SDL_HapticNewEffect(m_private->m_haptic, &m_private->m_hapticeffect);
+		}
+
+		// Run the effect
+		if (m_private->m_hapticeffect_id >= 0 &&
+			SDL_HapticRunEffect(m_private->m_haptic, m_private->m_hapticeffect_id, 1) != -1) {
+				m_private->m_hapticeffect_status = JOYHAPTIC_PLAYING_EFFECT;
+		}
+		else {
+			effects_issue = true;
+		}
+	}
+	
+	if (effects_issue || m_private->m_hapticeffect_status == JOYHAPTIC_UPDATING_RUMBLE) {
+		// Initialize simple rumble for both motors if effects are not supported
+		if (m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_RUMBLE) {
+			if (SDL_HapticRumbleInit(m_private->m_haptic) != 0) {
+				m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+				return false;
+			}
+		}
+
+		// Play effect at strength for m_duration milliseconds
+		if (SDL_HapticRumblePlay(m_private->m_haptic, strength_left, duration) != 0) {
+			m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+			return false;
+		}
+
+		m_private->m_hapticeffect_status = JOYHAPTIC_PLAYING_RUMBLE;
+	}
+
+	return true;
+#endif // WITH_SDL
+	return false;
+}
+
+bool DEV_Joystick::RumbleStop()
+{
+#ifdef WITH_SDL
+	if (m_private->m_haptic == NULL) {
+		return false;
+	}
+
+	if (m_private->m_hapticeffect_status == JOYHAPTIC_PLAYING_EFFECT ||
+		m_private->m_hapticeffect_status == JOYHAPTIC_UPDATING_EFFECT)
+	{
+		SDL_HapticStopEffect(m_private->m_haptic, m_private->m_hapticeffect_id);
+		SDL_HapticDestroyEffect(m_private->m_haptic, m_private->m_hapticeffect_id);
+		m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+		return true;
+	}
+	else if (m_private->m_hapticeffect_id == JOYHAPTIC_PLAYING_RUMBLE ||
+			 m_private->m_hapticeffect_id == JOYHAPTIC_UPDATING_RUMBLE)
+	{
+		SDL_HapticRumbleStop(m_private->m_haptic);
+		m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+		return true;
+	}
+#endif
+	return false;
+}
+
+bool DEV_Joystick::GetRumbleStatus()
+{
+#ifdef WITH_SDL
+	if (m_private->m_hapticeffect_status == JOYHAPTIC_STOPPED) {
+		return false;
+	}
+	else {
+		return true;
+	}
+#endif
+	return false;
+}
+
+bool DEV_Joystick::GetRumbleSupport()
+{
+#ifdef WITH_SDL
+	if (m_private->m_haptic) {
+		return true;
+	}
+	else {
+		return false;
+	}
+#endif
+	return false;
+}

--- a/source/gameengine/Device/DEV_JoystickVibration.cpp
+++ b/source/gameengine/Device/DEV_JoystickVibration.cpp
@@ -28,6 +28,8 @@
 #include "DEV_JoystickPrivate.h"
 #include "DEV_JoystickDefines.h"
 
+#include "CM_Message.h"
+
 #include <memory> // We have to include that on Windows to make memset available
 
 bool DEV_Joystick::RumblePlay(float strength_left, float strength_right, unsigned int duration)
@@ -119,6 +121,7 @@ bool DEV_Joystick::RumblePlay(float strength_left, float strength_right, unsigne
 		if (m_private->m_hapticeffect_status != JOYHAPTIC_UPDATING_RUMBLE) {
 			if (SDL_HapticRumbleInit(m_private->m_haptic) != 0) {
 				m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+				CM_Error("Vibration not reproduced. Rumble can not initialize");
 				return false;
 			}
 		}
@@ -126,6 +129,7 @@ bool DEV_Joystick::RumblePlay(float strength_left, float strength_right, unsigne
 		// Play effect at strength for m_duration milliseconds
 		if (SDL_HapticRumblePlay(m_private->m_haptic, strength_left, duration) != 0) {
 			m_private->m_hapticeffect_status = JOYHAPTIC_STOPPED;
+			CM_Error("Vibration not reproduced. Rumble can not play");
 			return false;
 		}
 

--- a/source/gameengine/GameLogic/SCA_VibrationActuator.cpp
+++ b/source/gameengine/GameLogic/SCA_VibrationActuator.cpp
@@ -32,10 +32,12 @@
 #include "SCA_JoystickManager.h"
 #include "PIL_time.h" // Module to get real time in Game Engine
 
-SCA_VibrationActuator::SCA_VibrationActuator(SCA_IObject *gameobj, int joyindex, float strength, int duration)
+SCA_VibrationActuator::SCA_VibrationActuator(SCA_IObject *gameobj, short mode, int joyindex, float strength_left,  float strength_right, int duration)
 	: SCA_IActuator(gameobj, KX_ACT_VIBRATION),
 	m_joyindex(joyindex),
-	m_strength(strength),
+    m_mode(mode),
+	m_strength_left(strength_left),
+    m_strength_right(strength_right),
 	m_duration(duration),
 	m_endtime(0.0f)
 {
@@ -62,16 +64,31 @@ bool SCA_VibrationActuator::Update()
 		return false;
 	}
 
-	bool bPositiveEvent = IsPositiveEvent();
-
-	if (bPositiveEvent) {
-		instance->RumblePlay(m_strength, m_duration);
-		m_endtime = PIL_check_seconds_timer() * 1000.0f + m_duration;
+	if (IsPositiveEvent()) {
+		switch (m_mode) {
+			case KX_ACT_VIBRATION_PLAY:
+			{
+				instance->RumblePlay(m_strength_left, m_strength_right, m_duration);
+				m_endtime = PIL_check_seconds_timer() * 1000.0f + m_duration;
+				break;
+			}
+		case KX_ACT_VIBRATION_STOP:
+			{
+				instance->RumbleStop();
+				m_endtime = 0.0f;
+				break;
+			}
+		}
 	}
 
 	RemoveAllEvents();
 
-	return PIL_check_seconds_timer() * 1000.0f < m_endtime;
+	if (!(PIL_check_seconds_timer() * 1000.0f < m_endtime)) {
+		instance->RumbleStop();
+		m_endtime = 0.0f;
+	}
+
+	return instance->GetRumbleStatus();
 }
 
 #ifdef WITH_PYTHON
@@ -106,14 +123,83 @@ PyTypeObject SCA_VibrationActuator::Type = {
 };
 
 PyMethodDef SCA_VibrationActuator::Methods[] = {
+	KX_PYMETHODTABLE_NOARGS(SCA_VibrationActuator, startVibration),
+	KX_PYMETHODTABLE_NOARGS(SCA_VibrationActuator, stopVibration),
 	{ NULL, NULL } //Sentinel
 };
 
 PyAttributeDef SCA_VibrationActuator::Attributes[] = {
 	KX_PYATTRIBUTE_INT_RW("duration", 0, INT_MAX, true, SCA_VibrationActuator, m_duration),
 	KX_PYATTRIBUTE_INT_RW("joyindex", 0, 7, true, SCA_VibrationActuator, m_joyindex),
-	KX_PYATTRIBUTE_FLOAT_RW("strength", 0.0, 1.0, SCA_VibrationActuator, m_strength),
+	KX_PYATTRIBUTE_FLOAT_RW("strengthLeft", 0.0, 1.0, SCA_VibrationActuator, m_strength_left),
+	KX_PYATTRIBUTE_FLOAT_RW("strengthRight", 0.0, 1.0, SCA_VibrationActuator, m_strength_right),
+	KX_PYATTRIBUTE_RO_FUNCTION("isVibrating", SCA_VibrationActuator, pyattr_get_statusVibration),
+	KX_PYATTRIBUTE_RO_FUNCTION("hasVibration", SCA_VibrationActuator, pyattr_get_hasVibration),
 	KX_PYATTRIBUTE_NULL	//Sentinel
 };
+
+/* Methods ----------------------------------------------------------------- */
+KX_PYMETHODDEF_DOC_NOARGS(SCA_VibrationActuator, startVibration,
+"startVibration()\n"
+"\tStarts the joystick vibration.\n")
+{
+	SCA_JoystickManager *mgr = (SCA_JoystickManager *)GetLogicManager();
+	DEV_Joystick *instance = mgr->GetJoystickDevice(m_joyindex);
+
+	if (!instance) {
+		Py_RETURN_NONE;
+	}
+
+	instance->RumblePlay(m_strength_left, m_strength_right, m_duration);
+	m_endtime = PIL_check_seconds_timer() * 1000.0f + m_duration;
+
+	Py_RETURN_NONE;
+}
+
+KX_PYMETHODDEF_DOC_NOARGS(SCA_VibrationActuator, stopVibration,
+"StopVibration()\n"
+"\tStops the joystick vibration.\n")
+{
+	SCA_JoystickManager *mgr = (SCA_JoystickManager *)GetLogicManager();
+	DEV_Joystick *instance = mgr->GetJoystickDevice(m_joyindex);
+
+	if (!instance) {
+		Py_RETURN_NONE;
+	}
+
+	instance->RumbleStop();
+	m_endtime = 0.0f;
+
+	Py_RETURN_NONE;
+}
+
+
+/* Attribute getting -------------------------------------------- */
+PyObject *SCA_VibrationActuator::pyattr_get_statusVibration(void *self_v, const struct KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_VibrationActuator *self = static_cast<SCA_VibrationActuator *>(self_v);
+	SCA_JoystickManager *mgr = (SCA_JoystickManager *)self->GetLogicManager();
+	DEV_Joystick *instance = mgr->GetJoystickDevice(self->m_joyindex);
+
+	if (!instance) {
+		return Py_False;
+	}
+
+	return PyBool_FromLong(instance->GetRumbleStatus());
+}
+
+/* Attribute getting -------------------------------------------- */
+PyObject *SCA_VibrationActuator::pyattr_get_hasVibration(void *self_v, const struct KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_VibrationActuator *self = static_cast<SCA_VibrationActuator *>(self_v);
+	SCA_JoystickManager *mgr = (SCA_JoystickManager *)self->GetLogicManager();
+	DEV_Joystick *instance = mgr->GetJoystickDevice(self->m_joyindex);
+
+	if (!instance) {
+		return Py_False;
+	}
+
+	return PyBool_FromLong(instance->GetRumbleSupport());
+}
 
 #endif // WITH_PYTHON

--- a/source/gameengine/GameLogic/SCA_VibrationActuator.h
+++ b/source/gameengine/GameLogic/SCA_VibrationActuator.h
@@ -39,19 +39,37 @@ class SCA_VibrationActuator : public SCA_IActuator
 private:
 
 	int m_joyindex;
-	float m_strength;
+	short mode;
+	float m_strength_left;
+	float m_strength_right;
 	int m_duration;
 	float m_endtime;
 
 public:
 
-	SCA_VibrationActuator(SCA_IObject *gameobj, int joyindex, float strength, int duration);
+	enum KX_ACT_VIBRATION_MODE {
+		KX_ACT_VIBRATION_NONE = 0,
+		KX_ACT_VIBRATION_PLAY,
+		KX_ACT_VIBRATION_STOP,
+		KX_ACT_VIBRATION_MAX
+	};
+
+	SCA_VibrationActuator(SCA_IObject *gameobj, short mode, int joyindex, float strength_left, float strength_right, int duration);
 
 	virtual	~SCA_VibrationActuator(void);
 
 	virtual CValue*	GetReplica(void);
 
 	virtual bool Update();
+
+#ifdef WITH_PYTHON
+	KX_PYMETHOD_DOC_NOARGS(SCA_VibrationActuator, startVibration);
+	KX_PYMETHOD_DOC_NOARGS(SCA_VibrationActuator, stopVibration);
+
+	static PyObject *pyattr_get_statusVibration(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_hasVibration(void *self, const struct KX_PYATTRIBUTE_DEF *attrdef);
+#endif  /* WITH_PYTHON */
+
 };
 
 #endif

--- a/source/gameengine/GameLogic/SCA_VibrationActuator.h
+++ b/source/gameengine/GameLogic/SCA_VibrationActuator.h
@@ -39,7 +39,7 @@ class SCA_VibrationActuator : public SCA_IActuator
 private:
 
 	int m_joyindex;
-	short mode;
+	short m_mode;
 	float m_strength_left;
 	float m_strength_right;
 	int m_duration;


### PR DESCRIPTION
Now the vibration actuator has 2 methods (start and stop). Start method
starts the vibration and also it can update the parameters of the
vibration on fly. Stop method stops the vibration.

Now there is 2 strenght parameters the "left" one sets the strenght of
the Low frequency joystick's motor and the "right" one sets the strenght
of the High frequency joystick's motor.

Additionaly, 2 new bool attributes have been included (isVibrating and
hasVibration) along the new python methods.