### PR TITLE
UPBGE: Branch to test/fix bullet culling

### DIFF
--- a/extern/bullet2/src/BulletCollision/BroadphaseCollision/btDbvt.cpp
+++ b/extern/bullet2/src/BulletCollision/BroadphaseCollision/btDbvt.cpp
@@ -1225,7 +1225,7 @@ void			btDbvt::benchmark()
 			static const btScalar	offset=0;
 			policy.m_nodes.resize(0);
 			policy.m_axis=vectors[i];
-			dbvt.collideKDOP(dbvt.m_root,&vectors[i],&offset,1,policy);
+			dbvt.collideKDOP(dbvt.m_root,&vectors[i],&offset, &corners,1,policy);
 			policy.m_nodes.quickSort(btDbvtBenchmark::P15::sortfnc);
 		}
 		const int	time=(int)wallclock.getTimeMilliseconds();

--- a/extern/bullet2/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/extern/bullet2/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -349,6 +349,7 @@ struct	btDbvt
 		static void		collideKDOP(const btDbvtNode* root,
 		const btVector3* normals,
 		const btScalar* offsets,
+		const btVector3 *corners,
 		int count,
 		DBVT_IPOLICY);
 	DBVT_PREFIX
@@ -1072,10 +1073,24 @@ inline void		btDbvt::rayTest(	const btDbvtNode* root,
 }
 
 //
+static bool PreIntersectionCheck(const btVector3 *corners, const btVector3 &boxmin, const btVector3 &boxmax)
+{
+	int behindcount = 0;
+
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][0] > boxmax[0]) ? 1 : 0); if (behindcount == 8) return true;
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][0] < boxmin[0]) ? 1 : 0); if (behindcount == 8) return true;
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][1] > boxmax[1]) ? 1 : 0); if (behindcount == 8) return true;
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][1] < boxmin[1]) ? 1 : 0); if (behindcount == 8) return true;
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][2] > boxmax[2]) ? 1 : 0); if (behindcount == 8) return true;
+	behindcount = 0; for (int i = 0; i<8; i++) behindcount += ((corners[i][2] < boxmin[2]) ? 1 : 0); if (behindcount == 8) return true;
+	return false;
+}
+
 DBVT_PREFIX
 inline void		btDbvt::collideKDOP(const btDbvtNode* root,
 									const btVector3* normals,
 									const btScalar* offsets,
+									const btVector3 *corners,
 									int count,
 									DBVT_IPOLICY)
 {
@@ -1097,7 +1112,11 @@ inline void		btDbvt::collideKDOP(const btDbvtNode* root,
 			do	{
 				sStkNP	se=stack[stack.size()-1];
 				bool	out=false;
+
 				stack.pop_back();
+
+				out = PreIntersectionCheck(corners, se.node->volume.Mins(), se.node->volume.Maxs());
+
 				for(int i=0,j=1;(!out)&&(i<count);++i,j<<=1)
 				{
 					if(0==(se.mask&j))

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -279,6 +279,28 @@ void KX_Camera::ExtractClipPlanes()
 	m_normalized = false;
 }
 
+MT_Vector3 *KX_Camera::GetFrustumCorners()
+{
+	return m_corners;
+}
+
+void KX_Camera::ExtractFrustumCorners()
+{
+	const MT_Matrix4x4 m = (m_projection_matrix * m_modelview_matrix).inverse();
+	m_corners[0][0] = m_corners[1][0] = m_corners[4][0] = m_corners[5][0] = -1.0f;
+	m_corners[2][0] = m_corners[3][0] = m_corners[6][0] = m_corners[7][0] = 1.0f;
+	m_corners[0][1] = m_corners[3][1] = m_corners[4][1] = m_corners[7][1] = -1.0f;
+	m_corners[1][1] = m_corners[2][1] = m_corners[5][1] = m_corners[6][1] = 1.0f;
+	m_corners[0][2] = m_corners[1][2] = m_corners[2][2] = m_corners[3][2] = -1.0f;
+	m_corners[4][2] = m_corners[5][2] = m_corners[6][2] = m_corners[7][2] = 1.0f;
+	
+	for (unsigned short i = 0; i < 8; i++) {
+		MT_Vector3& p3 = m_corners[i];
+		const MT_Vector4 p4 = m * MT_Vector4(p3.x(), p3.y(), p3.z(), 1.0f);
+		p3 = MT_Vector3(p4.x() / p4.w(), p4.y() / p4.w(), p4.z() / p4.w());
+	}
+}
+
 void KX_Camera::NormalizeClipPlanes()
 {
 	if (m_normalized)

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -98,6 +98,7 @@ protected:
 	 * View Frustum clip planes.
 	 */
 	MT_Vector4   m_planes[6];
+	MT_Vector3 m_corners[8];
 	
 	/**
 	 * This camera is frustum culling.
@@ -159,6 +160,9 @@ public:
 
 	KX_Camera(void* sgReplicationInfo,SG_Callbacks callbacks,const RAS_CameraData& camdata, bool frustum_culling = true, bool delete_node = false);
 	virtual ~KX_Camera();
+
+	void ExtractFrustumCorners();
+	MT_Vector3 *GetFrustumCorners();
 	
 	/** 
 	 * Inherited from CValue -- return a new copy of this

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -996,7 +996,23 @@ void KX_KetsjiEngine::RenderFrame(KX_Scene *scene, KX_Camera *cam, RAS_OffScreen
 	m_logger.StartLog(tc_scenegraph, m_kxsystem->GetTimeInSeconds(), true);
 	SG_SetActiveStage(SG_STAGE_CULLING);
 
-	scene->CalculateVisibleMeshes(m_rasterizer, cam);
+	CListValue *camList = scene->GetCameraList();
+	KX_Camera *debugCam;
+	for (CListValue::iterator<KX_Camera> it = camList->GetBegin(), camend = camList->GetEnd(); it != camend; ++it) {
+		KX_Camera *currentCam = *it;
+		if (currentCam->GetName() == "Camera") {
+			debugCam = currentCam;
+			debugCam->SetModelviewMatrix(MT_Matrix4x4(debugCam->GetWorldToCamera()));
+			debugCam->NodeUpdateGS(0.0);
+			break;
+		}
+		else {
+			debugCam = cam;
+		}
+	}
+	scene->CalculateVisibleMeshes(m_rasterizer, debugCam);
+	//scene->CalculateVisibleMeshes(m_rasterizer, cam);
+
 
 	// update levels of detail
 	scene->UpdateObjectLods(cam);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1432,6 +1432,7 @@ void KX_Scene::CalculateVisibleMeshes(RAS_Rasterizer* rasty,KX_Camera* cam, int 
 			gameobj->SetCulled(true);
 		}
 
+		cam->ExtractFrustumCorners();
 		// test culling through Bullet
 		// get the clip planes
 		const MT_Vector4* cplanes = cam->GetNormalizedClipPlanes();
@@ -1445,7 +1446,7 @@ void KX_Scene::CalculateVisibleMeshes(RAS_Rasterizer* rasty,KX_Camera* cam, int 
 		float pmat[16] = {0.0f};
 		cam->GetProjectionMatrix().getValue(pmat);
 
-		dbvt_culling = m_physicsEnvironment->CullingTest(PhysicsCullingCallback,&info,planes,6,m_dbvt_occlusion_res,
+		dbvt_culling = m_physicsEnvironment->CullingTest(PhysicsCullingCallback,&info,planes, cam->GetFrustumCorners(), 6,m_dbvt_occlusion_res,
 		                                                 KX_GetActiveEngine()->GetCanvas()->GetViewPort(),
 		                                                 mvmat, pmat);
 	}
@@ -1465,15 +1466,28 @@ void KX_Scene::DrawDebug(RAS_DebugDraw& debugDraw)
 		for (CListValue::iterator<KX_GameObject> it = m_objectlist->GetBegin(), end = m_objectlist->GetEnd(); it != end; ++it) {
 			KX_GameObject *gameobj = *it;
 
+			if (gameobj->GetMeshCount() != 0) {
+				const MT_Vector3& scale = gameobj->NodeGetWorldScaling();
+				const MT_Vector3& position = gameobj->NodeGetWorldPosition();
+				const MT_Matrix3x3& orientation = gameobj->NodeGetWorldOrientation();
+				const SG_BBox& box = gameobj->GetSGNode()->BBox();
+				const MT_Vector3& center = box.GetCenter();
+				if (gameobj->GetCulled()) {
+					debugDraw.DrawAabb(position, orientation, box.GetMin() * scale, box.GetMax() * scale,
+						MT_Vector4(1.0f, 0.0f, 0.0f, 1.0f));
+				}
+				else {
+					debugDraw.DrawAabb(position, orientation, box.GetMin() * scale, box.GetMax() * scale,
+						MT_Vector4(0.0f, 1.0f, 0.0f, 1.0f));
+				}
+			}
+
 			if (!gameobj->GetCulled() && gameobj->GetMeshCount() != 0) {
 				const MT_Vector3& scale = gameobj->NodeGetWorldScaling();
 				const MT_Vector3& position = gameobj->NodeGetWorldPosition();
 				const MT_Matrix3x3& orientation = gameobj->NodeGetWorldOrientation();
 				const SG_BBox& box = gameobj->GetSGNode()->BBox();
 				const MT_Vector3& center = box.GetCenter();
-
-				debugDraw.DrawAabb(position, orientation, box.GetMin() * scale, box.GetMax() * scale,
-					MT_Vector4(1.0f, 0.0f, 1.0f, 1.0f));
 
 				// Render center in red, green and blue.
 				debugDraw.DrawLine(orientation * center * scale + position,

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -206,7 +206,7 @@ public:
 	btTypedConstraint *GetConstraintById(int constraintId);
 
 	virtual PHY_IPhysicsController *RayTest(PHY_IRayCastFilterCallback &filterCallback, float fromX, float fromY, float fromZ, float toX, float toY, float toZ);
-	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, MT_Vector4 * planes, int nplanes, int occlusionRes, const int *viewport, float modelview[16], float projection[16]);
+	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, MT_Vector4 * planes, MT_Vector3 *corners, int nplanes, int occlusionRes, const int *viewport, float modelview[16], float projection[16]);
 
 
 	//Methods for gamelogic collision/physics callbacks

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -207,7 +207,7 @@ public:
 	// culling based on physical broad phase
 	// the plane number must be set as follow: near, far, left, right, top, botton
 	// the near plane must be the first one and must always be present, it is used to get the direction of the view
-	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, MT_Vector4 * planeNormals, int planeNumber, int occlusionRes, const int *viewport, float modelview[16], float projection[16]) = 0;
+	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, MT_Vector4 * planeNormals, MT_Vector3 *corners, int planeNumber, int occlusionRes, const int *viewport, float modelview[16], float projection[16]) = 0;
 
 	// Methods for gamelogic collision/physics callbacks
 	virtual void AddSensor(PHY_IPhysicsController *ctrl) = 0;

--- a/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
@@ -81,7 +81,7 @@ public:
 	}
 
 	virtual PHY_IPhysicsController *RayTest(PHY_IRayCastFilterCallback &filterCallback, float fromX, float fromY, float fromZ, float toX, float toY, float toZ);
-	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, class MT_Vector4 *planes, int nplanes, int occlusionRes, const int *viewport, float modelview[16], float projection[16])
+	virtual bool CullingTest(PHY_CullingCallback callback, void *userData, class MT_Vector4 *planes, class MT_Vector3 *corners, int nplanes, int occlusionRes, const int *viewport, float modelview[16], float projection[16])
 	{
 		return false;
 	}


### PR DESCRIPTION
To fix this bug: https://github.com/UPBGE/blender/issues/443

Adds a simple test before bullet culling test to avoid false positives. If you want to restore false positives, just remove out = PreIntersectionCheck(corners, se.node->volume.Mins(), se.node->volume.Maxs()); line 1118 in E:\Compilation\Blender\upbgeSources\extern\bullet2\src\BulletCollision\BroadphaseCollision\btDbvt.h

I add it in pull request just to have a better visibility

test file: http://pasteall.org/blend/index.php?id=46072