### PR TITLE
UPBGE: Prevent mipmapping while setting VideoFFmpeg (Old Branch)

### DIFF
--- a/source/gameengine/VideoTexture/ImageBase.cpp
+++ b/source/gameengine/VideoTexture/ImageBase.cpp
@@ -64,6 +64,7 @@ ImageBase::ImageBase (bool staticSrc) : m_image(NULL), m_imgSize(0), m_internalF
 m_avail(false), m_scale(false), m_scaleChange(false), m_flip(false),
 m_zbuff(false),
 m_depth(false),
+m_type(IMAGE_NONE),
 m_staticSources(staticSrc), m_pyfilter(NULL)
 {
 	m_size[0] = m_size[1] = 0;

--- a/source/gameengine/VideoTexture/ImageBase.h
+++ b/source/gameengine/VideoTexture/ImageBase.h
@@ -120,6 +120,15 @@ public:
 	/// number of buffer pointing to m_image, public because not handled by this class
 	int m_exports;
 
+	/// type of the image
+	enum {
+		IMAGE_RENDER,
+		IMAGE_VIEWPORT,
+		IMAGE_VIDEO,
+		IMAGE_MIRROR,
+		IMAGE_NONE
+	} m_type;
+
 protected:
 	/// image buffer
 	unsigned int * m_image;

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -92,6 +92,7 @@ ImageRender::ImageRender (KX_Scene *scene, KX_Camera * camera, unsigned int widt
 	m_engine = KX_GetActiveEngine();
 	m_rasterizer = m_engine->GetRasterizer();
 	m_canvas = m_engine->GetCanvas();
+	m_type = IMAGE_RENDER;
 
 	GPUHDRType type;
 	if (hdr == RAS_IRasterizer::RAS_HDR_HALF_FLOAT) {
@@ -888,6 +889,7 @@ ImageRender::ImageRender (KX_Scene *scene, KX_GameObject *observer, KX_GameObjec
     m_mirror(mirror),
     m_clip(100.f)
 {
+	m_type = IMAGE_MIRROR;
 	GPUHDRType type;
 	if (hdr == RAS_IRasterizer::RAS_HDR_HALF_FLOAT) {
 		type = GPU_HDR_HALF_FLOAT;

--- a/source/gameengine/VideoTexture/ImageViewport.cpp
+++ b/source/gameengine/VideoTexture/ImageViewport.cpp
@@ -72,6 +72,7 @@ ImageViewport::ImageViewport()
 	m_viewportImage = new BYTE [4 * getViewportSize()[0] * getViewportSize()[1]];
 	// set attributes
 	setWhole(true);
+	m_type = IMAGE_VIEWPORT;
 }
 
 // constructor

--- a/source/gameengine/VideoTexture/Texture.cpp
+++ b/source/gameengine/VideoTexture/Texture.cpp
@@ -479,10 +479,19 @@ int Texture::pyattr_set_mipmap(void *self_v, const KX_PYATTRIBUTE_DEF *attrdef, 
 		PyErr_SetString(PyExc_TypeError, "The value must be a bool");
 		return -1;
 	}
+	if (!self->m_source) {
+		PyErr_SetString(PyExc_ValueError, "The texture source must be set before setting mipmap");
+		return -1;
+	}
 	// set mipmap
-	self->m_mipmap = value == Py_True;
-	// success
-	return 0;
+	if (self->m_source->m_image &&
+		self->m_source->m_image->m_type != ImageBase::IMAGE_VIDEO) {
+		self->m_mipmap = value == Py_True;
+		// success
+		return 0;
+	}
+	PyErr_SetString(PyExc_TypeError, "Videos can't have mipmap");
+	return -1;
 }
 
 // get source object

--- a/source/gameengine/VideoTexture/VideoFFmpeg.cpp
+++ b/source/gameengine/VideoTexture/VideoFFmpeg.cpp
@@ -80,6 +80,7 @@ m_isThreaded(false), m_isStreaming(false), m_stopThread(false), m_cacheStarted(f
 	BLI_listbase_clear(&m_frameCacheBase);
 	BLI_listbase_clear(&m_packetCacheFree);
 	BLI_listbase_clear(&m_packetCacheBase);
+	m_type = IMAGE_VIDEO;
 }
 
 // destructor


### PR DESCRIPTION
Caused a crash.

Test file: https://drive.google.com/file/d/0B3GouQIyoCmrbHdybmdNV0ZFVGM/view?usp=sharing