### PR TITLE
UPBGE: Shadow Culling and Debug Light Frustum

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -790,6 +790,8 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         col.prop(lamp, "shadow_color", text="")
         if lamp.type == 'SUN':
             col.prop(lamp, "show_shadow_box")
+        if lamp.type in ('SUN', 'SPOT'):
+            col.prop(lamp, "show_shadow_box_bge")
         col.prop(lamp, "static_shadow")
 
         col = split.column()

--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -355,6 +355,8 @@ void GPU_lamp_shadow_buffer_unbind(GPULamp *lamp);
 int GPU_lamp_shadow_buffer_type(GPULamp *lamp);
 int GPU_lamp_shadow_bind_code(GPULamp *lamp);
 float *GPU_lamp_dynpersmat(GPULamp *lamp);
+float *GPU_lamp_get_viewmat(GPULamp *lamp);
+float *GPU_lamp_get_winmat(GPULamp *lamp);
 
 void GPU_lamp_update(GPULamp *lamp, int lay, int hide, float obmat[4][4]);
 void GPU_lamp_update_colors(GPULamp *lamp, float r, float g, float b, float energy);

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -2795,6 +2795,16 @@ float *GPU_lamp_dynpersmat(GPULamp *lamp)
 	return &lamp->dynpersmat[0][0];
 }
 
+float *GPU_lamp_get_viewmat(GPULamp *lamp)
+{
+	return &lamp->viewmat[0][0];
+}
+
+float *GPU_lamp_get_winmat(GPULamp *lamp)
+{
+	return &lamp->winmat[0][0];
+}
+
 int GPU_lamp_shadow_layer(GPULamp *lamp)
 {
 	if (lamp->fb && lamp->tex && (lamp->mode & (LA_LAYER | LA_LAYER_SHADOW)))

--- a/source/blender/makesdna/DNA_lamp_types.h
+++ b/source/blender/makesdna/DNA_lamp_types.h
@@ -154,6 +154,7 @@ typedef struct Lamp {
 #define LA_SHOW_CONE    (1 << 17)
 #define LA_SHOW_SHADOW_BOX (1 << 18)
 #define LA_STATIC_SHADOW (1 << 19)
+#define LA_SHOW_SHADOW_BOX_BGE (1 << 20)
 
 /* shadow_filter */
 #define LA_SHADOW_FILTER_NONE		0

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -719,6 +719,12 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	RNA_def_property_boolean_sdna(prop, NULL, "mode", LA_LAYER_SHADOW);
 	RNA_def_property_ui_text(prop, "Shadow Layer", "Objects on the same layers only cast shadows");
 	RNA_def_property_update(prop, 0, "rna_Lamp_update");
+
+	prop = RNA_def_property(srna, "show_shadow_box_bge", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "mode", LA_SHOW_SHADOW_BOX_BGE);
+	RNA_def_property_ui_text(prop, "Show Shadow Box in BGE",
+		"Draw a box in 3D view to visualize which objects are contained in it");
+	RNA_def_property_update(prop, 0, "rna_Lamp_draw_update");
 }
 
 static void rna_def_point_lamp(BlenderRNA *brna)

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -948,6 +948,7 @@ static KX_LightObject *gamelight_from_blamp(Object *ob, Lamp *la, unsigned int l
 	lightobj->m_spotblend = la->spotblend;
 	lightobj->m_spotsize = la->spotsize;
 	lightobj->m_staticShadow = la->mode & LA_STATIC_SHADOW;
+	lightobj->m_showLightDebugFrustum = (la->mode & LA_SHOW_SHADOW_BOX_BGE) != 0;
 	// Set to true to make at least one shadow render in static mode.
 	lightobj->m_requestShadowUpdate = true;
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -949,6 +949,7 @@ static KX_LightObject *gamelight_from_blamp(Object *ob, Lamp *la, unsigned int l
 	lightobj->m_spotsize = la->spotsize;
 	lightobj->m_staticShadow = la->mode & LA_STATIC_SHADOW;
 	lightobj->m_showLightDebugFrustum = (la->mode & LA_SHOW_SHADOW_BOX_BGE) != 0;
+	lightobj->m_isIntersecting = true;
 	// Set to true to make at least one shadow render in static mode.
 	lightobj->m_requestShadowUpdate = true;
 

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -98,6 +98,7 @@ protected:
 	 * View Frustum clip planes.
 	 */
 	MT_Vector4   m_planes[6];
+	MT_Vector3   m_corners[8];
 	
 	/**
 	 * This camera is frustum culling.
@@ -135,6 +136,8 @@ protected:
 	 * Extracts the camera clip frames from the projection and world-to-camera matrices.
 	 */
 	void ExtractClipPlanes();
+
+	void SetFrustumCorners();
 	/**
 	 * Normalize the camera clip frames.
 	 */
@@ -159,6 +162,8 @@ public:
 
 	KX_Camera(void* sgReplicationInfo,SG_Callbacks callbacks,const RAS_CameraData& camdata, bool frustum_culling = true, bool delete_node = false);
 	virtual ~KX_Camera();
+
+	bool ShadowFrustumInsideFrustum(MT_Vector4 *lightplanes, MT_Vector3 *lightcorners);
 	
 	/** 
 	 * Inherited from CValue -- return a new copy of this

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -52,6 +52,7 @@ class CListValue;
 class RAS_ICanvas;
 class RAS_OffScreen;
 class RAS_IRasterizer;
+class RAS_ILightObject;
 class SCA_IInputDevice;
 
 #define LEFT_EYE  1
@@ -150,6 +151,8 @@ private:
 	int m_exitcode;
 	std::string m_exitstring;
 
+	std::vector<KX_Camera *>m_activeCameras;
+
 	float m_cameraZoom;
 
 	bool m_overrideCam;
@@ -233,6 +236,13 @@ private:
 	void RenderDebugProperties();
 	/// Debug draw cameras frustum of a scene.
 	void DrawDebugCameraFrustum(KX_Scene *scene, RAS_DebugDraw& debugDraw, const RAS_Rect& viewport, const RAS_Rect& area);
+	/// Debug draw lights frustum of a scene.
+	void DrawDebugLightFrustum(KX_Scene *scene, RAS_DebugDraw& debugDraw, RAS_ILightObject *raslight);
+
+	/* Check intersection of custom light shadow
+	 * frustum with scene active cameras
+	 */
+	bool CheckLightAndCamerasFrustumIntersection(RAS_ILightObject *raslight);
 
 public:
 	KX_KetsjiEngine(KX_ISystem *system);
@@ -313,6 +323,8 @@ public:
 	float GetCameraZoom(KX_Camera *camera) const;
 
 	void EnableCameraOverride(const std::string& forscene, const MT_CmMatrix4x4& projmat, const MT_CmMatrix4x4& viewmat, const RAS_CameraData& camdata);
+
+	std::vector<KX_Camera *> GetActiveCameras();
 
 	// Update animations for object in this scene
 	void UpdateAnimations(KX_Scene *scene);

--- a/source/gameengine/Rasterizer/RAS_DebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_DebugDraw.cpp
@@ -115,7 +115,7 @@ void RAS_DebugDraw::DrawSolidBox(const std::array<MT_Vector3, 8>& vertices, cons
 	m_solidBoxes.emplace_back(insideColor, outsideColor, vertices, lineColor);
 }
 
-void RAS_DebugDraw::DrawCameraFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat)
+void RAS_DebugDraw::DrawFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat, const MT_Vector4& color)
 {
 	std::array<MT_Vector3, 8> box;
 
@@ -133,7 +133,7 @@ void RAS_DebugDraw::DrawCameraFrustum(const MT_Matrix4x4& projmat, const MT_Matr
 		p3 = MT_Vector3(p4.x() / p4.w(), p4.y() / p4.w(), p4.z() / p4.w());
 	}
 
-	DrawSolidBox(box, MT_Vector4(0.4f, 0.4f, 0.4f, 0.4f), MT_Vector4(0.0f, 0.0f, 0.0f, 0.4f),
+	DrawSolidBox(box, color, MT_Vector4(0.0f, 0.0f, 0.0f, 0.4f),
 		MT_Vector4(0.8f, 0.5f, 0.0f, 1.0f));
 }
 

--- a/source/gameengine/Rasterizer/RAS_DebugDraw.h
+++ b/source/gameengine/Rasterizer/RAS_DebugDraw.h
@@ -137,7 +137,7 @@ public:
 	 * \param projmat The camera projection matrix.
 	 * \param viewmat The camera view matrix.
 	 */
-	void DrawCameraFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat);
+	void DrawFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat, const MT_Vector4& color = MT_Vector4(0.2f, 0.2f, 0.2f, 1.0f));
 
 	void RenderBox2D(const MT_Vector2& pos, const MT_Vector2& size, const MT_Vector4& color);
 

--- a/source/gameengine/Rasterizer/RAS_DebugDraw.h
+++ b/source/gameengine/Rasterizer/RAS_DebugDraw.h
@@ -137,7 +137,7 @@ public:
 	 * \param projmat The camera projection matrix.
 	 * \param viewmat The camera view matrix.
 	 */
-	void DrawFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat, const MT_Vector4& color = MT_Vector4(0.2f, 0.2f, 0.2f, 1.0f));
+	void DrawFrustum(const MT_Matrix4x4& projmat, const MT_Matrix4x4& viewmat, const MT_Vector4& color = MT_Vector4(0.2f, 0.2f, 0.2f, 0.4f));
 
 	void RenderBox2D(const MT_Vector2& pos, const MT_Vector2& size, const MT_Vector4& color);
 

--- a/source/gameengine/Rasterizer/RAS_ILightObject.h
+++ b/source/gameengine/Rasterizer/RAS_ILightObject.h
@@ -32,6 +32,9 @@
 #ifndef __RAS_LIGHTOBJECT_H__
 #define __RAS_LIGHTOBJECT_H__
 
+#include "MT_Vector4.h"
+#include "MT_Vector3.h"
+
 class RAS_ICanvas;
 
 class KX_Camera;
@@ -65,6 +68,11 @@ public:
 	float	m_shadowbleedbias;
 	short	m_shadowmaptype;
 	float	m_shadowcolor[3];
+	bool	m_showLightDebugFrustum;
+
+	MT_Vector4   m_planes[6];
+	MT_Vector3   m_corners[8];
+	bool         m_isIntersecting;
 
 	float	m_color[3];
 
@@ -89,6 +97,12 @@ public:
 	virtual bool NeedShadowUpdate() = 0;
 	virtual int GetShadowBindCode() = 0;
 	virtual MT_Matrix4x4 GetShadowMatrix() = 0;
+	virtual MT_Vector4 *GetFrustumPlanes() = 0;
+	virtual void SetFrustumPlanes() = 0;
+	virtual MT_Vector3 *GetFrustumCorners() = 0;
+	virtual void SetFrustumCorners() = 0;
+	virtual MT_Matrix4x4 GetViewMat() = 0;
+	virtual MT_Matrix4x4 GetWinMat() = 0;
 	virtual int GetShadowLayer() = 0;
 	virtual void BindShadowBuffer(RAS_ICanvas *canvas, KX_Camera *cam, MT_Transform& camtrans) = 0;
 	virtual void UnbindShadowBuffer() = 0;

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
@@ -189,6 +189,24 @@ int RAS_OpenGLLight::GetShadowBindCode()
 	return -1;
 }
 
+MT_Matrix4x4 RAS_OpenGLLight::GetViewMat()
+{
+	GPULamp *lamp = GetGPULamp();
+	if (lamp) {
+		return MT_Matrix4x4(GPU_lamp_get_viewmat(lamp));
+	}
+	return MT_Matrix4x4::Identity();
+}
+
+MT_Matrix4x4 RAS_OpenGLLight::GetWinMat()
+{
+	GPULamp *lamp = GetGPULamp();
+	if (lamp) {
+		return MT_Matrix4x4(GPU_lamp_get_winmat(lamp));
+	}
+	return MT_Matrix4x4::Identity();
+}
+
 MT_Matrix4x4 RAS_OpenGLLight::GetShadowMatrix()
 {
 	GPULamp *lamp;
@@ -198,6 +216,62 @@ MT_Matrix4x4 RAS_OpenGLLight::GetShadowMatrix()
 	MT_Matrix4x4 mat;
 	mat.setIdentity();
 	return mat;
+}
+
+MT_Vector4 *RAS_OpenGLLight::GetFrustumPlanes()
+{
+	return m_planes;
+}
+
+void RAS_OpenGLLight::SetFrustumPlanes()
+{
+	GPULamp *lamp;
+
+	if ((lamp = GetGPULamp())) {
+		const MT_Matrix4x4 viewmat = GetViewMat();
+		const MT_Matrix4x4 projmat = GetWinMat();
+		const MT_Matrix4x4 m = projmat * viewmat;
+		// Left clip plane
+		m_planes[0] = m[3] + m[0];
+		// Right clip plane
+		m_planes[1] = m[3] - m[0];
+		// Top clip plane
+		m_planes[2] = m[3] - m[1];
+		// Bottom clip plane
+		m_planes[3] = m[3] + m[1];
+		// Near clip plane
+		m_planes[4] = m[3] + m[2];
+		// Far clip plane
+		m_planes[5] = m[3] - m[2];
+	}
+}
+
+MT_Vector3 *RAS_OpenGLLight::GetFrustumCorners()
+{
+	return m_corners;
+}
+
+void RAS_OpenGLLight::SetFrustumCorners()
+{
+	GPULamp *lamp;
+
+	if ((lamp = GetGPULamp())) {
+		const MT_Matrix4x4 viewmat = GetViewMat();
+		const MT_Matrix4x4 projmat = GetWinMat();
+		const MT_Matrix4x4 m = (projmat * viewmat).inverse();
+		m_corners[0][0] = m_corners[1][0] = m_corners[4][0] = m_corners[5][0] = -1.0f;
+		m_corners[2][0] = m_corners[3][0] = m_corners[6][0] = m_corners[7][0] = 1.0f;
+		m_corners[0][1] = m_corners[3][1] = m_corners[4][1] = m_corners[7][1] = -1.0f;
+		m_corners[1][1] = m_corners[2][1] = m_corners[5][1] = m_corners[6][1] = 1.0f;
+		m_corners[0][2] = m_corners[1][2] = m_corners[2][2] = m_corners[3][2] = -1.0f;
+		m_corners[4][2] = m_corners[5][2] = m_corners[6][2] = m_corners[7][2] = 1.0f;
+
+		for (unsigned short i = 0; i < 8; i++) {
+			MT_Vector3& p3 = m_corners[i];
+			const MT_Vector4 p4 = m * MT_Vector4(p3.x(), p3.y(), p3.z(), 1.0f);
+			p3 = MT_Vector3(p4.x() / p4.w(), p4.y() / p4.w(), p4.z() / p4.w());
+		}
+	}
 }
 
 int RAS_OpenGLLight::GetShadowLayer()

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.h
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.h
@@ -52,7 +52,13 @@ public:
 	bool HasShadowBuffer();
 	bool NeedShadowUpdate();
 	int GetShadowBindCode();
+	MT_Matrix4x4 GetViewMat();
+	MT_Matrix4x4 GetWinMat();
 	MT_Matrix4x4 GetShadowMatrix();
+	MT_Vector4 *GetFrustumPlanes();
+	void SetFrustumPlanes();
+	MT_Vector3 *GetFrustumCorners();
+	void SetFrustumCorners();
 	int GetShadowLayer();
 	void BindShadowBuffer(RAS_ICanvas *canvas, KX_Camera *cam, MT_Transform& camtrans);
 	void UnbindShadowBuffer();

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -921,6 +921,7 @@ ImageRender::ImageRender (KX_Scene *scene, KX_GameObject *observer, KX_GameObjec
 	m_owncamera = true;
 	// retrieve rendering objects
 	m_engine = KX_GetActiveEngine();
+	m_engine->GetActiveCameras().push_back(m_camera);
 	m_rasterizer = m_engine->GetRasterizer();
 	m_canvas = m_engine->GetCanvas();
 	// locate the vertex assigned to mat and do following calculation in mesh coordinates


### PR DESCRIPTION
*Branch up to date with master 19/03/2017.*
---------------  
- Supports Sun and Spot shapes (in intersection check)
- Use Matrices instead of geometry calculus.
---------------  
- Source: http://www.yosoygames.com.ar/wp/2016/12/frustum-vs-pyramid-intersection-also-frustum-vs-frustum/
---------------
1. Normal test files:  
- Test file: http://pasteall.org/blend/index.php?id=45977 (I animated the light with location keyframes)
- Test file2: http://pasteall.org/blend/index.php?id=45978  
- Culling test in top view: http://pasteall.org/blend/index.php?id=45987
---------------
2. Performances test files: 
- http://pasteall.org/blend/index.php?id=45985 (Each cube is subdivided 5 times (under each spot))
- http://pasteall.org/blend/index.php?id=45988 (Move the camera---Compare with master)
---------------
Pics:  
- Master: http://pasteall.org/pic/show.php?id=113721  
- Shadow Culling ON: http://pasteall.org/pic/show.php?id=113722  (green means the spot frustum is intersecting with camera frustum. I disabled shadow culling for viewport camera (__default_cam_) to have a better visibility when we are in viewport view.)
---------------  
- Maybe the current culling test for geometry rendering is false/wrong/bad (maybe we should have more FPS if we discard false positives in the culling test for geometry like we did for shadows). In the performance test file we could disable physics to have a better test file for normal culling performances.
**EDIT: I tested and didn't noticed differences.**
- If we want to avoid backward compatibility issues, we can add an UI option to disable shadow culling (but I propose to enable it by default on suns and spots)
