### PR TITLE
UPBGE: Makes distance and angle python attributes for Radar Sensor

### DIFF
--- a/extern/bullet2/patches/coneshape_setheight.patch
+++ b/extern/bullet2/patches/coneshape_setheight.patch
@@ -1,0 +1,26 @@
+diff --git a/extern/bullet2/patches/coneshape_setheight.patch b/extern/bullet2/patches/coneshape_setheight.patch
+new file mode 100644
+--- /dev/null
++++ b/extern/bullet2/patches/coneshape_setheight.patch
+@@ -0,0 +1,21 @@
++diff --git a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
++index 4a0df0d..41b5a13 100644
++--- a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
+++++ b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
++@@ -43,6 +43,16 @@ public:
++ 	btScalar getRadius() const { return m_radius;}
++ 	btScalar getHeight() const { return m_height;}
++ 
+++	virtual void setRadius(btScalar radius)
+++	{
+++		m_radius = radius;
+++	}
+++
+++	virtual void setHeight(btScalar height)
+++	{
+++		m_height = height;
+++	}
+++
++ 
++ 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const
++ 	{

--- a/extern/bullet2/readme.txt
+++ b/extern/bullet2/readme.txt
@@ -4,6 +4,10 @@ Questions? mail blender at erwincoumans.com, or check the bf-blender mailing lis
 Thanks,
 Erwin
 
+Applied patches/coneshape_setheight.patch to add access to the posibility of
+modify cone's height and angle is already upstreamed from bullet 2.85.
+There is no necessity to backport this patch to the next bullet version
+
 Apply patches/blender.patch to fix a few build errors and warnings and dd original
 vertex access for BMesh convex hull operator.
 

--- a/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
+++ b/extern/bullet2/src/BulletCollision/CollisionShapes/btConeShape.h
@@ -43,6 +43,15 @@ public:
 	btScalar getRadius() const { return m_radius;}
 	btScalar getHeight() const { return m_height;}
 
+	virtual void setRadius(btScalar radius)
+	{
+		m_radius = radius;
+	}
+
+	virtual void setHeight(btScalar height)
+	{
+		m_height = height;
+	}
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const
 	{

--- a/source/gameengine/Ketsji/KX_RadarSensor.cpp
+++ b/source/gameengine/Ketsji/KX_RadarSensor.cpp
@@ -219,7 +219,7 @@ PyMethodDef KX_RadarSensor::Methods[] = {
 PyAttributeDef KX_RadarSensor::Attributes[] = {
 	KX_PYATTRIBUTE_FLOAT_ARRAY_RO("coneOrigin", KX_RadarSensor, m_cone_origin, 3),
 	KX_PYATTRIBUTE_FLOAT_ARRAY_RO("coneTarget", KX_RadarSensor, m_cone_target, 3),
-	KX_PYATTRIBUTE_RW_FUNCTION("distance", KX_RadarSensor, pyattr_get_height, pyattr_set_height),
+	KX_PYATTRIBUTE_RW_FUNCTION("distance", KX_RadarSensor, pyattr_get_distance, pyattr_set_distance),
 	KX_PYATTRIBUTE_RW_FUNCTION("angle", KX_RadarSensor, pyattr_get_angle, pyattr_set_angle),
 	KX_PYATTRIBUTE_INT_RW("axis", 0, 5, true, KX_RadarSensor, m_axis),
 	{NULL} //Sentinel

--- a/source/gameengine/Ketsji/KX_RadarSensor.cpp
+++ b/source/gameengine/Ketsji/KX_RadarSensor.cpp
@@ -36,6 +36,7 @@
 #include "PHY_IPhysicsController.h"
 #include "PHY_IMotionState.h"
 #include "DNA_sensor_types.h"
+#include "MT_Scalar.h"
 
 /**
  * 	RadarSensor constructor. Creates a near-sensor derived class, with a cone collision shape.
@@ -66,6 +67,7 @@ KX_RadarSensor::KX_RadarSensor(SCA_EventManager* eventmgr,
 				m_axis(axis)
 {
 	m_client_info->m_type = KX_ClientObjectInfo::SENSOR;
+	m_coneshape_modified = false;
 	//m_client_info->m_clientobject = gameobj;
 	//m_client_info->m_auxilary_info = NULL;
 	//sumoObj->setClientObject(&m_client_info);
@@ -166,6 +168,12 @@ void KX_RadarSensor::SynchronizeTransform()
 		const MT_Vector3& pos = trans.getOrigin();
 		float ori[12];
 		trans.getBasis().getValue(ori);
+		if (m_coneshape_modified) {
+			m_physCtrl->SuspendPhysics();
+			m_physCtrl->SetConeShape(m_coneradius, m_coneheight);
+			m_physCtrl->RestorePhysics();
+			m_coneshape_modified = false;
+		}
 		motionState->SetWorldPosition(pos[0], pos[1], pos[2]);
 		motionState->SetWorldOrientation(ori);
 		m_physCtrl->WriteMotionStateToDynamics(true);
@@ -211,20 +219,59 @@ PyMethodDef KX_RadarSensor::Methods[] = {
 PyAttributeDef KX_RadarSensor::Attributes[] = {
 	KX_PYATTRIBUTE_FLOAT_ARRAY_RO("coneOrigin", KX_RadarSensor, m_cone_origin, 3),
 	KX_PYATTRIBUTE_FLOAT_ARRAY_RO("coneTarget", KX_RadarSensor, m_cone_target, 3),
-	KX_PYATTRIBUTE_FLOAT_RO("distance", KX_RadarSensor, m_coneheight),
-	KX_PYATTRIBUTE_RO_FUNCTION("angle", KX_RadarSensor, pyattr_get_angle),
+	KX_PYATTRIBUTE_RW_FUNCTION("distance", KX_RadarSensor, pyattr_get_height, pyattr_set_height),
+	KX_PYATTRIBUTE_RW_FUNCTION("angle", KX_RadarSensor, pyattr_get_angle, pyattr_set_angle),
 	KX_PYATTRIBUTE_INT_RW("axis", 0, 5, true, KX_RadarSensor, m_axis),
 	{NULL} //Sentinel
 };
 
 PyObject *KX_RadarSensor::pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
-	KX_RadarSensor* self = static_cast<KX_RadarSensor*>(self_v);
+	KX_RadarSensor* self = static_cast<KX_RadarSensor *>(self_v);
 
 	// The original angle from the gui was converted, so we recalculate the value here to maintain
 	// consistency between Python and the gui
-	return PyFloat_FromDouble(MT_degrees(atan(self->m_coneradius / self->m_coneheight)) * 2);
+	return PyFloat_FromDouble(MT_degrees(atan(self->m_coneradius / self->m_coneheight)) * 2.0f);
 	
+}
+
+int KX_RadarSensor::pyattr_set_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_RadarSensor *self = static_cast<KX_RadarSensor *>(self_v);
+	float radius;
+
+	if (!PyFloat_Check(value)) {
+		PyErr_SetString(PyExc_TypeError, "sensor.angle = float: Radar Sensor, expected a float value");
+		return PY_SET_ATTR_FAIL;
+	}
+
+	radius = self->m_coneheight * tan(MT_radians(PyFloat_AsDouble(value) * 0.5f));
+	self->m_coneradius = radius;
+	self->m_coneshape_modified = true;
+
+	return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_RadarSensor::pyattr_get_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	KX_RadarSensor* self = static_cast<KX_RadarSensor *>(self_v);
+
+	return PyFloat_FromDouble(self->m_coneheight);
+}
+
+int KX_RadarSensor::pyattr_set_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value)
+{
+	KX_RadarSensor *self = static_cast<KX_RadarSensor *>(self_v);
+
+	if (!PyFloat_Check(value)) {
+		PyErr_SetString(PyExc_TypeError, "sensor.distance = float: Radar Sensor, expected a float value");
+		return PY_SET_ATTR_FAIL;
+	}
+
+	self->m_coneheight = PyFloat_AsDouble(value);
+	self->m_coneshape_modified = true;
+
+	return PY_SET_ATTR_SUCCESS;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_RadarSensor.h
+++ b/source/gameengine/Ketsji/KX_RadarSensor.h
@@ -60,6 +60,8 @@ class KX_RadarSensor : public KX_NearSensor
 	 * The previous direction of the cone (origin to bottom plane).
 	 */
 	float       m_cone_target[3];
+
+	bool m_coneshape_modified;
 	
 public:
 
@@ -93,7 +95,10 @@ public:
 	virtual sensortype GetSensorType() { return ST_RADAR; }
 	/* python */
 #ifdef WITH_PYTHON
-	static PyObject*	pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject* pyattr_get_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_angle(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject* pyattr_get_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_distance(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 #endif
 };
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -768,6 +768,16 @@ public:
 		m_cci.m_radius = margin;
 	}
 
+	// Cone Shape (radius & height)
+	virtual void SetConeShape(float radius, float height)
+	{
+		if (m_collisionShape && (m_collisionShape->getShapeType() == CONE_SHAPE_PROXYTYPE)) {
+			btConeShape *coneShape = static_cast<btConeShape *>(m_collisionShape);
+			coneShape->setRadius(radius);
+			coneShape->setHeight(height);
+		}
+	}
+
 	/// velocity clamping
 	virtual void SetLinVelocityMin(float val)
 	{

--- a/source/gameengine/Physics/Common/PHY_IPhysicsController.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsController.h
@@ -128,6 +128,7 @@ public:
 	virtual float GetMargin() const = 0;
 	virtual float GetRadius() const = 0;
 	virtual void SetRadius(float margin) = 0;
+	virtual void SetConeShape(float radius, float height) = 0;
 
 	virtual float GetLinVelocityMin() const = 0;
 	virtual void SetLinVelocityMin(float val) = 0;


### PR DESCRIPTION
writables

This patch adds the posibility to modify the radar cone's distance and
angle attributes during the runtime through BGE python.

Credits for this patch goes to @Kseniya Halezova (blenderprowlee) too.

An example to can check the feature http://pasteall.org/blend/index.php?
id=44156