### PR TITLE
UPBGE: Quick refactor of texts drawing

### DIFF
--- a/source/blender/blenfont/BLF_api.h
+++ b/source/blender/blenfont/BLF_api.h
@@ -82,6 +82,8 @@ void BLF_draw_default_ascii(float x, float y, float z, const char *str, size_t l
 /* Draw the string using the current font. */
 void BLF_draw_ex(int fontid, const char *str, size_t len, struct ResultBLF *r_info) ATTR_NONNULL(2);
 void BLF_draw(int fontid, const char *str, size_t len) ATTR_NONNULL(2);
+void BLF_draw_ge_ex(int fontid, const char *str, size_t len, struct ResultBLF *r_info) ATTR_NONNULL(2);
+void BLF_draw_ge(int fontid, const char *str, size_t len) ATTR_NONNULL(2);
 void BLF_draw_ascii_ex(int fontid, const char *str, size_t len, struct ResultBLF *r_info) ATTR_NONNULL(2);
 void BLF_draw_ascii(int fontid, const char *str, size_t len) ATTR_NONNULL(2);
 int BLF_draw_mono(int fontid, const char *str, size_t len, int cwidth) ATTR_NONNULL(2);

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -1161,8 +1161,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 
 	if (m_show_framerate || m_show_profile) {
 		// Title for profiling("Profile")
-		m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-		                           "Profile",
+		m_rasterizer->RenderText2D("Profile",
 		                           xcoord + const_xindent + title_xmargin,  // Adds the constant x indent (0 for now) to the title x margin
 		                           ycoord,
 		                           m_canvas->GetWidth() /* RdV, TODO ?? */,
@@ -1176,16 +1175,14 @@ void KX_KetsjiEngine::RenderDebugProperties()
 
 	// Framerate display
 	if (m_show_framerate) {
-		m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-		                           "Frametime :",
+		m_rasterizer->RenderText2D("Frametime :",
 		                           xcoord + const_xindent,
 		                           ycoord,
 		                           m_canvas->GetWidth() /* RdV, TODO ?? */,
 		                           m_canvas->GetHeight() /* RdV, TODO ?? */);
 
 		debugtxt = (boost::format("%5.2fms (%.1ffps)") %  (tottime * 1000.0f) % (1.0f / tottime)).str();
-		m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-		                           debugtxt,
+		m_rasterizer->RenderText2D(debugtxt,
 		                           xcoord + const_xindent + profile_indent,
 		                           ycoord,
 		                           m_canvas->GetWidth() /* RdV, TODO ?? */,
@@ -1197,8 +1194,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 	// Profile display
 	if (m_show_profile) {
 		for (int j = tc_first; j < tc_numCategories; j++) {
-			m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-			                           m_profileLabels[j],
+			m_rasterizer->RenderText2D(m_profileLabels[j],
 			                           xcoord + const_xindent,
 			                           ycoord,
 			                           m_canvas->GetWidth(),
@@ -1207,8 +1203,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 			double time = m_logger->GetAverage((KX_TimeCategory)j);
 
 			debugtxt = (boost::format("%5.2fms | %d%%") % (time*1000.f) % (int)(time/tottime * 100.f)).str();
-			m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-			                           debugtxt,
+			m_rasterizer->RenderText2D(debugtxt,
 			                           xcoord + const_xindent + profile_indent, ycoord,
 			                           m_canvas->GetWidth(),
 			                           m_canvas->GetHeight());
@@ -1224,8 +1219,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 	if (m_show_debug_properties) {
 
 		/* Title for debugging("Debug properties") */
-		m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-		                           "Debug Properties",
+		m_rasterizer->RenderText2D("Debug Properties",
 		                           xcoord + const_xindent + title_xmargin,  // Adds the constant x indent (0 for now) to the title x margin
 		                           ycoord,
 		                           m_canvas->GetWidth() /* RdV, TODO ?? */,
@@ -1265,8 +1259,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 							first = false;
 						}
 					}
-					m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-					                           debugtxt,
+					m_rasterizer->RenderText2D(debugtxt,
 					                           xcoord + const_xindent,
 					                           ycoord,
 					                           m_canvas->GetWidth(),
@@ -1278,8 +1271,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 					if (propval) {
 						std::string text = propval->GetText();
 						debugtxt = objname + ": '" + propname + "' = " + text;
-						m_rasterizer->RenderText2D(RAS_IRasterizer::RAS_TEXT_PADDED,
-						                           debugtxt,
+						m_rasterizer->RenderText2D(debugtxt,
 						                           xcoord + const_xindent,
 						                           ycoord,
 						                           m_canvas->GetWidth(),

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.cpp
@@ -1635,12 +1635,9 @@ void RAS_IRasterizer::GetTransform(float *origmat, int objectdrawmode, float mat
 
 void RAS_IRasterizer::DisableForText()
 {
-	SetAlphaBlend(GPU_BLEND_ALPHA);
 	SetLines(false); /* needed for texture fonts otherwise they render as wireframe */
 
 	Enable(RAS_CULL_FACE);
-
-	ProcessLighting(false, MT_Transform::Identity());
 
 	m_impl->DisableForText();
 }
@@ -1662,12 +1659,11 @@ void RAS_IRasterizer::RenderText3D(
 }
 
 void RAS_IRasterizer::RenderText2D(
-    RAS_TEXT_RENDER_MODE mode,
     const std::string& text,
     int xco, int yco,
     int width, int height)
 {
-	m_impl->RenderText2D(mode, text, xco, yco, width, height);
+	m_impl->RenderText2D(text, xco, yco, width, height);
 }
 
 void RAS_IRasterizer::PushMatrix()

--- a/source/gameengine/Rasterizer/RAS_IRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_IRasterizer.h
@@ -69,12 +69,6 @@ struct GPUShader;
 class RAS_IRasterizer
 {
 public:
-	enum RAS_TEXT_RENDER_MODE {
-		RAS_TEXT_RENDER_NODEF = 0,
-		RAS_TEXT_NORMAL,
-		RAS_TEXT_PADDED,
-		RAS_TEXT_MAX,
-	};
 
 	/**
 	 * Drawing types
@@ -864,7 +858,7 @@ public:
 	 * \param height	Height of the canvas to draw to.
 	 */
 	void RenderText2D(
-	        RAS_TEXT_RENDER_MODE mode, const std::string& text,
+	        const std::string& text,
 	        int xco, int yco, int width, int height);
 
 	void ProcessLighting(bool uselights, const MT_Transform &trans);

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -707,6 +707,7 @@ void RAS_OpenGLRasterizer::RenderText3D(
 	/* gl prepping */
 	DisableForText();
 	SetFrontFace(true);
+	m_rasterizer->SetAlphaBlend(GPU_BLEND_ALPHA);
 
 	/* the actual drawing */
 	glColor4fv(color);
@@ -730,7 +731,7 @@ void RAS_OpenGLRasterizer::RenderText3D(
 }
 
 void RAS_OpenGLRasterizer::RenderText2D(
-    RAS_IRasterizer::RAS_TEXT_RENDER_MODE mode,
+
     const std::string& text,
     int xco, int yco,
     int width, int height)
@@ -740,6 +741,11 @@ void RAS_OpenGLRasterizer::RenderText2D(
 	 * what cause it, though :/ .*/
 	DisableForText();
 	SetFrontFace(true);
+
+	/* Disable lighting to draw profile texts */
+	Disable(RAS_IRasterizer::RAS_LIGHTING);
+	Disable(RAS_IRasterizer::RAS_COLOR_MATERIAL);
+
 	Disable(RAS_IRasterizer::RAS_DEPTH_TEST);
 
 	SetMatrixMode(RAS_IRasterizer::RAS_PROJECTION);
@@ -752,13 +758,11 @@ void RAS_OpenGLRasterizer::RenderText2D(
 	PushMatrix();
 	LoadIdentity();
 
-	if (mode == RAS_IRasterizer::RAS_TEXT_PADDED) {
-		/* draw in black first */
-		glColor3ub(0, 0, 0);
-		BLF_size(blf_mono_font, 11, 72);
-		BLF_position(blf_mono_font, (float)xco + 1, (float)(height - yco - 1), 0.0f);
-		BLF_draw(blf_mono_font, text.c_str(), text.size());
-	}
+	/* draw in black first */
+	glColor3ub(0, 0, 0);
+	BLF_size(blf_mono_font, 11, 72);
+	BLF_position(blf_mono_font, (float)xco + 1, (float)(height - yco - 1), 0.0f);
+	BLF_draw(blf_mono_font, text.c_str(), text.size());
 
 	/* the actual drawing */
 	glColor3ub(255, 255, 255);

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.cpp
@@ -723,7 +723,7 @@ void RAS_OpenGLRasterizer::RenderText3D(
 
 	BLF_size(fontid, size, dpi);
 	BLF_position(fontid, 0, 0, 0);
-	BLF_draw(fontid, text.c_str(), text.size());
+	BLF_draw_ge(fontid, text.c_str(), text.size());
 
 	BLF_disable(fontid, BLF_MATRIX | BLF_ASPECT);
 
@@ -762,13 +762,13 @@ void RAS_OpenGLRasterizer::RenderText2D(
 	glColor3ub(0, 0, 0);
 	BLF_size(blf_mono_font, 11, 72);
 	BLF_position(blf_mono_font, (float)xco + 1, (float)(height - yco - 1), 0.0f);
-	BLF_draw(blf_mono_font, text.c_str(), text.size());
+	BLF_draw_ge(blf_mono_font, text.c_str(), text.size());
 
 	/* the actual drawing */
 	glColor3ub(255, 255, 255);
 	BLF_size(blf_mono_font, 11, 72);
 	BLF_position(blf_mono_font, (float)xco, (float)(height - yco), 0.0f);
-	BLF_draw(blf_mono_font, text.c_str(), text.size());
+	BLF_draw_ge(blf_mono_font, text.c_str(), text.size());
 
 	SetMatrixMode(RAS_IRasterizer::RAS_PROJECTION);
 	PopMatrix();

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLRasterizer.h
@@ -129,7 +129,7 @@ public:
 	void RenderBox2D(int xco, int yco, int width, int height, float percentage);
 	void RenderText3D(int fontid, const std::string& text, int size, int dpi,
 	                  const float color[4], const float mat[16], float aspect);
-	void RenderText2D(RAS_IRasterizer::RAS_TEXT_RENDER_MODE mode, const std::string& text,
+	void RenderText2D(const std::string& text,
 	                  int xco, int yco, int width, int height);
 
 	void PushMatrix();


### PR DESCRIPTION
See comments on both commits.

test file: http://pasteall.org/blend/index.php?id=45723

Fixes #396, improves performances in some files and make the profile more "accurate" I guess (as the drawing profile takes less performances).

I didn't noticed different behavior with master (except the fixed bug).

The part in blf can be simplified I guess because some code is already in game engine code... But as it is, I think it costs nothing to commit.