### PR TITLE
UPBGE: Display "Invalid Uniform Value" error message only at the firs…

### DIFF
--- a/source/gameengine/Rasterizer/RAS_Shader.cpp
+++ b/source/gameengine/Rasterizer/RAS_Shader.cpp
@@ -166,7 +166,9 @@ RAS_Shader::RAS_Shader()
 	m_use(0),
 	m_attr(0),
 	m_error(0),
-	m_dirty(true)
+	m_dirty(true),
+	m_firstRunDebugMessage(true),
+	m_invalidUniformsAlreadyCalled(NULL)
 {
 	for (unsigned short i = 0; i < MAX_PROGRAM; ++i) {
 		m_progs[i] = "";
@@ -482,8 +484,16 @@ int RAS_Shader::GetUniformLocation(const std::string& name, bool debug)
 {
 	BLI_assert(m_shader != NULL);
 	int location = GPU_shader_get_uniform(m_shader, name.c_str());
+	
+	if (location == -1 && debug && m_firstRunDebugMessage) {
 
-	if (location == -1 && debug) {
+		if (std::find(m_invalidUniformsAlreadyCalled.begin(), m_invalidUniformsAlreadyCalled.end(), name) != m_invalidUniformsAlreadyCalled.end()) {
+			m_firstRunDebugMessage = false;
+			return -1;
+		}
+
+		m_invalidUniformsAlreadyCalled.push_back(name);
+
 		CM_Error("invalid uniform value: " << name << ".");
 	}
 

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -109,6 +109,12 @@ protected:
 	std::string m_progs[MAX_PROGRAM];
 	bool m_error;
 	bool m_dirty;
+	/* If there is an Invalid Uniform Value in the shader, display an error
+	* only the first time we run the shader to avoid to fill the console
+	* with messages repeated each frame
+	*/
+	bool m_firstRunDebugMessage;
+	std::vector<std::string>m_invalidUniformsAlreadyCalled;
 
 	// Stored uniform variables
 	RAS_UniformVec m_uniforms;


### PR DESCRIPTION
…t run

This is to avoid to fill the console with repeated error messages each
frame. This is related to https://github.com/UPBGE/blender/issues/319

test file: http://pasteall.org/blend/index.php?id=44739
better test file: http://pasteall.org/blend/index.php?id=44742