### PR TITLE
Add option to override scene culling by a camera.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -89,6 +89,12 @@ base class --- :class:`PyObjectPlus`
          
          This can be set directly from python to avoid using the :class:`KX_SceneActuator`.
 
+   .. attribute:: overrideCullingCamera
+
+      The override camera used for scene culling, if set to None the culling is proceeded with the camera used to render.
+
+      :type: :class:`KX_Camera` or None
+
    .. attribute:: world
 
       The current active world, (read-only).

--- a/release/scripts/startup/bl_ui/properties_data_camera.py
+++ b/release/scripts/startup/bl_ui/properties_data_camera.py
@@ -151,6 +151,23 @@ class DATA_PT_levels_of_detail(CameraButtonsPanel, Panel):
         col.prop(cam, "lod_factor", text="Distance Factor")
 
 
+class DATA_PT_frustum_culling(CameraButtonsPanel, Panel):
+    bl_label = "Frustum Culling"
+    COMPAT_ENGINES = {'BLENDER_GAME'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.camera and context.scene.render.engine in cls.COMPAT_ENGINES
+
+    def draw(self, context):
+        layout = self.layout
+        cam = context.camera
+
+        row = layout.row()
+        row.prop(cam, "show_frustum")
+        row.prop(cam, "override_culling")
+
+
 class DATA_PT_camera_stereoscopy(CameraButtonsPanel, Panel):
     bl_label = "Stereoscopy"
     COMPAT_ENGINES = {'BLENDER_RENDER'}
@@ -274,8 +291,6 @@ class DATA_PT_camera_display(CameraButtonsPanel, Panel):
 
         col = split.column()
         col.prop(cam, "show_limits", text="Limits")
-        if context.scene.render.engine == 'BLENDER_GAME':
-            col.prop(cam, "show_frustum", text="Frustum")
         col.prop(cam, "show_mist", text="Mist")
 
         col.prop(cam, "show_sensor", text="Sensor")
@@ -350,6 +365,7 @@ classes = (
     DATA_PT_lens,
     DATA_PT_camera,
     DATA_PT_levels_of_detail,
+    DATA_PT_frustum_culling,
     DATA_PT_camera_stereoscopy,
     DATA_PT_camera_dof,
     DATA_PT_camera_display,

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -216,5 +216,18 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
 				scene->gm.timeScale = 1.0f;
 			}
 		}
+
+		if (!DNA_struct_elem_find(fd->filesdna, "Camera", "short", "gameflag")) {
+			for (Camera *camera = main->camera.first; camera; camera = camera->id.next) {
+				/* Previous value of GAME_CAM_SHOW_FRUSTUM was 1 << 10, it was possibly conflicting
+				 * with new flags. To fix this issue we use a separate flag value: gameflag.
+				 */
+				if (camera->flag & (1 << 10)) {
+					camera->gameflag |= GAME_CAM_SHOW_FRUSTUM;
+					/* Disable bit 10 */
+					camera->flag &= ~(1 << 10);
+				}
+			}
+		}
 	}
 }

--- a/source/blender/makesdna/DNA_camera_types.h
+++ b/source/blender/makesdna/DNA_camera_types.h
@@ -66,6 +66,8 @@ typedef struct Camera {
 	char type; /* CAM_PERSP, CAM_ORTHO or CAM_PANO */
 	char dtx; /* draw type extra */
 	short flag;
+	short gameflag;
+	short pad2;
 	float passepartalpha;
 	float clipsta, clipend;
 	float lens, ortho_scale, drawsize;
@@ -77,6 +79,7 @@ typedef struct Camera {
 	/* qdn: yafray var 'YF_dofdist' now enabled for defocus composite node as well.
 	 * The name was not changed so that no other files need to be modified */
 	float YF_dofdist;
+	int pad3;
 
 	struct Ipo *ipo  DNA_DEPRECATED; /* old animation system, deprecated for 2.5 */
 	
@@ -125,7 +128,12 @@ enum {
 #endif
 	CAM_SHOWSENSOR          = (1 << 8),
 	CAM_SHOW_SAFE_CENTER    = (1 << 9),
-	CAM_SHOW_FRUSTUM		= (1 << 10),
+};
+
+/* gameflag */
+enum {
+	GAME_CAM_SHOW_FRUSTUM		= (1 << 0),
+	GAME_CAM_OVERRIDE_CULLING	= (1 << 1),
 };
 
 /* yafray: dof sampling switch */

--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -340,8 +340,13 @@ void RNA_def_camera(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Stereo", "");
 
 	/* flag */
+	prop = RNA_def_property(srna, "override_culling", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_OVERRIDE_CULLING);
+	RNA_def_property_ui_text(prop, "Override Culling", "Use only this camera for scene culling in Game Engine");
+	RNA_def_property_update(prop, NC_CAMERA, NULL);
+
 	prop = RNA_def_property(srna, "show_frustum", PROP_BOOLEAN, PROP_NONE);
-	RNA_def_property_boolean_sdna(prop, NULL, "flag", CAM_SHOW_FRUSTUM);
+	RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_SHOW_FRUSTUM);
 	RNA_def_property_ui_text(prop, "Show Frustum", "Show a visualization of frustum in Game Engine");
 	RNA_def_property_update(prop, NC_CAMERA, NULL);
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -977,8 +977,18 @@ static KX_Camera *gamecamera_from_bcamera(Object *ob, KX_Scene *kxscene, KX_Blen
 	gamecamera= new KX_Camera(kxscene, KX_Scene::m_callbacks, camdata);
 	gamecamera->SetName(ca->id.name + 2);
 
-	gamecamera->SetShowCameraFrustum(ca->flag & CAM_SHOW_FRUSTUM);
+	gamecamera->SetShowCameraFrustum(ca->gameflag & GAME_CAM_SHOW_FRUSTUM);
 	gamecamera->SetLodDistanceFactor(ca->lodfactor);
+
+	if (ca->gameflag & GAME_CAM_OVERRIDE_CULLING) {
+		if (kxscene->GetOverrideCullingCamera()) {
+			CM_Warning("\"" << gamecamera->GetName() << "\" sets for culling override whereas \""
+				<< kxscene->GetOverrideCullingCamera()->GetName() << "\" is already used for culling override.");
+		}
+		else {
+			kxscene->SetOverrideCullingCamera(gamecamera);
+		}
+	}
 
 	return gamecamera;
 }

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -107,12 +107,13 @@ public:
 private:
 	struct CameraFrameRenderData
 	{
-		CameraFrameRenderData(KX_Camera *camera, const RAS_Rect& area, const RAS_Rect& viewport, RAS_Rasterizer::StereoEye eye);
+		CameraFrameRenderData(KX_Camera *rendercam, KX_Camera *cullingcam, const RAS_Rect& area, const RAS_Rect& viewport, RAS_Rasterizer::StereoEye eye);
 		CameraFrameRenderData(const CameraFrameRenderData& other);
 		~CameraFrameRenderData();
 
 		/// Rendered camera, could be a temporary camera in case of stereo.
-		KX_Camera *m_camera;
+		KX_Camera *m_renderCamera;
+		KX_Camera *m_cullingCamera;
 		RAS_Rect m_area;
 		RAS_Rect m_viewport;
 		RAS_Rasterizer::StereoEye m_eye;
@@ -257,6 +258,8 @@ private:
 	/// Update and return the projection matrix of a camera depending on the viewport.
 	MT_Matrix4x4 GetCameraProjectionMatrix(KX_Scene *scene, KX_Camera *cam, RAS_Rasterizer::StereoEye eye,
 										   const RAS_Rect& viewport, const RAS_Rect& area) const;
+	CameraFrameRenderData GetCameraRenderData(KX_Scene *scene, KX_Camera *camera, KX_Camera *overrideCullingCam, const RAS_Rect& displayArea,
+											  RAS_Rasterizer::StereoEye eye, bool usestereo);
 	/// Compute frame render data per eyes (in case of stereo), scenes and camera.
 	bool GetFrameRenderData(std::vector<FrameRenderData>& frameDataList);
 

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -207,6 +207,8 @@ protected:
 	 * The active camera for the scene
 	 */
 	KX_Camera* m_active_camera;
+	/// The active camera for scene culling.
+	KX_Camera *m_overrideCullingCamera;
 
 	/**
 	 * Another temporary variable outstaying its welcome
@@ -411,6 +413,9 @@ public:
 		class KX_Camera*
 	);
 
+	KX_Camera *GetOverrideCullingCamera() const;
+	void SetOverrideCullingCamera(KX_Camera *cam);
+
 	/**
 	 * Move this camera to the end of the list so that it is rendered last.
 	 * If the camera is not on the list, it will be added
@@ -577,6 +582,8 @@ public:
 	static PyObject*	pyattr_get_world(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject*	pyattr_get_active_camera(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_active_camera(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject*	pyattr_get_overrideCullingCamera(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static int			pyattr_set_overrideCullingCamera(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_drawing_callback(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static int			pyattr_set_drawing_callback(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject*	pyattr_get_gravity(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);


### PR DESCRIPTION
Idea from youle in ge_lightfrustum2.

The user can now debug the culling of a scene by using a culling camera
which have a transform different to the render camera.
To set a camera as culling override, the user have to check an option in
UI into the new panel named "Frustum Culling", or set in python the value
KX_Scene.overrideCullingCamera to the used camera for culling.