### PR TITLE
UPBGE: Fix compilation errors in MSVC2015 in debug mode

### DIFF
--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -933,9 +933,7 @@ const MT_Matrix4x4& KX_KetsjiEngine::GetCameraProjection(KX_Scene *scene, KX_Cam
 // update graphics
 void KX_KetsjiEngine::RenderFrame(KX_Scene *scene, KX_Camera *cam, unsigned short pass)
 {
-	bool override_camera;
 	RAS_Rect viewport, area;
-	float nearfrust, farfrust, focallength;
 
 	if (!cam)
 		return;

--- a/source/gameengine/Rasterizer/Node/RAS_DownwardNode.h
+++ b/source/gameengine/Rasterizer/Node/RAS_DownwardNode.h
@@ -29,7 +29,7 @@
 
 #ifdef DEBUG
 #  include <typeinfo>
-#  include <cxxabi.h>
+//#  include <cxxabi.h>
 #endif  // DEBUG
 
 /** RAS_DownwardNode is a node which store its children nodes.

--- a/source/gameengine/Rasterizer/Node/RAS_UpwardNode.h
+++ b/source/gameengine/Rasterizer/Node/RAS_UpwardNode.h
@@ -27,7 +27,7 @@
 
 #ifdef DEBUG
 #  include <typeinfo>
-#  include <cxxabi.h>
+//#  include <cxxabi.h>
 #endif  // DEBUG
 
 /** RAS_UpwardNode is a node storing its parent node.


### PR DESCRIPTION
commented cxxabi.h
removed unused variables

Important note: To Build in debug mode, we now have to set ge_rasterizer
properties/command lines with /bigobj to build in debug mode because
of something in RAS_IBatchDisplayArray.cpp

https://drive.google.com/file/d/0B3GouQIyoCmrQXREZlFiMGtnMFU/view?usp=sharing
(picture of MSVC2015)