### PR TITLE
UPBGE: Add sky texture option in world tab

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -724,6 +724,15 @@ class WORLD_PT_game_environment_lighting(WorldButtonsPanel, Panel):
         split.prop(light, "environment_energy", text="Energy")
         split.prop(light, "environment_color", text="")
 
+        split = layout.split()
+        split.prop(light, "environment_lodbias", text="Blur")
+        split = layout.split()
+        split.prop(light, "environment_fresnel", text="Fresnel")
+        split = layout.split()
+        split.prop(light, "environment_refr_ratio", text="Refraction Ratio")
+        split = layout.split()
+        split.prop(light, "environment_ior", text="IOR")
+
 
 class WORLD_PT_game_mist(WorldButtonsPanel, Panel):
     bl_label = "Mist"

--- a/release/scripts/startup/bl_ui/properties_world.py
+++ b/release/scripts/startup/bl_ui/properties_world.py
@@ -140,6 +140,15 @@ class WORLD_PT_environment_lighting(WorldButtonsPanel, Panel):
         split.prop(light, "environment_energy", text="Energy")
         split.prop(light, "environment_color", text="")
 
+        split = layout.split()
+        split.prop(light, "environment_lodbias", text="Blur")
+        split = layout.split()
+        split.prop(light, "environment_fresnel", text="Fresnel")
+        split = layout.split()
+        split.prop(light, "environment_refr_ratio", text="Refraction Ratio")
+        split = layout.split()
+        split.prop(light, "environment_ior", text="IOR")
+
 
 class WORLD_PT_indirect_lighting(WorldButtonsPanel, Panel):
     bl_label = "Indirect Lighting"

--- a/source/blender/makesdna/DNA_world_types.h
+++ b/source/blender/makesdna/DNA_world_types.h
@@ -104,10 +104,11 @@ typedef struct World {
 	
 	/* ambient occlusion */
 	float aodist, aodistfac, aoenergy, aobias;
+	float ao_refrratio, ao_ior, ao_fresnel, ao_pad2;
 	short aomode, aosamp, aomix, aocolor;
 	float ao_adapt_thresh, ao_adapt_speed_fac;
 	float ao_approx_error, ao_approx_correction;
-	float ao_indirect_energy, ao_env_energy, ao_pad2;
+	float ao_indirect_energy, ao_env_energy, ao_lodbias;
 	short ao_indirect_bounces, ao_pad;
 	short ao_samp_method, ao_gather_method, ao_approx_passes;
 	

--- a/source/blender/makesrna/intern/rna_world.c
+++ b/source/blender/makesrna/intern/rna_world.c
@@ -283,6 +283,30 @@ static void rna_def_lighting(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Environment Color", "Defines where the color of the environment light comes from");
 	RNA_def_property_update(prop, 0, "rna_World_draw_update");
 
+	prop = RNA_def_property(srna, "environment_lodbias", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "ao_lodbias");
+	RNA_def_property_ui_range(prop, -FLT_MAX, FLT_MAX, 1, 3);
+	RNA_def_property_ui_text(prop, "Environment Texture LodBias", "Defines the Environment light blur effect");
+	RNA_def_property_update(prop, 0, "rna_World_draw_update");
+
+	prop = RNA_def_property(srna, "environment_refr_ratio", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "ao_refrratio");
+	RNA_def_property_ui_range(prop, 0.0, 1.0, 1, 3);
+	RNA_def_property_ui_text(prop, "Environment Texture Refraction Ratio", "Defines the Environment reflection/refraction ratio");
+	RNA_def_property_update(prop, 0, "rna_World_draw_update");
+
+	prop = RNA_def_property(srna, "environment_ior", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "ao_ior");
+	RNA_def_property_ui_range(prop, 1.0, 50.0, 1, 3);
+	RNA_def_property_ui_text(prop, "Environment Texture Indice of refraction", "Defines the Environment indice of refraction");
+	RNA_def_property_update(prop, 0, "rna_World_draw_update");
+
+	prop = RNA_def_property(srna, "environment_fresnel", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "ao_fresnel");
+	RNA_def_property_ui_range(prop, FLT_MIN, FLT_MAX, 1, 3);
+	RNA_def_property_ui_text(prop, "Environment Texture Fresnel", "Defines the Environment Fresnel");
+	RNA_def_property_update(prop, 0, "rna_World_draw_update");
+
 	/* indirect lighting */
 	prop = RNA_def_property(srna, "use_indirect_light", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "mode", WO_INDIRECT_LIGHT);


### PR DESCRIPTION
TODO:

- Split shader in several shaders (do as for normal cubemaps with IOR and mixratio)
- Add an option to map reflection according ti view position instead of
  view normal (why? Because if we have a worldtex that represents a room,
  the objects must reflect the context room according to their view
  position because the room is near, whereas if we have a distant sky, the
  mapping must be done according to view normal)