### PR TITLE
UPBGE: Apply modifiers at game start for rendering part to avoid slow rendering

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1076,7 +1076,7 @@ static KX_GameObject *gameobject_from_blenderobject(
 		bool bHasArmature = (BL_ModifierDeformer::HasArmatureDeformer(ob) && ob->parent && ob->parent->type == OB_ARMATURE && bHasDvert);
 
 		/* Since we apply modifiers at game engine start, we set bHasModifier to false by default */
-		bool bHasModifier = false; //BL_ModifierDeformer::HasCompatibleDeformer(ob);
+		bool bHasModifier = bHasArmature ? BL_ModifierDeformer::HasCompatibleDeformer(ob) : false;
 
 #ifdef WITH_BULLET
 		bool bHasSoftBody = (!ob->parent && (ob->gameflag & OB_SOFT_BODY));

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -484,9 +484,15 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	RAS_MeshObject *meshobj;
 	int lightlayer = blenderobj ? blenderobj->lay:(1<<20)-1; // all layers if no object.
 
+	const bool hasModifier = blenderobj->modifiers.first;
+
 	// Without checking names, we get some reuse we don't want that can cause
 	// problems with material LoDs.
-	if (blenderobj && ((meshobj = converter->FindGameMesh(mesh/*, ob->lay*/)) != nullptr)) {
+	/* For Objects with modifiers, as we apply modifiers at game start, we skip this part
+	 * because we need an unique mesh for objects with modifiers.
+	 * So we add && !hasModifier to check that the object has no modifier.
+	 */
+	if (blenderobj && ((meshobj = converter->FindGameMesh(mesh/*, ob->lay*/)) != nullptr) && !hasModifier) {
 		const std::string bge_name = meshobj->GetName();
 		const std::string blender_name = ((ID *)blenderobj->data)->name + 2;
 		if (bge_name == blender_name) {
@@ -495,7 +501,8 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	}
 
 	// Get DerivedMesh data
-	DerivedMesh *dm = CDDM_from_mesh(mesh);
+	DerivedMesh *dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), blenderobj, NULL, CD_MASK_MESH);
+
 	DM_ensure_tessface(dm);
 
 	MVert *mvert = dm->getVertArray(dm);
@@ -566,7 +573,13 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 		}
 	}
 
-	meshobj = new RAS_MeshObject(mesh, layersInfo);
+	std::string name = mesh->id.name + 2;
+	if (hasModifier) {
+		name += ":";
+		name += blenderobj->id.name + 2;
+	}
+
+	meshobj = new RAS_MeshObject(mesh, name, layersInfo);
 
 	meshobj->m_sharedvertex_map.resize(totvert);
 
@@ -744,7 +757,8 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 
 	dm->release(dm);
 
-	converter->RegisterGameMesh(scene, meshobj, mesh);
+	// We avoid linking a mesh object using modifier to the blender mesh.
+	converter->RegisterGameMesh(scene, meshobj, hasModifier ? nullptr : mesh);
 	return meshobj;
 }
 
@@ -996,7 +1010,7 @@ static KX_GameObject *gameobject_from_blenderobject(
 {
 	KX_GameObject *gameobj = nullptr;
 	Scene *blenderscene = kxscene->GetBlenderScene();
-	
+
 	switch (ob->type) {
 	case OB_LAMP:
 	{
@@ -1060,13 +1074,16 @@ static KX_GameObject *gameobject_from_blenderobject(
 		bool bHasShapeKey = mesh->key != nullptr && mesh->key->type==KEY_RELATIVE;
 		bool bHasDvert = mesh->dvert != nullptr && ob->defbase.first;
 		bool bHasArmature = (BL_ModifierDeformer::HasArmatureDeformer(ob) && ob->parent && ob->parent->type == OB_ARMATURE && bHasDvert);
-		bool bHasModifier = BL_ModifierDeformer::HasCompatibleDeformer(ob);
+
+		/* Since we apply modifiers at game engine start, we set bHasModifier to false by default */
+		bool bHasModifier = false; //BL_ModifierDeformer::HasCompatibleDeformer(ob);
+
 #ifdef WITH_BULLET
 		bool bHasSoftBody = (!ob->parent && (ob->gameflag & OB_SOFT_BODY));
 #endif
 
 		RAS_Deformer *deformer = nullptr;
-		BL_DeformableGameObject *deformableGameObj = (BL_DeformableGameObject *)gameobj;
+		BL_DeformableGameObject *deformableGameObj = static_cast<BL_DeformableGameObject *>(gameobj);
 
 		if (bHasModifier) {
 			deformer = new BL_ModifierDeformer(deformableGameObj, kxscene->GetBlenderScene(), ob, meshobj);
@@ -1090,9 +1107,7 @@ static KX_GameObject *gameobject_from_blenderobject(
 		}
 #endif
 
-		if (deformer) {
-			deformableGameObj->SetDeformer(deformer);
-		}
+		deformableGameObj->SetDeformer(deformer);
 		break;
 	}
 	

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1048,9 +1048,21 @@ static KX_GameObject *gameobject_from_blenderobject(
 	{
 		Mesh* mesh = static_cast<Mesh*>(ob->data);
 		RAS_MeshObject* meshobj = BL_ConvertMesh(mesh,ob,kxscene,converter, libloading);
+
+		/* We need unique mesh name for objects with modifiers applied in render code (RAS_MeshObject)
+		 * but for logic we can/have to keep the original mesh name to avoid backward compatibility issues
+		 * (See commit related to modifiers applied at game engine start)
+		 */
+		std::string meshName;
+		if (ob && meshobj->GetName().find(":" + std::string(ob->id.name + 2))) {
+			meshName = meshobj->GetName().substr(0, meshobj->GetName().size() - (std::string(ob->id.name + 2).size() + 1));
+		}
+		else {
+			meshName = meshobj->GetName();
+		}
 		
 		// needed for python scripting
-		kxscene->GetLogicManager()->RegisterMeshName(meshobj->GetName(),meshobj);
+		kxscene->GetLogicManager()->RegisterMeshName(meshName, meshobj);
 
 		if (ob->gameflag & OB_NAVMESH)
 		{

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1016,7 +1016,7 @@ static KX_GameObject *gameobject_from_blenderobject(
 {
 	KX_GameObject *gameobj = nullptr;
 	Scene *blenderscene = kxscene->GetBlenderScene();
-
+	
 	switch (ob->type) {
 	case OB_LAMP:
 	{

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -484,7 +484,7 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	RAS_MeshObject *meshobj;
 	int lightlayer = blenderobj ? blenderobj->lay:(1<<20)-1; // all layers if no object.
 
-	const bool hasModifier = blenderobj->modifiers.first;
+	const bool hasModifier = blenderobj ? blenderobj->modifiers.first : false;
 
 	// Without checking names, we get some reuse we don't want that can cause
 	// problems with material LoDs.
@@ -501,7 +501,13 @@ RAS_MeshObject* BL_ConvertMesh(Mesh* mesh, Object* blenderobj, KX_Scene* scene, 
 	}
 
 	// Get DerivedMesh data
-	DerivedMesh *dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), blenderobj, NULL, CD_MASK_MESH);
+	DerivedMesh *dm;
+	if (blenderobj) {
+		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), blenderobj, NULL, CD_MASK_MESH);
+	}
+	else {
+		dm = CDDM_from_mesh(mesh);
+	}
 
 	DM_ensure_tessface(dm);
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1814,9 +1814,14 @@ bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm,
 		/* Before we applied modifiers at game engine start, the function used
 		 * was dm = CDDM_from_mesh(meshobj->GetMesh()); but this generated crashes
 		 * with some modifiers. So we use the same function as in BlenderDataConversion
-		 * when we convert the mesh for rendering here.
+		 * when we convert the mesh for rendering here... if we have the possibility to use it
 		 */
-		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
+		if (gameobj && gameobj->GetBlenderObject()) {
+			dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
+		}
+		else {
+			dm = CDDM_from_mesh(meshobj->GetMesh());
+		}
 	}
 
 	// Some meshes with modifiers returns 0 polys, call DM_ensure_tessface avoid this.

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1788,7 +1788,7 @@ void CcdShapeConstructionInfo::ProcessReplica()
 	m_shapeArray.clear();
 }
 
-bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm, bool polytope)
+bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope)
 {
 	int numpolys, numverts;
 
@@ -1810,7 +1810,13 @@ bool CcdShapeConstructionInfo::SetMesh(RAS_MeshObject *meshobj, DerivedMesh *dm,
 
 	if (!dm) {
 		free_dm = true;
-		dm = CDDM_from_mesh(meshobj->GetMesh());
+
+		/* Before we applied modifiers at game engine start, the function used
+		 * was dm = CDDM_from_mesh(meshobj->GetMesh()); but this generated crashes
+		 * with some modifiers. So we use the same function as in BlenderDataConversion
+		 * when we convert the mesh for rendering here.
+		 */
+		dm = mesh_create_derived_no_virtual(scene->GetBlenderScene(), gameobj->GetBlenderObject(), NULL, CD_MASK_MESH);
 	}
 
 	// Some meshes with modifiers returns 0 polys, call DM_ensure_tessface avoid this.

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -44,6 +44,7 @@ class btMotionState;
 class RAS_MeshObject;
 struct DerivedMesh;
 class btCollisionShape;
+class KX_Scene;
 
 #define CCD_BSB_SHAPE_MATCHING  2
 #define CCD_BSB_BENDING_CONSTRAINTS 8
@@ -153,7 +154,7 @@ public:
 		return true;
 	}
 
-	bool SetMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, bool polytope);
+	bool SetMesh(class RAS_MeshObject *mesh, struct DerivedMesh *dm, KX_Scene *scene, KX_GameObject *gameobj, bool polytope);
 	RAS_MeshObject *GetMesh(void)
 	{
 		return m_meshObject;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -3143,7 +3143,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 		}
 		case OB_BOUND_CONVEX_HULL:
 		{
-			shapeInfo->SetMesh(meshobj, dm, true);
+			shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, true);
 			bm = shapeInfo->CreateBulletShape(ci.m_margin);
 			break;
 		}
@@ -3167,7 +3167,7 @@ void CcdPhysicsEnvironment::ConvertObject(KX_GameObject *gameobj, RAS_MeshObject
 				shapeInfo->AddRef();
 			}
 			else {
-				shapeInfo->SetMesh(meshobj, dm, false);
+				shapeInfo->SetMesh(meshobj, dm, kxscene, gameobj, false);
 			}
 
 			// Soft bodies can benefit from welding, don't do it on non-soft bodies

--- a/source/gameengine/Rasterizer/RAS_MeshObject.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.cpp
@@ -100,8 +100,8 @@ struct RAS_MeshObject::fronttoback
 
 // mesh object
 
-RAS_MeshObject::RAS_MeshObject(Mesh *mesh, const LayersInfo& layersInfo)
-	:m_name(mesh->id.name + 2),
+RAS_MeshObject::RAS_MeshObject(Mesh *mesh, const std::string& name, const LayersInfo& layersInfo)
+	:m_name(name),
 	m_layersInfo(layersInfo),
 	m_boundingBox(nullptr),
 	m_mesh(mesh)

--- a/source/gameengine/Rasterizer/RAS_MeshObject.h
+++ b/source/gameengine/Rasterizer/RAS_MeshObject.h
@@ -108,7 +108,7 @@ protected:
 
 public:
 	// for now, meshes need to be in a certain layer (to avoid sorting on lights in realtime)
-	RAS_MeshObject(Mesh *mesh, const LayersInfo& layersInfo);
+	RAS_MeshObject(Mesh *mesh, const std::string& name, const LayersInfo& layersInfo);
 	virtual ~RAS_MeshObject();
 
 	// materials


### PR DESCRIPTION
**APPLY MODIFIERS AT GAME START FOR RENDERING PART TO AVOID SLOW RENDERING**

I think:
- It restores the performances as before RAS_ListRasterizer removal
- RAS_ListRasterizer was to render only the meshes without armatures I think
-----------------------------------------------------------------------------------------------
- So the meshes with an armature parent are rendered with the viewport code, as in BF.
- The meshes without armature but with modifiers are rendered with RAS_VBO.cpp.
-----
- All modifiers available in embedded will be available in standalone.
-----------------------------------------------------------------------------------------------

**Issues:**
- Problem with objects with modifiers and multiple mesh users: **Fixed**
- Problem with modifier Armature + modifier subsurf: http://pasteall.org/blend/index.php?id=45877: **Fixed**
- Dark_War: with libload (iirc the game shared by joel gomes in the issue related to libfree) (crash at start): **Fixed**
- The file BPR doesn't want we share (the head doesn't move... issue with constraints?): **Fixed**

**Test files:**
- For issue with armature + subsurf modifier: http://pasteall.org/blend/index.php?id=45896
- For issue with BPR file, I can't share it here because he doesn't want we share it on the net but panzergame and me have it. The issue was related to mesh name in the logicmanager. I kept same name as before this patch in the logicmanager and for KX_MeshProxy, but another name for RAS_MeshObject (the mesh rendered).
- For issue with multiple mesh users: http://pasteall.org/blend/index.php?id=45897 (By the way you can test physics behaviour in this file). The original issue was that when we have an object with modifiers, if it has a mesh shared by several objects in viewport, at runtime we have to make the ras mesh unique for the rendering part. See commit message in old branch.
- For libload issue, see bge_dw test file here: https://github.com/UPBGE/blender/issues/382 (Fixed by adding a check for null blenderobj in BL_ConvertMesh.

**Performances:**
- Modifiers not applied: https://drive.google.com/file/d/0B3GouQIyoCmrRXRYY21PNVB2LVE/view?usp=sharing
- Modifiers applied: https://drive.google.com/file/d/0B3GouQIyoCmrdm40TU1pT1p5R00/view?usp=sharing

**Historic:**
- https://github.com/UPBGE/blender/pull/361
- https://github.com/UPBGE/blender/tree/ge_nomodifier

**Note:**
In this patch I didn't included patch for physics DerivedMeshes removal made by panzergame because I had issues with this commit and I didn't noticed slowdowns for Physics DerivedMeshes (the performance leak comes only from the rendering part as far I saw).