### PR TITLE
UPBGE: Fix replication of armature constraint objects.

### DIFF
--- a/source/gameengine/Converter/BL_ArmatureConstraint.h
+++ b/source/gameengine/Converter/BL_ArmatureConstraint.h
@@ -58,10 +58,6 @@ private:
 	KX_GameObject*  m_subtarget;
 	struct Object*	m_blendtarget;
 	struct Object*	m_blendsubtarget;
-	float		m_blendmat[4][4];
-	float		m_blendsubmat[4][4];
-	struct bPose*	m_pose;
-	struct bPose*	m_subpose;
 
 public:
 	BL_ArmatureConstraint(class BL_ArmatureObject *armature, 
@@ -72,12 +68,12 @@ public:
 	virtual ~BL_ArmatureConstraint();
 
 	virtual CValue *GetReplica();
+	void CopyBlenderTargets();
 	void ReParent(BL_ArmatureObject* armature);
 	void Relink(std::map<void *, void *>& map);
 	bool UnlinkObject(SCA_IObject* clientobj);
 
 	void UpdateTarget();
-	void RestoreTarget();
 
 	bool Match(const std::string& posechannel, const std::string& constraint);
 	virtual std::string GetName() { return m_name; }

--- a/source/gameengine/Converter/BL_ArmatureObject.cpp
+++ b/source/gameengine/Converter/BL_ArmatureObject.cpp
@@ -275,6 +275,7 @@ void BL_ArmatureObject::LoadConstraints(KX_BlenderSceneConverter *converter)
 				case CONSTRAINT_TYPE_TRANSFORM:
 				case CONSTRAINT_TYPE_DISTLIMIT:
 				case CONSTRAINT_TYPE_TRANSLIKE:
+				{
 					const bConstraintTypeInfo *cti = BKE_constraint_typeinfo_get(pcon);
 					KX_GameObject *gametarget = nullptr;
 					KX_GameObject *gamesubtarget = nullptr;
@@ -302,6 +303,7 @@ void BL_ArmatureObject::LoadConstraints(KX_BlenderSceneConverter *converter)
 					}
 					BL_ArmatureConstraint* constraint = new BL_ArmatureConstraint(this, pchan, pcon, gametarget, gamesubtarget);
 					m_controlledConstraints->Add(constraint);
+				}
 			}
 		}
 	}
@@ -448,15 +450,9 @@ void BL_ArmatureObject::ApplyPose()
 		}
 		// update ourself
 		UpdateBlenderObjectMatrix(m_objArma);
-		BKE_pose_where_is(m_scene, m_objArma); // XXX
+		BKE_pose_where_is(m_scene, m_objArma);
 		// restore ourself
 		memcpy(m_objArma->obmat, m_obmat, sizeof(m_obmat));
-		// restore active targets
-		for (CListValue::iterator<BL_ArmatureConstraint> it = m_controlledConstraints->GetBegin(), end = m_controlledConstraints->GetEnd();
-			 it != end; ++it)
-		{
-			(*it)->RestoreTarget();
-		}
 		m_lastapplyframe = m_lastframe;
 	}
 }


### PR DESCRIPTION
The object used for the armature constraint are blender objects, but previously
when an armature were replicated the blender objects wasn't, so the solve of
the constraints was wrong.

To solve this issue we need to use a new blender object, instead of replicating
the original blender object targeted, we simply use a dummy object which is
an enpty blender object created by each BL_ArmatureConstraint, this object is
set to the constraints calling flush_constraint_targets with no_copy to 0.

For constraint targeting an other armature bone, the pose is set into the blender
object in BL_ArmatureConstraint::UpdateTarget.

These object are then freed at the BL_ArmatureContraint desctruction with a pose
set to nullptr to avoid free a not owned armature pose.


@youle31, @lordloki, @DCubix : Could you please test this branch with any file using an armature with a bone constraint and review this branch too ?