### PR TITLE
UPBGE: Add an option to create objects list looping in c++

### DIFF
--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2141,6 +2141,7 @@ PyMethodDef KX_Scene::Methods[] = {
 	KX_PYMETHODTABLE(KX_Scene, suspend),
 	KX_PYMETHODTABLE(KX_Scene, resume),
 	KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
+	KX_PYMETHODTABLE_KEYWORDS(KX_Scene, getMatching),
 
 	
 	/* dict style access */
@@ -2531,6 +2532,36 @@ KX_PYMETHODDEF_DOC(KX_Scene, get, "")
 	
 	Py_INCREF(def);
 	return def;
+}
+
+/* Find gameobjects matching a name, a property... */
+KX_PYMETHODDEF_DOC(KX_Scene, getMatching, "scene.getMatching(objectsName, objectsProperty...)")
+{
+	PyObject *objectslist = PyList_New(0);
+	char *objectsName = "";
+	char *objectsProperty = "";
+
+	static const char *kwlist[] = { "name", "property", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ss:getMatching", (char **)(kwlist), &objectsName, &objectsProperty))
+		return NULL;
+
+	for (int i = 0; i < m_objectlist->GetCount(); i++) {
+		KX_GameObject *gameobj = (KX_GameObject *)m_objectlist->GetValue(i);
+		if (strlen(objectsName)) {
+			if (gameobj->GetName() == objectsName) {
+				PyList_Append(objectslist, gameobj->GetProxy());
+			}
+		}
+		else if (strlen(objectsProperty)) {
+			std::vector<std::string>propnames = gameobj->GetPropertyNames();
+			if (std::find(propnames.begin(), propnames.end(), objectsProperty) != propnames.end()) {
+				PyList_Append(objectslist, gameobj->GetProxy());
+			}
+		}
+	}
+
+	return objectslist;
 }
 
 #endif // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2547,16 +2547,15 @@ KX_PYMETHODDEF_DOC(KX_Scene, getMatching, "scene.getMatching(objectsName, object
 		return NULL;
 
 	for (int i = 0; i < m_objectlist->GetCount(); i++) {
-		KX_GameObject *gameobj = (KX_GameObject *)m_objectlist->GetValue(i);
+		CValue *obj = m_objectlist->GetValue(i);
 		if (strlen(objectsName)) {
-			if (gameobj->GetName() == objectsName) {
-				PyList_Append(objectslist, gameobj->GetProxy());
+			if (obj->GetName() == objectsName) {
+				PyList_Append(objectslist, obj->GetProxy());
 			}
 		}
 		else if (strlen(objectsProperty)) {
-			std::vector<std::string>propnames = gameobj->GetPropertyNames();
-			if (std::find(propnames.begin(), propnames.end(), objectsProperty) != propnames.end()) {
-				PyList_Append(objectslist, gameobj->GetProxy());
+			if (obj->GetProperty(objectsProperty)) {
+				PyList_Append(objectslist, obj->GetProxy());
 			}
 		}
 	}

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2546,16 +2546,16 @@ KX_PYMETHODDEF_DOC(KX_Scene, getMatching, "scene.getMatching(objectsName, object
 	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ss:getMatching", (char **)(kwlist), &objectsName, &objectsProperty))
 		return NULL;
 
-	for (int i = 0; i < m_objectlist->GetCount(); i++) {
-		CValue *obj = m_objectlist->GetValue(i);
+	for (CListValue::iterator<KX_GameObject> it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
+		KX_GameObject *gameobj = *it;
 		if (strlen(objectsName)) {
-			if (obj->GetName() == objectsName) {
-				PyList_Append(objectslist, obj->GetProxy());
+			if (gameobj->GetName() == objectsName) {
+				PyList_Append(objectslist, gameobj->GetProxy());
 			}
 		}
 		else if (strlen(objectsProperty)) {
-			if (obj->GetProperty(objectsProperty)) {
-				PyList_Append(objectslist, obj->GetProxy());
+			if (gameobj->GetProperty(objectsProperty)) {
+				PyList_Append(objectslist, gameobj->GetProxy());
 			}
 		}
 	}

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -567,6 +567,7 @@ public:
 	KX_PYMETHOD_DOC(KX_Scene, resume);
 	KX_PYMETHOD_DOC(KX_Scene, get);
 	KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
+	KX_PYMETHOD_DOC(KX_Scene, getMatching);
 
 
 	/* attributes */


### PR DESCRIPTION
temp work. creates objects list that match name or property. Keyword args

test file: http://pasteall.org/blend/index.php?id=44729

requires performances tests

Performance test file: http://pasteall.org/blend/index.php?id=44738 ... Wait... I fix a mistake in the code

So not big difference on a list of 100 objects. This only makes difference for really big lists. But before sending it to trash, maybe we could test with getMatching(materialName = "...") or with other things... Also on other computers than mine who has a powerful CPU