### PR TITLE
Revert exposure and range dynamic uniforms to test performances

### DIFF
--- a/source/blender/editors/space_view3d/view3d_draw.c
+++ b/source/blender/editors/space_view3d/view3d_draw.c
@@ -2702,7 +2702,6 @@ static void gpu_update_lamps_shadows_world(Scene *scene, View3D *v3d)
 		GPU_horizon_update_color(&world->horr);
 		GPU_ambient_update_color(&world->ambr);
 		GPU_zenith_update_color(&world->zenr);
-		GPU_update_exposure_range(world->exp, world->range);
 		GPU_update_envlight_energy(world->ao_env_energy);
 	}
 }

--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -197,9 +197,7 @@ typedef enum GPUDynamicType {
 	GPU_DYNAMIC_HORIZON_COLOR        = 1  | GPU_DYNAMIC_GROUP_WORLD,
 	GPU_DYNAMIC_AMBIENT_COLOR        = 2  | GPU_DYNAMIC_GROUP_WORLD,
 	GPU_DYNAMIC_ZENITH_COLOR         = 3  | GPU_DYNAMIC_GROUP_WORLD,
-	GPU_DYNAMIC_WORLD_LINFAC         = 4  | GPU_DYNAMIC_GROUP_WORLD,
-	GPU_DYNAMIC_WORLD_LOGFAC         = 5  | GPU_DYNAMIC_GROUP_WORLD,
-	GPU_DYNAMIC_ENVLIGHT_ENERGY      = 6  | GPU_DYNAMIC_GROUP_WORLD,
+	GPU_DYNAMIC_ENVLIGHT_ENERGY      = 4  | GPU_DYNAMIC_GROUP_WORLD,
 
 	GPU_DYNAMIC_MAT_DIFFRGB          = 1  | GPU_DYNAMIC_GROUP_MAT,
 	GPU_DYNAMIC_MAT_REF              = 2  | GPU_DYNAMIC_GROUP_MAT,
@@ -382,7 +380,6 @@ void GPU_mist_update_values(int type, float start, float dist, float inten, floa
 void GPU_horizon_update_color(float color[3]);
 void GPU_ambient_update_color(float color[3]);
 void GPU_zenith_update_color(float color[3]);
-void GPU_update_exposure_range(float exp, float range);
 void GPU_update_envlight_energy(float energy);
 
 struct GPUParticleInfo

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -89,8 +89,6 @@ static struct GPUWorld {
 	float horicol[3];
 	float ambcol[4];
 	float zencol[3];
-	float logfac;
-	float linfac;
 	float envlightenergy;
 } GPUWorld;
 
@@ -1878,12 +1876,6 @@ void GPU_zenith_update_color(float color[3])
 	copy_v3_v3(GPUWorld.zencol, color);
 }
 
-void GPU_update_exposure_range(float exp, float range)
-{
-	GPUWorld.linfac = 1.0f + powf((2.0f * exp + 0.5f), -10.0f);
-	GPUWorld.logfac = log((GPUWorld.linfac - 1.0f) / GPUWorld.linfac) / range;
-}
-
 void GPU_update_envlight_energy(float energy)
 {
 	GPUWorld.envlightenergy = energy;
@@ -1892,9 +1884,10 @@ void GPU_update_envlight_energy(float energy)
 void GPU_shaderesult_set(GPUShadeInput *shi, GPUShadeResult *shr)
 {
 	GPUMaterial *mat = shi->gpumat;
-	GPUNodeLink *emit, *mistfac;
+	GPUNodeLink *emit, *ulinfac, *ulogfac, *mistfac;
 	Material *ma = shi->mat;
 	World *world = mat->scene->world;
+	float linfac, logfac;
 
 	mat->dynproperty |= DYN_LAMP_CO;
 	memset(shr, 0, sizeof(*shr));
@@ -1932,14 +1925,18 @@ void GPU_shaderesult_set(GPUShadeInput *shi, GPUShadeResult *shr)
 
 		if (world) {
 			/* exposure correction */
-			GPU_link(mat, "shade_exposure_correct", shr->combined,
-					 GPU_select_uniform(&GPUWorld.linfac, GPU_DYNAMIC_WORLD_LINFAC, NULL, ma),
-					 GPU_select_uniform(&GPUWorld.logfac, GPU_DYNAMIC_WORLD_LOGFAC, NULL, ma),
-					 &shr->combined);
-			GPU_link(mat, "shade_exposure_correct", shr->spec,
-					 GPU_select_uniform(&GPUWorld.linfac, GPU_DYNAMIC_WORLD_LINFAC, NULL, ma),
-					 GPU_select_uniform(&GPUWorld.logfac, GPU_DYNAMIC_WORLD_LOGFAC, NULL, ma),
-					 &shr->spec);
+			if (world->exp != 0.0f || world->range != 1.0f) {
+				linfac = 1.0f + powf((2.0f * world->exp + 0.5f), -10);
+				logfac = logf((linfac - 1.0f) / linfac) / world->range;
+				
+				GPU_link(mat, "set_value", GPU_uniform(&linfac), &ulinfac);
+				GPU_link(mat, "set_value", GPU_uniform(&logfac), &ulogfac);
+				
+				GPU_link(mat, "shade_exposure_correct", shr->combined,
+					ulinfac, ulogfac, &shr->combined);
+				GPU_link(mat, "shade_exposure_correct", shr->spec,
+					ulinfac, ulogfac, &shr->spec);
+			}
 
 			/* environment lighting */
 			if (!(mat->scene->gm.flag & GAME_GLSL_NO_ENV_LIGHTING) &&

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -73,8 +73,6 @@ KX_WorldInfo::KX_WorldInfo(Scene *blenderscene, World *blenderworld)
 		setHorizonColor(MT_Vector4(blenderworld->horr, blenderworld->horg, blenderworld->horb, 1.0f));
 		setZenithColor(MT_Vector4(blenderworld->zenr, blenderworld->zeng, blenderworld->zenb, 1.0f));
 		setAmbientColor(MT_Vector3(blenderworld->ambr, blenderworld->ambg, blenderworld->ambb));
-		setExposure(blenderworld->exp);
-		setRange(blenderworld->range);
 	}
 	else {
 		m_hasworld = false;
@@ -129,16 +127,6 @@ void KX_WorldInfo::setMistIntensity(float intensity)
 	m_mistintensity = intensity;
 }
 
-void KX_WorldInfo::setExposure(float exposure)
-{
-	m_exposure = exposure;
-}
-
-void KX_WorldInfo::setRange(float range)
-{
-	m_range = range;
-}
-
 void KX_WorldInfo::setMistColor(const MT_Vector3& mistcolor)
 {
 	m_mistcolor = mistcolor;
@@ -185,7 +173,6 @@ void KX_WorldInfo::UpdateWorldSettings(RAS_Rasterizer *rasty)
 	if (m_hasworld) {
 		rasty->SetAmbientColor(m_con_ambientcolor);
 		GPU_ambient_update_color(m_ambientcolor.getValue());
-		GPU_update_exposure_range(m_exposure, m_range);
 		GPU_update_envlight_energy(m_envLightEnergy);
 
 		if (m_hasmist) {
@@ -295,8 +282,6 @@ PyAttributeDef KX_WorldInfo::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("backgroundColor", KX_WorldInfo, pyattr_get_background_color, pyattr_set_background_color),
 	KX_PYATTRIBUTE_RW_FUNCTION("zenithColor", KX_WorldInfo, pyattr_get_zenith_color, pyattr_set_zenith_color),
 	KX_PYATTRIBUTE_RW_FUNCTION("ambientColor", KX_WorldInfo, pyattr_get_ambient_color, pyattr_set_ambient_color),
-	KX_PYATTRIBUTE_FLOAT_RW("exposure", 0.0f, 1.0f, KX_WorldInfo, m_exposure),
-	KX_PYATTRIBUTE_FLOAT_RW("range", 0.2f, 5.0f, KX_WorldInfo, m_range),
 	KX_PYATTRIBUTE_FLOAT_RW("envLightEnergy", 0.0f, FLT_MAX, KX_WorldInfo, m_envLightEnergy),
 	KX_PYATTRIBUTE_NULL /* Sentinel */
 };

--- a/source/gameengine/Ketsji/KX_WorldInfo.h
+++ b/source/gameengine/Ketsji/KX_WorldInfo.h
@@ -57,8 +57,6 @@ class KX_WorldInfo : public PyObjectPlus
 	float m_miststart;
 	float m_mistdistance;
 	float m_mistintensity;
-	float m_range;
-	float m_exposure;
 	float m_envLightEnergy;
 	MT_Vector3 m_mistcolor;
 	MT_Vector4 m_horizoncolor;
@@ -90,8 +88,6 @@ public:
 	void setMistStart(float d);
 	void setMistDistance(float d);
 	void setMistIntensity(float intensity);
-	void setExposure(float exposure);
-	void setRange(float range);
 	void setMistColor(const MT_Vector3& mistcolor);
 	void setHorizonColor(const MT_Vector4& horizoncolor);
 	void setZenithColor(const MT_Vector4& zenithcolor);


### PR DESCRIPTION
This branch is just to point a performances problem with this commit: https://github.com/UPBGE/blender/commit/887962d5b6d6cb5440a9c91721239bcf9095412e

Test file: http://pasteall.org/blend/index.php?id=46519

NOTE: ALL constants are checked.

@Akira1San && @panzergame: Can you confirm that you have a big performance increase when you revert this commit with this test file?

On my computer I have 415 fps in master and 450 in this branch.