### PR TITLE
Fix constraint when suspending physics.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -741,9 +741,13 @@ base class --- :class:`SCA_IObject`
       :arg angular_damping: Angular ("rotational") damping factor.
       :type angular_damping: float ∈ [0, 1]
 
-   .. method:: suspendPhysics()
+   .. method:: suspendPhysics([freeConstraints])
 
       Suspends physics for this object.
+
+      :arg freeConstraints: When set to `True` physics constraints used by the object are deleted.
+          Else when `False` (the default) constraints are restored when restoring physics.
+      :type freeConstraints: bool
 
    .. method:: restorePhysics()
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -1911,7 +1911,7 @@ PyMethodDef KX_GameObject::Methods[] = {
 	{"getReactionForce", (PyCFunction) KX_GameObject::sPyGetReactionForce, METH_NOARGS},
 	{"alignAxisToVect",(PyCFunction) KX_GameObject::sPyAlignAxisToVect, METH_VARARGS},
 	{"getAxisVect",(PyCFunction) KX_GameObject::sPyGetAxisVect, METH_O},
-	{"suspendPhysics", (PyCFunction)KX_GameObject::sPySuspendPhysics, METH_NOARGS},
+	{"suspendPhysics", (PyCFunction)KX_GameObject::sPySuspendPhysics, METH_VARARGS},
 	{"restorePhysics", (PyCFunction)KX_GameObject::sPyRestorePhysics,METH_NOARGS},
 	{"suspendDynamics", (PyCFunction)KX_GameObject::sPySuspendDynamics, METH_VARARGS},
 	{"restoreDynamics", (PyCFunction)KX_GameObject::sPyRestoreDynamics,METH_NOARGS},
@@ -3561,10 +3561,16 @@ PyObject *KX_GameObject::PyApplyImpulse(PyObject *args)
 	return nullptr;
 }
 
-PyObject *KX_GameObject::PySuspendPhysics()
+PyObject *KX_GameObject::PySuspendPhysics(PyObject *args)
 {
+	int removeConstraint = true;
+
+	if (!PyArg_ParseTuple(args, "|i:suspendPhysics", &removeConstraint)) {
+		return nullptr;
+	}
+
 	if (GetPhysicsController()) {
-		GetPhysicsController()->SuspendPhysics();
+		GetPhysicsController()->SuspendPhysics((bool)removeConstraint);
 	}
 	Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -3563,14 +3563,14 @@ PyObject *KX_GameObject::PyApplyImpulse(PyObject *args)
 
 PyObject *KX_GameObject::PySuspendPhysics(PyObject *args)
 {
-	int removeConstraint = true;
+	int freeConstraints = false;
 
-	if (!PyArg_ParseTuple(args, "|i:suspendPhysics", &removeConstraint)) {
+	if (!PyArg_ParseTuple(args, "|i:suspendPhysics", &freeConstraints)) {
 		return nullptr;
 	}
 
 	if (GetPhysicsController()) {
-		GetPhysicsController()->SuspendPhysics((bool)removeConstraint);
+		GetPhysicsController()->SuspendPhysics((bool)freeConstraints);
 	}
 	Py_RETURN_NONE;
 }

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -952,7 +952,7 @@ public:
 	KX_PYMETHOD_O(KX_GameObject,SetState);
 	KX_PYMETHOD_VARARGS(KX_GameObject,AlignAxisToVect);
 	KX_PYMETHOD_O(KX_GameObject,GetAxisVect);
-	KX_PYMETHOD_NOARGS(KX_GameObject,SuspendPhysics);
+	KX_PYMETHOD_VARARGS(KX_GameObject,SuspendPhysics);
 	KX_PYMETHOD_NOARGS(KX_GameObject,RestorePhysics);
 	KX_PYMETHOD_VARARGS(KX_GameObject,SuspendDynamics);
 	KX_PYMETHOD_NOARGS(KX_GameObject,RestoreDynamics);

--- a/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
+++ b/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
@@ -584,7 +584,7 @@ static PyObject *gPyRemoveConstraint(PyObject *self,
 	{
 		if (PHY_GetActiveEnvironment())
 		{
-			PHY_GetActiveEnvironment()->RemoveConstraintById(constraintid);
+			PHY_GetActiveEnvironment()->RemoveConstraintById(constraintid, true);
 		}
 	}
 	else {

--- a/source/gameengine/Ketsji/KX_SCA_DynamicActuator.cpp
+++ b/source/gameengine/Ketsji/KX_SCA_DynamicActuator.cpp
@@ -144,7 +144,7 @@ bool KX_SCA_DynamicActuator::Update()
 		}
 		case KX_DYN_DISABLE_PHYSICS:
 		{
-			controller->SuspendPhysics(true);
+			controller->SuspendPhysics(false);
 			break;
 		}
 	}

--- a/source/gameengine/Ketsji/KX_SCA_DynamicActuator.cpp
+++ b/source/gameengine/Ketsji/KX_SCA_DynamicActuator.cpp
@@ -144,7 +144,7 @@ bool KX_SCA_DynamicActuator::Update()
 		}
 		case KX_DYN_DISABLE_PHYSICS:
 		{
-			controller->SuspendPhysics();
+			controller->SuspendPhysics(true);
 			break;
 		}
 	}

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -231,6 +231,13 @@ public:
 	}
 };
 
+CcdPhysicsController::CcdConstraint::CcdConstraint(bool disableCollision)
+	:m_disableCollision(disableCollision),
+	m_active(false)
+{
+}
+
+
 btRigidBody *CcdPhysicsController::GetRigidBody()
 {
 	return btRigidBody::upcast(m_object);
@@ -650,7 +657,7 @@ CcdPhysicsController::~CcdPhysicsController()
 {
 	//will be reference counted, due to sharing
 	if (m_cci.m_physicsEnv)
-		m_cci.m_physicsEnv->RemoveCcdPhysicsController(this);
+		m_cci.m_physicsEnv->RemoveCcdPhysicsController(this, true);
 
 	if (m_MotionState)
 		delete m_MotionState;
@@ -833,7 +840,7 @@ void CcdPhysicsController::SetPhysicsEnvironment(class PHY_IPhysicsEnvironment *
 		// since the environment is changing, we must also move the controler to the
 		// new environment. Note that we don't handle sensor explicitly: this
 		// function can be called on sensor but only when they are not registered
-		if (m_cci.m_physicsEnv->RemoveCcdPhysicsController(this))
+		if (m_cci.m_physicsEnv->RemoveCcdPhysicsController(this, true))
 		{
 			physicsEnv->AddCcdPhysicsController(this);
 
@@ -1015,9 +1022,9 @@ void CcdPhysicsController::RefreshCollisions()
 	GetPhysicsEnvironment()->UpdateCcdPhysicsController(this, GetMass(), m_object->getCollisionFlags(), handle->m_collisionFilterGroup, handle->m_collisionFilterMask);
 }
 
-void CcdPhysicsController::SuspendPhysics()
+void CcdPhysicsController::SuspendPhysics(bool removeConstraints)
 {
-	GetPhysicsEnvironment()->RemoveCcdPhysicsController(this);
+	GetPhysicsEnvironment()->RemoveCcdPhysicsController(this, removeConstraints);
 }
 
 void CcdPhysicsController::RestorePhysics()
@@ -1508,7 +1515,7 @@ void CcdPhysicsController::AddCompoundChild(PHY_IPhysicsController *child)
 	// must update the broadphase cache,
 	GetPhysicsEnvironment()->RefreshCcdPhysicsController(this);
 	// remove the children
-	GetPhysicsEnvironment()->RemoveCcdPhysicsController(childCtrl);
+	GetPhysicsEnvironment()->RemoveCcdPhysicsController(childCtrl, true);
 }
 
 /* Reverse function of the above, it will remove a shape from a compound shape

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1022,9 +1022,9 @@ void CcdPhysicsController::RefreshCollisions()
 	GetPhysicsEnvironment()->UpdateCcdPhysicsController(this, GetMass(), m_object->getCollisionFlags(), handle->m_collisionFilterGroup, handle->m_collisionFilterMask);
 }
 
-void CcdPhysicsController::SuspendPhysics(bool removeConstraints)
+void CcdPhysicsController::SuspendPhysics(bool freeConstraints)
 {
-	GetPhysicsEnvironment()->RemoveCcdPhysicsController(this, removeConstraints);
+	GetPhysicsEnvironment()->RemoveCcdPhysicsController(this, freeConstraints);
 }
 
 void CcdPhysicsController::RestorePhysics()

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -694,7 +694,7 @@ public:
 
 	virtual void ResolveCombinedVelocities(float linvelX, float linvelY, float linvelZ, float angVelX, float angVelY, float angVelZ);
 	virtual void RefreshCollisions();
-	virtual void SuspendPhysics(bool removeConstraints);
+	virtual void SuspendPhysics(bool freeConstraints);
 	virtual void RestorePhysics();
 	virtual void SuspendDynamics(bool ghost);
 	virtual void RestoreDynamics();

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -515,6 +515,17 @@ public:
 /// CcdPhysicsController is a physics object that supports continuous collision detection and time of impact based physics resolution.
 class CcdPhysicsController : public PHY_IPhysicsController
 {
+public:
+	/// Constraint user data.
+	struct CcdConstraint
+	{
+		CcdConstraint(bool m_disableCollision);
+		/// Disable collision between constrained objects?
+		bool m_disableCollision;
+		/// The constraint is added in dynamic world?
+		bool m_active;
+	};
+
 protected:
 	btCollisionObject *m_object;
 	BlenderBulletCharacterController *m_characterController;
@@ -683,7 +694,7 @@ public:
 
 	virtual void ResolveCombinedVelocities(float linvelX, float linvelY, float linvelZ, float angVelX, float angVelY, float angVelZ);
 	virtual void RefreshCollisions();
-	virtual void SuspendPhysics();
+	virtual void SuspendPhysics(bool removeConstraints);
 	virtual void RestorePhysics();
 	virtual void SuspendDynamics(bool ghost);
 	virtual void RestoreDynamics();

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -25,10 +25,11 @@
 #include "KX_KetsjiEngine.h"
 #include "KX_Globals.h"
 
+#include "CcdPhysicsController.h"
+
 #include <vector>
 #include <set>
 #include <map>
-class CcdPhysicsController;
 class CcdGraphicController;
 #include "LinearMath/btVector3.h"
 #include "LinearMath/btTransform.h"
@@ -66,7 +67,9 @@ class CcdPhysicsEnvironment : public PHY_IPhysicsEnvironment
 	btVector3 m_gravity;
 
 	/// Removes the constraint and his references from the owner and the target.
-	void RemoveConstraint(btTypedConstraint *con);
+	void RemoveConstraint(btTypedConstraint *con, bool free);
+	/// Restore the constraint if the owner and target are presents.
+	void RestoreConstraint(CcdPhysicsController *ctrl, btTypedConstraint *con);
 
 protected:
 	btIDebugDraw *m_debugDrawer;
@@ -172,21 +175,11 @@ public:
 								 float axis1X = 0, float axis1Y = 0, float axis1Z = 0,
 								 float axis2X = 0, float axis2Y = 0, float axis2Z = 0, int flag = 0);
 
-	//Following the COLLADA physics specification for constraints
-	virtual int CreateUniversalD6Constraint(
-				class PHY_IPhysicsController *ctrlRef, class PHY_IPhysicsController *ctrlOther,
-				btTransform& localAttachmentFrameRef,
-				btTransform& localAttachmentOther,
-				const btVector3& linearMinLimits,
-				const btVector3& linearMaxLimits,
-				const btVector3& angularMinLimits,
-				const btVector3& angularMaxLimits, int flags);
-
 	virtual void SetConstraintParam(int constraintId, int param, float value, float value1);
 
 	virtual float GetConstraintParam(int constraintId, int param);
 
-	virtual void RemoveConstraintById(int constraintid);
+	virtual void RemoveConstraintById(int constraintid, bool free);
 
 	virtual float getAppliedImpulse(int constraintid);
 
@@ -230,7 +223,7 @@ public:
 
 	void AddCcdPhysicsController(CcdPhysicsController *ctrl);
 
-	bool RemoveCcdPhysicsController(CcdPhysicsController *ctrl);
+	bool RemoveCcdPhysicsController(CcdPhysicsController *ctrl, bool freeConstraints);
 
 	void UpdateCcdPhysicsController(CcdPhysicsController *ctrl, btScalar newMass, int newCollisionFlags, short int newCollisionGroup, short int newCollisionMask);
 

--- a/source/gameengine/Physics/Common/PHY_IPhysicsController.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsController.h
@@ -98,7 +98,7 @@ public:
 	virtual void SetDamping(float linear, float angular) = 0;
 
 	virtual void RefreshCollisions() = 0;
-	virtual void SuspendPhysics() = 0;
+	virtual void SuspendPhysics(bool removeConstraints) = 0;
 	virtual void RestorePhysics() = 0;
 	virtual void SuspendDynamics(bool ghost = false) = 0;
 	virtual void RestoreDynamics() = 0;

--- a/source/gameengine/Physics/Common/PHY_IPhysicsController.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsController.h
@@ -98,7 +98,7 @@ public:
 	virtual void SetDamping(float linear, float angular) = 0;
 
 	virtual void RefreshCollisions() = 0;
-	virtual void SuspendPhysics(bool removeConstraints) = 0;
+	virtual void SuspendPhysics(bool freeConstraints) = 0;
 	virtual void RestorePhysics() = 0;
 	virtual void SuspendDynamics(bool ghost = false) = 0;
 	virtual void RestoreDynamics() = 0;

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -191,7 +191,7 @@ public:
 								 float axis0X, float axis0Y, float axis0Z,
 								 float axis1X = 0, float axis1Y = 0, float axis1Z = 0,
 								 float axis2X = 0, float axis2Y = 0, float axis2Z = 0, int flag = 0) = 0;
-	virtual void RemoveConstraintById(int constraintid) = 0;
+	virtual void RemoveConstraintById(int constraintid, bool free) = 0;
 	virtual float GetAppliedImpulse(int constraintid)
 	{
 		return 0.0f;

--- a/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.cpp
@@ -97,7 +97,7 @@ int DummyPhysicsEnvironment::CreateConstraint(class PHY_IPhysicsController *ctrl
 	return constraintid;
 }
 
-void DummyPhysicsEnvironment::RemoveConstraintById(int constraintid)
+void DummyPhysicsEnvironment::RemoveConstraintById(int constraintid, bool free)
 {
 	if (constraintid) {
 	}

--- a/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Dummy/DummyPhysicsEnvironment.h
@@ -66,7 +66,7 @@ public:
 								 float axis1X = 0, float axis1Y = 0, float axis1Z = 0,
 								 float axis2X = 0, float axis2Y = 0, float axis2Z = 0, int flag = 0);
 
-	virtual void RemoveConstraintById(int constraintid);
+	virtual void RemoveConstraintById(int constraintid, bool free);
 
 	//complex constraint for vehicles
 	virtual PHY_IVehicle *GetVehicleConstraint(int constraintId)


### PR DESCRIPTION
Previously when we was suspending physics of an object using constraints, they were removed. This behaviour could be needed in some rare case but for the most case where the user just want to optimize physics computation the engine should keep the constraints.

To do so the constraints have to be removed from the dynamic world but not removed from the controller  or deleted in RemoveCcdPhysicsController. In the same time AddCcdPhysicsController iterate over all the constraint in the activated controller and add they in the dynamic world.

Unfortunately there's some limitation, first we could not do redundant operation in removing and adding of the constraint in the world, second we have to keep the disable collision between bodies flag used when adding a constraint into world.
To solve both of these issues the user pointer of the constraint are used to store a new type: CcdConstraint (in CcdPhysicsController). This new type only store the disable collision flag and a boolean named m_valid set to true when the constraint is added in world else to false when removed.

Two functions are added to clean the code: RemoveConstraint and RestoreConstraint.

@youle31, @DCubix, @lordloki : Could you review the patch please ?

Example file: http://pasteall.org/blend/index.php?id=46774
Press Space to apply torque, Q to suspend physics of a cube, E to restore.