### PR TITLE
UPBGE: Fix wrong spacing and offset tex

### DIFF
--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -1177,9 +1177,9 @@ void RAS_OpenGLRasterizer::IndexPrimitivesText(RAS_MeshSlot *ms)
 
 	float mat[16];
 	memcpy(mat, textUser->GetMatrix(), sizeof(float) * 16);
-
-	const MT_Vector3& spacing = textUser->GetSpacing();
-	const MT_Vector3& offset = textUser->GetOffset();
+	MT_Matrix3x3 m = MT_Matrix3x3(mat);
+	const MT_Vector3& spacing = m * textUser->GetSpacing();
+	const MT_Vector3& offset = m * textUser->GetOffset();
 
 	mat[12] += offset[0];
 	mat[13] += offset[1];


### PR DESCRIPTION
In void RAS_OpenGLRasterizer::IndexPrimitivesText(RAS_MeshSlot *ms),
spacing and offset were not multiplied with text matrix.

This caused bugs with text displayed on several lines.

see: https://github.com/UPBGE/blender/issues/321 : Game with no name