### PR TITLE
UPBGE: Fix format for HDR_NONE RGB RGBA8

### DIFF
--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -104,7 +104,7 @@ ImageRender::ImageRender (KX_Scene *scene, KX_Camera * camera, unsigned int widt
 	}
 	else {
 		type = GPU_HDR_NONE;
-		m_format = GL_RGBA8;
+		m_format = GL_RGB;
 	}
 
 	m_offScreen = GPU_offscreen_create(m_width, m_height, m_samples, type, GPU_OFFSCREEN_RENDERBUFFER_DEPTH, NULL);


### PR DESCRIPTION
Before
https://github.com/UPBGE/blender/commit/732d176d09b6c2497232bd3ecfced9042b66deff
the format used to make bgl Buffer when you called texture.source.image
was RGB. The default format has been replaced with GL_RGBA8. This caused
error mentionned here:
https://github.com/UPBGE/blender/issues/311
To avoid to break backward compatibility, I restore the old default format
for render to texture. Indeed old files that use texture.source.image used
a 3 components R, G, B buffer. I guess changing that can cause issues to
have now 4 values.