### PR TITLE
UPBGE: Improve tooltip for margin in physics tab

### DIFF
--- a/source/blender/makesrna/intern/rna_object.c
+++ b/source/blender/makesrna/intern/rna_object.c
@@ -1889,7 +1889,8 @@ static void rna_def_object_game_settings(BlenderRNA *brna)
 	RNA_def_property_float_default(prop, 0.04f);
 	RNA_def_property_ui_text(prop, "Collision Margin",
 	                         "Extra margin around object for collision detection, small amount required "
-	                         "for stability");
+	                         "for stability. In most cases margin can be set to 0.0 for static/not moving objects."
+							 "If you have jittering, decrease the margin");
 
 	prop = RNA_def_property(srna, "soft_body", PROP_POINTER, PROP_NONE);
 	RNA_def_property_pointer_sdna(prop, NULL, "bsoft");


### PR DESCRIPTION
The default margin should always be 0.04. The default Cube has a margin of
0.06. This is only a bit annoying if you set this cube to rigid body,
enable collision bounds with triangle mesh, add a plane with margin of
0.04 and set the plane to static with triangle mesh because it creates a
small jitter.

This jitter doesn't occur when plane and cube have their margin set to
0.04.

But:
1) I didn't found how to change margin for default cube (it doesn't work
in versioning legacy)
2) When you add an object, its default margin is set to 0.04
3) This seems a rare bug

So I just propose to improve tooltip of margin with the following patch.

I think this is enough to answer this report:
https://github.com/UPBGE/blender/issues/484