### PR TITLE
UPBGE: replace setIdentity each frame with const matrix

### DIFF
--- a/source/gameengine/Rasterizer/RAS_2DFilter.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilter.cpp
@@ -95,8 +95,11 @@ void RAS_2DFilter::Start(RAS_IRasterizer *rasty, RAS_ICanvas *canvas, unsigned s
 		BindTextures(rasty, depthfbo, colorfbo);
 		BindUniforms(canvas);
 
-		MT_Matrix4x4 mat;
-		mat.setIdentity();
+		static const MT_Matrix4x4 mat = MT_Matrix4x4(1.0f, 0.0f, 0.0f, 0.0f,
+			                                         0.0f, 1.0f, 0.0f, 0.0f,
+			                                         0.0f, 0.0f, 1.0f, 0.0f,
+			                                         0.0f, 0.0f, 0.0f, 1.0f);
+
 		Update(rasty, mat);
 
 		ApplyShader();


### PR DESCRIPTION
In RAS_2DFilter::Start, each frame a MT_Matrix4x4 was created and set to
identity. I replaced it with static const mat already set to identity.