### PR TITLE
panzergame no_modifier branch in last master (old branch)

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -878,13 +878,9 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 	PHY_ShapeProps* shapeprops =
 			CreateShapePropsFromBlenderObject(blenderobject);
 
-	DerivedMesh* dm = NULL;
-	if (gameobj->GetDeformer())
-		dm = gameobj->GetDeformer()->GetPhysicsMesh();
-
 	class PHY_IMotionState* motionstate = new KX_MotionState(gameobj->GetSGNode());
 
-	kxscene->GetPhysicsEnvironment()->ConvertObject(gameobj, meshobj, dm, kxscene, shapeprops, motionstate, activeLayerBitInfo, isCompoundChild, hasCompoundChildren);
+	kxscene->GetPhysicsEnvironment()->ConvertObject(gameobj, meshobj, kxscene, shapeprops, motionstate, activeLayerBitInfo, isCompoundChild, hasCompoundChildren);
 
 	bool isActor = (blenderobject->gameflag & OB_ACTOR)!=0;
 	bool isSensor = (blenderobject->gameflag & OB_SENSOR) != 0;
@@ -893,10 +889,6 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject* gameobj,
 		(isActor) ? KX_ClientObjectInfo::ACTOR : KX_ClientObjectInfo::STATIC;
 
 	delete shapeprops;
-	if (dm) {
-		dm->needsFree = 1;
-		dm->release(dm);
-	}
 }
 
 static KX_LodManager *lodmanager_from_blenderobject(Object *ob, KX_Scene *scene, KX_BlenderSceneConverter *converter, bool libloading)

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -477,7 +477,7 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 
 	// Without checking names, we get some reuse we don't want that can cause
 	// problems with material LoDs.
-	if (blenderobj && ((meshobj = converter->FindGameMesh(mesh/*, ob->lay*/)) != NULL)) {
+	if (blenderobj && ((meshobj = converter->FindGameMesh(mesh/*, ob->lay*/)) != NULL) && !blenderobj->modifiers.first) {
 		const std::string bge_name = meshobj->GetName();
 		const std::string blender_name = ((ID *)blenderobj->data)->name + 2;
 		if (bge_name == blender_name) {
@@ -556,8 +556,8 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 			layersInfo.layers.push_back(layer);
 		}
 	}
-
-	meshobj = new RAS_MeshObject(mesh, layersInfo);
+	bool hasModifier = (blenderobj->modifiers.first != NULL);
+	meshobj = new RAS_MeshObject(mesh, blenderobj, hasModifier, layersInfo);
 
 	meshobj->m_sharedvertex_map.resize(totvert);
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -477,6 +477,10 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 
 	// Without checking names, we get some reuse we don't want that can cause
 	// problems with material LoDs.
+	/* For Objects with modifiers, as we apply modifiers at game start, we skip this part
+	 * because we need an unique mesh for objects with modifiers.
+	 * So we add && !blenderobj->modifiers.first to check that the object has no modifier.
+	 */
 	if (blenderobj && ((meshobj = converter->FindGameMesh(mesh/*, ob->lay*/)) != NULL) && !blenderobj->modifiers.first) {
 		const std::string bge_name = meshobj->GetName();
 		const std::string blender_name = ((ID *)blenderobj->data)->name + 2;
@@ -1050,7 +1054,10 @@ static KX_GameObject *gameobject_from_blenderobject(
 		bool bHasShapeKey = mesh->key != NULL && mesh->key->type==KEY_RELATIVE;
 		bool bHasDvert = mesh->dvert != NULL && ob->defbase.first;
 		bool bHasArmature = (BL_ModifierDeformer::HasArmatureDeformer(ob) && ob->parent && ob->parent->type == OB_ARMATURE && bHasDvert);
+
+		/* Since we apply modifiers at game engine start, we set bHasModifier to false by default */
 		bool bHasModifier = false; //BL_ModifierDeformer::HasCompatibleDeformer(ob);
+
 #ifdef WITH_BULLET
 		bool bHasSoftBody = (!ob->parent && (ob->gameflag & OB_SOFT_BODY));
 #endif

--- a/source/gameengine/Ketsji/KX_NavMeshObject.cpp
+++ b/source/gameengine/Ketsji/KX_NavMeshObject.cpp
@@ -245,7 +245,7 @@ bool KX_NavMeshObject::BuildVertIndArrays(float *&vertices, int& nverts,
 		float* vert = vertices;
 		for (int vi=0; vi<nverts; vi++)
 		{
-			const float* pos = !meshobj->m_sharedvertex_map[vi].empty() ? meshobj->GetVertexLocation(vi) : NULL;
+			const float* pos = !meshobj->m_sharedvertex_map[vi].empty() ? meshobj->GetVertexOrigIndex(vi)->getXYZ() : NULL;
 			if (pos)
 				copy_v3_v3(vert, pos);
 			else

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1754,9 +1754,9 @@ void DefaultMotionState::CalculateWorldTransformations()
 // Shape constructor
 std::map<RAS_MeshObject *, CcdShapeConstructionInfo *> CcdShapeConstructionInfo::m_meshShapeMap;
 
-CcdShapeConstructionInfo *CcdShapeConstructionInfo::FindMesh(RAS_MeshObject *mesh, struct DerivedMesh *dm, bool polytope)
+CcdShapeConstructionInfo *CcdShapeConstructionInfo::FindMesh(RAS_MeshObject *mesh, bool polytope)
 {
-	if (polytope || dm)
+	if (polytope)
 		// not yet supported
 		return NULL;
 
@@ -1788,319 +1788,16 @@ void CcdShapeConstructionInfo::ProcessReplica()
 	m_shapeArray.clear();
 }
 
-bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope)
+bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, bool polytope)
 {
-	int numpolys, numverts;
-
-	// assume no shape information
-	// no support for dynamic change of shape yet
-	assert(IsUnused());
-	m_shapeType = PHY_SHAPE_NONE;
-	m_meshObject = NULL;
-	bool free_dm = false;
-
 	// No mesh object or mesh has no polys
 	if (!meshobj || !meshobj->HasColliderPolygon()) {
-		m_vertexArray.clear();
-		m_polygonIndexArray.clear();
-		m_triFaceArray.clear();
-		m_triFaceUVcoArray.clear();
 		return false;
-	}
-
-	if (!dm) {
-		free_dm = true;
-
-		/* Before we applied modifiers at game engine start, the function used
-		 * was dm = CDDM_from_mesh(meshobj->GetMesh()); but this generated crashes
-		 * with some modifiers. So we use the same function as in BlenderDataConversion
-		 * when we convert the mesh for rendering here.
-		 */
-		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
-	}
-
-	// Some meshes with modifiers returns 0 polys, call DM_ensure_tessface avoid this.
-	DM_ensure_tessface(dm);
-
-	MVert *mvert = dm->getVertArray(dm);
-	MFace *mface = dm->getTessFaceArray(dm);
-	numpolys = dm->getNumTessFaces(dm);
-	numverts = dm->getNumVerts(dm);
-	MTFace *tface = (MTFace *)dm->getTessFaceDataArray(dm, CD_MTFACE);
-
-	/* double lookup */
-	const int *index_mf_to_mpoly = (const int *)dm->getTessFaceDataArray(dm, CD_ORIGINDEX);
-	const int *index_mp_to_orig  = (const int *)dm->getPolyDataArray(dm, CD_ORIGINDEX);
-	if (!index_mf_to_mpoly) {
-		index_mp_to_orig = NULL;
 	}
 
 	m_shapeType = (polytope) ? PHY_SHAPE_POLYTOPE : PHY_SHAPE_MESH;
 
-	// Convert blender geometry into bullet mesh, need these vars for mapping
-	std::vector<bool> vert_tag_array(numverts, false);
-	unsigned int tot_bt_verts = 0;
-
-	if (polytope) {
-		// Tag verts we're using
-		for (int p2 = 0; p2 < numpolys; p2++) {
-			MFace *mf = &mface[p2];
-			const int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, p2) : p2;
-			RAS_Polygon *poly = (origi != ORIGINDEX_NONE) ? meshobj->GetPolygon(origi) : NULL;
-
-			// only add polygons that have the collision flag set
-			if (poly && poly->IsCollider()) {
-				if (!vert_tag_array[mf->v1]) {
-					vert_tag_array[mf->v1] = true;
-					tot_bt_verts++;
-				}
-				if (!vert_tag_array[mf->v2]) {
-					vert_tag_array[mf->v2] = true;
-					tot_bt_verts++;
-				}
-				if (!vert_tag_array[mf->v3]) {
-					vert_tag_array[mf->v3] = true;
-					tot_bt_verts++;
-				}
-				if (mf->v4 && !vert_tag_array[mf->v4]) {
-					vert_tag_array[mf->v4] = true;
-					tot_bt_verts++;
-				}
-			}
-		}
-
-		/* Can happen with ngons */
-		if (!tot_bt_verts) {
-			goto cleanup_empty_mesh;
-		}
-
-		m_vertexArray.resize(tot_bt_verts * 3);
-
-		btScalar *bt = &m_vertexArray[0];
-
-		for (int p2 = 0; p2 < numpolys; p2++) {
-			MFace *mf = &mface[p2];
-			const int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, p2) : p2;
-			RAS_Polygon *poly = (origi != ORIGINDEX_NONE) ? meshobj->GetPolygon(origi) : NULL;
-
-			// only add polygons that have the collisionflag set
-			if (poly->IsCollider()) {
-				if (vert_tag_array[mf->v1]) {
-					const float *vtx = mvert[mf->v1].co;
-					vert_tag_array[mf->v1] = false;
-					*bt++ = vtx[0];
-					*bt++ = vtx[1];
-					*bt++ = vtx[2];
-				}
-				if (vert_tag_array[mf->v2]) {
-					const float *vtx = mvert[mf->v2].co;
-					vert_tag_array[mf->v2] = false;
-					*bt++ = vtx[0];
-					*bt++ = vtx[1];
-					*bt++ = vtx[2];
-				}
-				if (vert_tag_array[mf->v3]) {
-					const float *vtx = mvert[mf->v3].co;
-					vert_tag_array[mf->v3] = false;
-					*bt++ = vtx[0];
-					*bt++ = vtx[1];
-					*bt++ = vtx[2];
-				}
-				if (mf->v4 && vert_tag_array[mf->v4]) {
-					const float *vtx = mvert[mf->v4].co;
-					vert_tag_array[mf->v4] = false;
-					*bt++ = vtx[0];
-					*bt++ = vtx[1];
-					*bt++ = vtx[2];
-				}
-			}
-		}
-	}
-	else {
-		unsigned int tot_bt_tris = 0;
-		std::vector<int> vert_remap_array(numverts, 0);
-
-		// Tag verts we're using
-		for (int p2 = 0; p2 < numpolys; p2++) {
-			MFace *mf = &mface[p2];
-			const int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, p2) : p2;
-			RAS_Polygon *poly = (origi != ORIGINDEX_NONE) ? meshobj->GetPolygon(origi) : NULL;
-
-			// only add polygons that have the collision flag set
-			if (poly && poly->IsCollider()) {
-				if (!vert_tag_array[mf->v1]) {
-					vert_tag_array[mf->v1] = true;
-					vert_remap_array[mf->v1] = tot_bt_verts;
-					tot_bt_verts++;
-				}
-				if (!vert_tag_array[mf->v2]) {
-					vert_tag_array[mf->v2] = true;
-					vert_remap_array[mf->v2] = tot_bt_verts;
-					tot_bt_verts++;
-				}
-				if (!vert_tag_array[mf->v3]) {
-					vert_tag_array[mf->v3] = true;
-					vert_remap_array[mf->v3] = tot_bt_verts;
-					tot_bt_verts++;
-				}
-				if (mf->v4 && !vert_tag_array[mf->v4]) {
-					vert_tag_array[mf->v4] = true;
-					vert_remap_array[mf->v4] = tot_bt_verts;
-					tot_bt_verts++;
-				}
-				tot_bt_tris += (mf->v4 ? 2 : 1); /* a quad or a tri */
-			}
-		}
-
-		/* Can happen with ngons */
-		if (!tot_bt_verts) {
-			goto cleanup_empty_mesh;
-		}
-
-		m_vertexArray.resize(tot_bt_verts * 3);
-		m_polygonIndexArray.resize(tot_bt_tris);
-		m_triFaceArray.resize(tot_bt_tris * 3);
-		btScalar *bt = &m_vertexArray[0];
-		int *poly_index_pt = &m_polygonIndexArray[0];
-		int *tri_pt = &m_triFaceArray[0];
-
-		UVco *uv_pt = NULL;
-		if (tface) {
-			m_triFaceUVcoArray.resize(tot_bt_tris * 3);
-			uv_pt = &m_triFaceUVcoArray[0];
-		}
-		else
-			m_triFaceUVcoArray.clear();
-
-		for (int p2 = 0; p2 < numpolys; p2++) {
-			MFace *mf = &mface[p2];
-			MTFace *tf = (tface) ? &tface[p2] : NULL;
-			const int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, p2) : p2;
-			RAS_Polygon *poly = (origi != ORIGINDEX_NONE) ? meshobj->GetPolygon(origi) : NULL;
-
-			// only add polygons that have the collisionflag set
-			if (poly && poly->IsCollider()) {
-				MVert *v1 = &mvert[mf->v1];
-				MVert *v2 = &mvert[mf->v2];
-				MVert *v3 = &mvert[mf->v3];
-
-				// the face indices
-				tri_pt[0] = vert_remap_array[mf->v1];
-				tri_pt[1] = vert_remap_array[mf->v2];
-				tri_pt[2] = vert_remap_array[mf->v3];
-				tri_pt = tri_pt + 3;
-				if (tf) {
-					uv_pt[0].uv[0] = tf->uv[0][0];
-					uv_pt[0].uv[1] = tf->uv[0][1];
-					uv_pt[1].uv[0] = tf->uv[1][0];
-					uv_pt[1].uv[1] = tf->uv[1][1];
-					uv_pt[2].uv[0] = tf->uv[2][0];
-					uv_pt[2].uv[1] = tf->uv[2][1];
-					uv_pt += 3;
-				}
-
-				// m_polygonIndexArray
-				*poly_index_pt = origi;
-				poly_index_pt++;
-
-				// the vertex location
-				if (vert_tag_array[mf->v1]) { /* *** v1 *** */
-					vert_tag_array[mf->v1] = false;
-					*bt++ = v1->co[0];
-					*bt++ = v1->co[1];
-					*bt++ = v1->co[2];
-				}
-				if (vert_tag_array[mf->v2]) { /* *** v2 *** */
-					vert_tag_array[mf->v2] = false;
-					*bt++ = v2->co[0];
-					*bt++ = v2->co[1];
-					*bt++ = v2->co[2];
-				}
-				if (vert_tag_array[mf->v3]) { /* *** v3 *** */
-					vert_tag_array[mf->v3] = false;
-					*bt++ = v3->co[0];
-					*bt++ = v3->co[1];
-					*bt++ = v3->co[2];
-				}
-
-				if (mf->v4) {
-					MVert *v4 = &mvert[mf->v4];
-
-					tri_pt[0] = vert_remap_array[mf->v1];
-					tri_pt[1] = vert_remap_array[mf->v3];
-					tri_pt[2] = vert_remap_array[mf->v4];
-					tri_pt = tri_pt + 3;
-					if (tf) {
-						uv_pt[0].uv[0] = tf->uv[0][0];
-						uv_pt[0].uv[1] = tf->uv[0][1];
-						uv_pt[1].uv[0] = tf->uv[2][0];
-						uv_pt[1].uv[1] = tf->uv[2][1];
-						uv_pt[2].uv[0] = tf->uv[3][0];
-						uv_pt[2].uv[1] = tf->uv[3][1];
-						uv_pt += 3;
-					}
-
-					// m_polygonIndexArray
-					*poly_index_pt = origi;
-					poly_index_pt++;
-
-					// the vertex location
-					if (vert_tag_array[mf->v4]) { // *** v4 ***
-						vert_tag_array[mf->v4] = false;
-						*bt++ = v4->co[0];
-						*bt++ = v4->co[1];
-						*bt++ = v4->co[2];
-					}
-				}
-			}
-		}
-
-	// If this ever gets confusing, print out an OBJ file for debugging
-#if 0
-		CM_Debug("# vert count " << m_vertexArray.size());
-		for (i = 0; i < m_vertexArray.size(); i += 1) {
-			CM_Debug("v " << m_vertexArray[i].x() << " " << m_vertexArray[i].y() << " " << m_vertexArray[i].z());
-		}
-
-		CM_Debug("# face count " << m_triFaceArray.size());
-		for (i = 0; i < m_triFaceArray.size(); i += 3) {
-			CM_Debug("f " << m_triFaceArray[i] + 1 << " " <<  m_triFaceArray[i + 1] + 1 << " " <<  m_triFaceArray[i + 2] + 1);
-		}
-#endif
-	}
-
-#if 0
-	if (validpolys == false) {
-		// should not happen
-		m_shapeType = PHY_SHAPE_NONE;
-		return false;
-	}
-#endif
-
-	m_meshObject = meshobj;
-	if (free_dm) {
-		dm->release(dm);
-		dm = NULL;
-	}
-
-	// sharing only on static mesh at present, if you change that, you must also change in FindMesh
-	if (!polytope && !dm) {
-		// triangle shape can be shared, store the mesh object in the map
-		m_meshShapeMap.insert(std::pair<RAS_MeshObject *, CcdShapeConstructionInfo *>(meshobj, this));
-	}
-	return true;
-
-cleanup_empty_mesh:
-	m_shapeType = PHY_SHAPE_NONE;
-	m_meshObject = NULL;
-	m_vertexArray.clear();
-	m_polygonIndexArray.clear();
-	m_triFaceArray.clear();
-	m_triFaceUVcoArray.clear();
-	if (free_dm) {
-		dm->release(dm);
-	}
-	return false;
+	return UpdateMesh(NULL, meshobj);
 }
 
 #include <cstdio>
@@ -2116,7 +1813,7 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 	unsigned int tot_bt_tris = 0;
 	unsigned int tot_bt_verts = 0;
 
-	int i, j;
+	int i;
 	int v_orig;
 
 	// Use for looping over verts in a face as a try or 2 tris
@@ -2127,169 +1824,9 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 	if (!gameobj && !meshobj)
 		return false;
 
-	if (m_shapeType != PHY_SHAPE_MESH)
-		return false;
-
 	RAS_Deformer *deformer = gameobj ? gameobj->GetDeformer() : NULL;
-	DerivedMesh *dm = NULL;
 
-	if (deformer)
-		dm = deformer->GetPhysicsMesh();
-
-	// get the mesh from the object if not defined
-	if (!meshobj) {
-		// modifier mesh
-		if (dm)
-			meshobj = deformer->GetRasMesh();
-
-		// game object first mesh
-		if (!meshobj) {
-			if (gameobj->GetMeshCount() > 0) {
-				meshobj = gameobj->GetMesh(0);
-			}
-		}
-	}
-
-	if (dm && deformer->GetRasMesh() == meshobj) {
-		/*
-		 * Derived Mesh Update
-		 *
-		 * */
-
-		MVert *mvert = dm->getVertArray(dm);
-		MFace *mface = dm->getTessFaceArray(dm);
-		numpolys = dm->getNumTessFaces(dm);
-		numverts = dm->getNumVerts(dm);
-
-		// double lookup
-		const int *index_mf_to_mpoly = (const int *)dm->getTessFaceDataArray(dm, CD_ORIGINDEX);
-		const int *index_mp_to_orig = (const int *)dm->getPolyDataArray(dm, CD_ORIGINDEX);
-		if (!index_mf_to_mpoly) {
-			index_mp_to_orig = NULL;
-		}
-
-		MFace *mf;
-		MVert *mv;
-
-		if (CustomData_has_layer(&dm->faceData, CD_MTFACE)) {
-			MTFace *tface = (MTFace *)dm->getTessFaceDataArray(dm, CD_MTFACE);
-			MTFace *tf;
-
-			std::vector<bool> vert_tag_array(numverts, false);
-			std::vector<int> vert_remap_array(numverts, 0);
-
-			for (mf = mface, tf = tface, i = 0; i < numpolys; mf++, tf++, i++) {
-				if (tf->mode & TF_DYNAMIC) {
-					int flen;
-
-					if (mf->v4) {
-						tot_bt_tris += 2;
-						flen = 4;
-					}
-					else {
-						tot_bt_tris++;
-						flen = 3;
-					}
-
-					for (j = 0; j < flen; j++) {
-						v_orig = (*(&mf->v1 + j));
-
-						if (!vert_tag_array[v_orig]) {
-							vert_tag_array[v_orig] = true;
-							vert_remap_array[v_orig] = tot_bt_verts;
-							tot_bt_verts++;
-						}
-					}
-				}
-			}
-
-			m_vertexArray.resize(tot_bt_verts * 3);
-			btScalar *bt = &m_vertexArray[0];
-
-			m_triFaceArray.resize(tot_bt_tris * 3);
-			int *tri_pt = &m_triFaceArray[0];
-
-			m_triFaceUVcoArray.resize(tot_bt_tris * 3);
-			UVco *uv_pt = &m_triFaceUVcoArray[0];
-
-			m_polygonIndexArray.resize(tot_bt_tris);
-			int *poly_index_pt = &m_polygonIndexArray[0];
-
-			for (mf = mface, tf = tface, i = 0; i < numpolys; mf++, tf++, i++) {
-				if (tf->mode & TF_DYNAMIC) {
-					int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, i) : i;
-
-					if (mf->v4) {
-						fv_pt = quad_verts;
-						*poly_index_pt++ = origi;
-						*poly_index_pt++ = origi;
-					}
-					else {
-						fv_pt = tri_verts;
-						*poly_index_pt++ = origi;
-					}
-
-					for (; *fv_pt > -1; fv_pt++) {
-						v_orig = (*(&mf->v1 + (*fv_pt)));
-
-						if (vert_tag_array[v_orig]) {
-							mv = mvert + v_orig;
-							*bt++ = mv->co[0];
-							*bt++ = mv->co[1];
-							*bt++ = mv->co[2];
-
-							vert_tag_array[v_orig] = false;
-						}
-						*tri_pt++ = vert_remap_array[v_orig];
-						uv_pt->uv[0] = tf->uv[*fv_pt][0];
-						uv_pt->uv[1] = tf->uv[*fv_pt][1];
-						uv_pt++;
-					}
-				}
-			}
-		}
-		else {
-			// no need for a vertex mapping. simple/fast
-			tot_bt_verts = numverts;
-
-			for (mf = mface, i = 0; i < numpolys; mf++, i++) {
-				tot_bt_tris += (mf->v4 ? 2 : 1);
-			}
-
-			m_vertexArray.resize(tot_bt_verts * 3);
-			btScalar *bt = &m_vertexArray[0];
-
-			m_triFaceArray.resize(tot_bt_tris * 3);
-			int *tri_pt = &m_triFaceArray[0];
-
-			m_polygonIndexArray.resize(tot_bt_tris);
-			int *poly_index_pt = &m_polygonIndexArray[0];
-
-			m_triFaceUVcoArray.clear();
-
-			for (mv = mvert, i = 0; i < numverts; mv++, i++) {
-				*bt++ = mv->co[0]; *bt++ = mv->co[1]; *bt++ = mv->co[2];
-			}
-
-			for (mf = mface, i = 0; i < numpolys; mf++, i++) {
-				int origi = index_mf_to_mpoly ? DM_origindex_mface_mpoly(index_mf_to_mpoly, index_mp_to_orig, i) : i;
-
-				if (mf->v4) {
-					fv_pt = quad_verts;
-					*poly_index_pt++ = origi;
-					*poly_index_pt++ = origi;
-				}
-				else {
-					fv_pt = tri_verts;
-					*poly_index_pt++ = origi;
-				}
-
-				for (; *fv_pt > -1; fv_pt++)
-					*tri_pt++ = (*(&mf->v1 + (*fv_pt)));
-			}
-		}
-	}
-	else {  /*
+	{  /*
 		     * RAS Mesh Update
 		     *
 		     * */
@@ -2341,6 +1878,9 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 		m_triFaceArray.resize(tot_bt_tris * 3);
 		int *tri_pt = &m_triFaceArray[0];
 
+		m_triFaceUVcoArray.resize(tot_bt_tris * 3);
+		UVco *uv_pt = m_triFaceUVcoArray.data();
+
 		/* cant be used for anything useful in this case, since we don't rely on the original mesh
 		 * will just be an array like pythons range(tot_bt_tris) */
 		m_polygonIndexArray.resize(tot_bt_tris);
@@ -2356,7 +1896,9 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 
 				for (; *fv_pt > -1; fv_pt++) {
 					v_orig = poly->GetVertexInfo(*fv_pt).getOrigIndex();
+					RAS_ITexVert *vert = meshobj->GetVertexOrigIndex(v_orig);
 					if (vert_tag_array[v_orig]) {
+						
 						if (transverts) {
 							/* deformed mesh, using RAS_TexVert locations would be too troublesome
 							 * because they are use the gameob as a hash in the material slot */
@@ -2366,7 +1908,7 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 						}
 						else {
 							/* static mesh python may have modified */
-							xyz = meshobj->GetVertexLocation(v_orig);
+							xyz = vert->getXYZ();
 							*bt++ = xyz[0];
 							*bt++ = xyz[1];
 							*bt++ = xyz[2];
@@ -2374,6 +1916,10 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 						vert_tag_array[v_orig] = false;
 					}
 					*tri_pt++ = vert_remap_array[v_orig];
+					const float *vertuv = vert->getUV(0);
+					UVco *uv = uv_pt++;
+					uv->uv[0] = vertuv[0];
+					uv->uv[1] = vertuv[1];
 				}
 			}
 			// first triangle
@@ -2414,15 +1960,11 @@ bool CcdShapeConstructionInfo::UpdateMesh(class KX_GameObject *gameobj, class RA
 	std::map<RAS_MeshObject *, CcdShapeConstructionInfo *>::iterator mit = m_meshShapeMap.find(m_meshObject);
 	if (mit != m_meshShapeMap.end()) {
 		m_meshShapeMap.erase(mit);
-		m_meshShapeMap[meshobj] = this;
 	}
 
 	m_meshObject = meshobj;
+	m_meshShapeMap[m_meshObject] = this;
 
-	if (dm) {
-		dm->needsFree = 1;
-		dm->release(dm);
-	}
 	return true;
 }
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1810,6 +1810,12 @@ bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm,
 
 	if (!dm) {
 		free_dm = true;
+
+		/* Before we applied modifiers at game engine start, the function used
+		 * was dm = CDDM_from_mesh(meshobj->GetMesh()); but this generated crashes
+		 * with some modifiers. So we use the same function as in BlenderDataConversion
+		 * when we convert the mesh for rendering here.
+		 */
 		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
 	}
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1788,7 +1788,7 @@ void CcdShapeConstructionInfo::ProcessReplica()
 	m_shapeArray.clear();
 }
 
-bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm, bool polytope)
+bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope)
 {
 	int numpolys, numverts;
 
@@ -1810,7 +1810,7 @@ bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm,
 
 	if (!dm) {
 		free_dm = true;
-		dm = CDDM_from_mesh(meshobj->GetMesh());
+		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
 	}
 
 	// Some meshes with modifiers returns 0 polys, call DM_ensure_tessface avoid this.

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -44,6 +44,7 @@ class btMotionState;
 class RAS_MeshObject;
 struct DerivedMesh;
 class btCollisionShape;
+class KX_Scene;
 
 #define CCD_BSB_SHAPE_MATCHING  2
 #define CCD_BSB_BENDING_CONSTRAINTS 8
@@ -153,7 +154,7 @@ public:
 		return true;
 	}
 
-	bool SetMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, bool polytope);
+	bool SetMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope);
 	RAS_MeshObject *GetMesh(void)
 	{
 		return m_meshObject;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -44,7 +44,6 @@ class btMotionState;
 class RAS_MeshObject;
 struct DerivedMesh;
 class btCollisionShape;
-class KX_Scene;
 
 #define CCD_BSB_SHAPE_MATCHING  2
 #define CCD_BSB_BENDING_CONSTRAINTS 8
@@ -67,7 +66,7 @@ public:
 		float uv[2];
 	};
 
-	static CcdShapeConstructionInfo *FindMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, bool polytope);
+	static CcdShapeConstructionInfo *FindMesh(class RAS_MeshObject *mesh, bool polytope);
 
 	CcdShapeConstructionInfo() 
 		:m_shapeType(PHY_SHAPE_NONE),
@@ -154,7 +153,7 @@ public:
 		return true;
 	}
 
-	bool SetMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope);
+	bool SetMesh(class RAS_MeshObject *mesh, bool polytope);
 	RAS_MeshObject *GetMesh(void)
 	{
 		return m_meshObject;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -3143,7 +3143,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 		}
 		case OB_BOUND_CONVEX_HULL:
 		{
-			shapeInfo->SetMesh(meshobj, dm, true);
+			shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, true);
 			bm = shapeInfo->CreateBulletShape(ci.m_margin);
 			break;
 		}
@@ -3167,7 +3167,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 				shapeInfo->AddRef();
 			}
 			else {
-				shapeInfo->SetMesh(meshobj, dm, false);
+				shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, false);
 			}
 
 			// Soft bodies can benefit from welding, don't do it on non-soft bodies

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -2909,7 +2909,7 @@ CcdPhysicsEnvironment *CcdPhysicsEnvironment::Create(Scene *blenderscene, bool v
 	return ccdPhysEnv;
 }
 
-void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject *meshobj, DerivedMesh *dm, KX_Scene *kxscene, PHY_ShapeProps *shapeprops, PHY_IMotionState *motionstate, int activeLayerBitInfo, bool isCompoundChild, bool hasCompoundChildren)
+void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject *meshobj, KX_Scene *kxscene, PHY_ShapeProps *shapeprops, PHY_IMotionState *motionstate, int activeLayerBitInfo, bool isCompoundChild, bool hasCompoundChildren)
 {
 	Object *blenderobject = gameobj->GetBlenderObject();
 
@@ -3143,7 +3143,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 		}
 		case OB_BOUND_CONVEX_HULL:
 		{
-			shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, true);
+			shapeInfo->SetMesh(meshobj, true);
 			bm = shapeInfo->CreateBulletShape(ci.m_margin);
 			break;
 		}
@@ -3160,14 +3160,14 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 		case OB_BOUND_TRIANGLE_MESH:
 		{
 			// mesh shapes can be shared, check first if we already have a shape on that mesh
-			class CcdShapeConstructionInfo *sharedShapeInfo = CcdShapeConstructionInfo::FindMesh(meshobj, dm, false);
+			class CcdShapeConstructionInfo *sharedShapeInfo = CcdShapeConstructionInfo::FindMesh(meshobj, false);
 			if (sharedShapeInfo != NULL) {
 				shapeInfo->Release();
 				shapeInfo = sharedShapeInfo;
 				shapeInfo->AddRef();
 			}
 			else {
-				shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, false);
+				shapeInfo->SetMesh(meshobj, false);
 			}
 
 			// Soft bodies can benefit from welding, don't do it on non-soft bodies

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -284,7 +284,6 @@ public:
 
 	virtual void ConvertObject(KX_GameObject *gameobj,
 	                           RAS_MeshObject *meshobj,
-	                           DerivedMesh *dm,
 	                           KX_Scene *kxscene,
 	                           PHY_ShapeProps *shapeprops,
 	                           PHY_IMotionState *motionstate,

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -239,7 +239,6 @@ public:
 
 	virtual void ConvertObject(KX_GameObject *gameobj,
 	                           RAS_MeshObject *meshobj,
-	                           DerivedMesh *dm,
 	                           KX_Scene *kxscene,
 	                           PHY_ShapeProps *shapeprops,
 	                           PHY_IMotionState *motionstate,

--- a/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
@@ -129,7 +129,6 @@ public:
 
 	virtual void ConvertObject(KX_GameObject *gameobj,
 	                           RAS_MeshObject *meshobj,
-	                           DerivedMesh *dm,
 	                           KX_Scene *kxscene,
 	                           PHY_ShapeProps *shapeprops,
 	                           PHY_IMotionState *motionstate,

--- a/source/gameengine/Rasterizer/RAS_MeshObject.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.cpp
@@ -101,15 +101,12 @@ struct RAS_MeshObject::fronttoback
 
 // mesh object
 
-RAS_MeshObject::RAS_MeshObject(Mesh *mesh, Object *blenderobj, bool hasModifier, const LayersInfo& layersInfo)
-	:m_layersInfo(layersInfo),
+RAS_MeshObject::RAS_MeshObject(Mesh *mesh, const std::string& name, const LayersInfo& layersInfo)
+	:m_name(name),
+	m_layersInfo(layersInfo),
 	m_boundingBox(NULL),
 	m_mesh(mesh)
 {
-	/* If we have a blenderobject (Object *) with modifiers, its mesh is unique and must have an unique name to identify it.
-	 * Else the mesh can be shared by several Objects so we don't need an unique name.
-	 */
-	m_name = hasModifier ? std::string(mesh->id.name + 2) + std::string(":") + std::string(blenderobj->id.name + 2) : mesh->id.name + 2;
 }
 
 RAS_MeshObject::~RAS_MeshObject()

--- a/source/gameengine/Rasterizer/RAS_MeshObject.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.cpp
@@ -106,6 +106,9 @@ RAS_MeshObject::RAS_MeshObject(Mesh *mesh, Object *blenderobj, bool hasModifier,
 	m_boundingBox(NULL),
 	m_mesh(mesh)
 {
+	/* If we have a blenderobject (Object *) with modifiers, its mesh is unique and must have an unique name to identify it.
+	 * Else the mesh can be shared by several Objects so we don't need an unique name.
+	 */
 	m_name = hasModifier ? std::string(mesh->id.name + 2) + std::string(":") + std::string(blenderobj->id.name + 2) : mesh->id.name + 2;
 }
 

--- a/source/gameengine/Rasterizer/RAS_MeshObject.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "DNA_mesh_types.h"
+#include "DNA_object_types.h"
 
 #include "RAS_MeshObject.h"
 #include "RAS_MeshUser.h"
@@ -100,12 +101,12 @@ struct RAS_MeshObject::fronttoback
 
 // mesh object
 
-RAS_MeshObject::RAS_MeshObject(Mesh *mesh, const LayersInfo& layersInfo)
-	:m_name(mesh->id.name + 2),
-	m_layersInfo(layersInfo),
+RAS_MeshObject::RAS_MeshObject(Mesh *mesh, Object *blenderobj, bool hasModifier, const LayersInfo& layersInfo)
+	:m_layersInfo(layersInfo),
 	m_boundingBox(NULL),
 	m_mesh(mesh)
 {
+	m_name = hasModifier ? std::string(mesh->id.name + 2) + std::string(":") + std::string(blenderobj->id.name + 2) : mesh->id.name + 2;
 }
 
 RAS_MeshObject::~RAS_MeshObject()

--- a/source/gameengine/Rasterizer/RAS_MeshObject.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.cpp
@@ -340,11 +340,11 @@ RAS_ITexVert *RAS_MeshObject::GetVertex(unsigned int matid, unsigned int index)
 	return NULL;
 }
 
-const float *RAS_MeshObject::GetVertexLocation(unsigned int orig_index)
+RAS_ITexVert *RAS_MeshObject::GetVertexOrigIndex(unsigned int orig_index)
 {
 	std::vector<SharedVertex>& sharedmap = m_sharedvertex_map[orig_index];
 	std::vector<SharedVertex>::iterator it = sharedmap.begin();
-	return it->m_darray->GetVertex(it->m_offset)->getXYZ();
+	return it->m_darray->GetVertex(it->m_offset);
 }
 
 RAS_BoundingBox *RAS_MeshObject::GetBoundingBox() const

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -56,6 +56,7 @@ class RAS_BoundingBoxManager;
 struct Mesh;
 struct MTFace;
 struct MCol;
+struct Object;
 
 /* RAS_MeshObject is a mesh used for rendering. It stores polygons,
  * but the actual vertices and index arrays are stored in material
@@ -108,7 +109,7 @@ protected:
 
 public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
-	RAS_MeshObject(Mesh *mesh, const LayersInfo& layersInfo);
+	RAS_MeshObject(Mesh *mesh, Object *blenderobj, bool hasModifier, const LayersInfo& layersInfo);
 	virtual ~RAS_MeshObject();
 
 	// materials

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -109,7 +109,7 @@ protected:
 
 public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
-	RAS_MeshObject(Mesh *mesh, Object *blenderobj, bool hasModifier, const LayersInfo& layersInfo);
+	RAS_MeshObject(Mesh *mesh, const std::string& name, const LayersInfo& layersInfo);
 	virtual ~RAS_MeshObject();
 
 	// materials

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -150,7 +150,7 @@ public:
 	// vertex and polygon acces
 	RAS_IDisplayArray *GetDisplayArray(unsigned int matid) const;
 	RAS_ITexVert *GetVertex(unsigned int matid, unsigned int index);
-	const float *GetVertexLocation(unsigned int orig_index);
+	RAS_ITexVert *GetVertexOrigIndex(unsigned int orig_index);
 
 	int NumPolygons();
 	RAS_Polygon *GetPolygon(int num) const;


### PR DESCRIPTION
I exhume panzergame branch about applying modifiers at game engine start.

**The problem is: http://pasteall.org/193042**

**Test files:** 

- Modifiers not applied: https://drive.google.com/file/d/0B3GouQIyoCmrRXRYY21PNVB2LVE/view?usp=sharing

- Modifiers applied: https://drive.google.com/file/d/0B3GouQIyoCmrdm40TU1pT1p5R00/view?usp=sharing

**Performances:**

Master:

- Modifiers applied : 395 fps
- Modifiers not applied: 118 fps

ge_modifiers2:

- Modiers applied: 395 fps
- Modifiers not applied: 395 fps

**Bug with multiples mesh users:** 

- http://pasteall.org/blend/index.php?id=45077

**Next steps:**

- Fix the bug.

- Remove a part of the derived meshes code.