### PR TITLE
Implement CListValue name and property regex search.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.CListValue.rst
+++ b/doc/python_api/rst/bge_types/bge.types.CListValue.rst
@@ -45,6 +45,13 @@ base class --- :class:`CPropValue`
 
       :return: The key value or a default.
 
+   .. method:: getMatching(name, prop)
+
+      Return a list of items with name matching `name` regex and with a property matching `prop` regex.
+      If `name` is empty every items are checked, if `prop` is empty no property check is proceeded.
+
+      :return: The list of matching items.
+
    .. method:: from_id(id)
 
       This is a funtion especially for the game engine to return a value with a spesific id.

--- a/source/gameengine/Expressions/EXP_ListValue.h
+++ b/source/gameengine/Expressions/EXP_ListValue.h
@@ -118,6 +118,7 @@ public:
 	KX_PYMETHOD_O(CListValue, index);
 	KX_PYMETHOD_O(CListValue, count);
 	KX_PYMETHOD_VARARGS(CListValue, get);
+	KX_PYMETHOD_VARARGS(CListValue, getMatching);
 	KX_PYMETHOD_O(CListValue, from_id);
 #endif
 };


### PR DESCRIPTION
This branch implement a method named `getMatching`in `CListValue`which take two arguments `name` and `prop`. These two arguments are used in a regex search of the list item which have a matching name or a matching property.

Example file: http://pasteall.org/blend/index.php?id=46149.