### PR TITLE
UPBGE: Securise std::vector erase iteration.

### DIFF
--- a/source/gameengine/GameLogic/SCA_IScene.cpp
+++ b/source/gameengine/GameLogic/SCA_IScene.cpp
@@ -120,10 +120,12 @@ void SCA_IScene::RemoveDebugProperty(class CValue *gameobj,
 
 		if (debugobj == gameobj && debugname == name) {
 			delete (*it);
-			m_debugList.erase(it);
+			it = m_debugList.erase(it);
 			break;
 		}
-		++it;
+		else {
+			++it;
+		}
 	}
 }
 
@@ -136,10 +138,12 @@ void SCA_IScene::RemoveObjectDebugProperties(class CValue* gameobj)
 
 		if (debugobj == gameobj) {
 			delete (*it);
-			m_debugList.erase(it);
+			it = m_debugList.erase(it);
 			continue;
 		}
-		++it;
+		else {
+			++it;
+		}
 	}
 }
 


### PR DESCRIPTION
Using a fixed end iterator or a incrementing the iterator after
delete its previous is unsafe for std::vector. Because erasing
an element can realloc the whole container and then invaldate
the existing iterators.

see: 2c669cc7adfc71de78470dbc17a969e542fb2807

for example file see: https://github.com/UPBGE/blender/issues/321 (Every man's sky-> crash at start in MSVC debug mode)