### PR TITLE
Show render queries

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -466,6 +466,7 @@ class RENDER_PT_game_debug(RenderButtonsPanel, Panel):
 
         col = split.column()
         col.prop(gs, "show_framerate_profile", text="Framerate and Profile")
+        col.prop(gs, "show_render_queries", text="Render Queries")
         col.prop(gs, "show_debug_properties", text="Properties")
         col.prop(gs, "show_physics_visualization", text="Physics Visualization")
 

--- a/release/scripts/startup/bl_ui/space_info.py
+++ b/release/scripts/startup/bl_ui/space_info.py
@@ -240,6 +240,7 @@ class INFO_MT_game(Menu):
         layout.separator()
 
         layout.prop(gs, "show_framerate_profile")
+        layout.prop(gs, "show_render_queries")
         layout.prop(gs, "use_deprecation_warnings")
         layout.menu("INFO_MT_game_show_debug")
         layout.separator()

--- a/source/blender/editors/space_view3d/view3d_view.c
+++ b/source/blender/editors/space_view3d/view3d_view.c
@@ -1713,6 +1713,9 @@ static void game_set_commmandline_options(GameData *gm)
 		SYS_WriteCommandLineInt(syshandle, "show_framerate", test);
 		SYS_WriteCommandLineInt(syshandle, "show_profile", test);
 
+		test = (gm->flag & GAME_SHOW_RENDER_QUERIES);
+		SYS_WriteCommandLineInt(syshandle, "show_render_queries", test);
+
 		test = (gm->flag & GAME_SHOW_DEBUG_PROPS);
 		SYS_WriteCommandLineInt(syshandle, "show_properties", test);
 

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -952,6 +952,7 @@ typedef struct GameData {
 #endif
 #define GAME_PYTHON_CONSOLE					(1 << 20)
 #define GAME_GLSL_NO_ENV_LIGHTING			(1 << 21)
+#define GAME_SHOW_RENDER_QUERIES			(1 << 22)
 /* Note: GameData.flag is now an int (max 32 flags). A short could only take 16 flags */
 
 #define GAME_DEBUG_DISABLE	0

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -4860,6 +4860,11 @@ static void rna_def_scene_game_data(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Show Framerate and Profile",
 	                         "Show framerate and profiling information while the game runs");
 
+	prop = RNA_def_property(srna, "show_render_queries", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "flag", GAME_SHOW_RENDER_QUERIES);
+	RNA_def_property_ui_text(prop, "Show Render Queries",
+	                         "Show render queries information while the game runs");
+
 	prop = RNA_def_property(srna, "show_physics_visualization", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "flag", GAME_SHOW_PHYSICS);
 	RNA_def_property_ui_text(prop, "Show Physics Visualization",

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -489,6 +489,7 @@ static void usage(const std::string& program, bool isBlenderPlayer)
 	CM_Message("       nomipmap                       0         Disable mipmaps");
 	CM_Message("       wireframe                      0         Wireframe render");
 	CM_Message("       show_framerate                 0         Show the frame rate");
+	CM_Message("       show_render_queries            0         Show the render queries");
 	CM_Message("       show_properties                0         Show debug properties");
 	CM_Message("       show_profile                   0         Show profiling information");
 	CM_Message("       show_bounding_box              0         Show debug bounding box volume");

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -253,9 +253,13 @@ void KX_KetsjiEngine::StartEngine()
 
 void KX_KetsjiEngine::BeginFrame()
 {
+	m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
+
 	for (RAS_Query& query : m_renderQueries) {
 		query.Begin();
 	}
+
+	m_logger.StartLog(tc_rasterizer, m_kxsystem->GetTimeInSeconds());
 
 	m_rasterizer->BeginFrame(m_frameTime);
 
@@ -266,12 +270,13 @@ void KX_KetsjiEngine::EndFrame()
 {
 	m_rasterizer->MotionBlur();
 
+	// Show profiling info
+	m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
+
 	for (RAS_Query& query : m_renderQueries) {
 		query.End();
 	}
 
-	// Show profiling info
-	m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
 	if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES | SHOW_RENDER_QUERIES)) {
 		RenderDebugProperties();
 	}

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -51,6 +51,7 @@
 #include "RAS_Rasterizer.h"
 #include "RAS_ICanvas.h"
 #include "RAS_OffScreen.h"
+#include "RAS_Query.h"
 #include "RAS_ILightObject.h"
 #include "MT_Vector3.h"
 #include "MT_Transform.h"
@@ -135,6 +136,12 @@ const std::string KX_KetsjiEngine::m_profileLabels[tc_numCategories] = {
 	"GPU Latency:" // tc_latency
 };
 
+const std::string KX_KetsjiEngine::m_renderQueriesLabels[QUERY_MAX] = {
+	"Samples:", // QUERY_SAMPLES
+	"Primitives:", // QUERY_PRIMITIVES
+	"Time:" // QUERY_TIME
+};
+
 /**
  * Constructor of the Ketsji Engine
  */
@@ -171,6 +178,10 @@ KX_KetsjiEngine::KX_KetsjiEngine(KX_ISystem *system)
 	for (int i = tc_first; i < tc_numCategories; i++) {
 		m_logger.AddCategory((KX_TimeCategory)i);
 	}
+
+	m_renderQueries.push_back(RAS_Query(RAS_Query::SAMPLES));
+	m_renderQueries.push_back(RAS_Query(RAS_Query::PRIMITIVES));
+	m_renderQueries.push_back(RAS_Query(RAS_Query::TIME));
 
 #ifdef WITH_PYTHON
 	m_pyprofiledict = PyDict_New();
@@ -242,6 +253,10 @@ void KX_KetsjiEngine::StartEngine()
 
 void KX_KetsjiEngine::BeginFrame()
 {
+	for (RAS_Query& query : m_renderQueries) {
+		query.Begin();
+	}
+
 	m_rasterizer->BeginFrame(m_frameTime);
 
 	m_canvas->BeginDraw();
@@ -251,9 +266,13 @@ void KX_KetsjiEngine::EndFrame()
 {
 	m_rasterizer->MotionBlur();
 
+	for (RAS_Query& query : m_renderQueries) {
+		query.End();
+	}
+
 	// Show profiling info
 	m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
-	if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
+	if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES | SHOW_RENDER_QUERIES)) {
 		RenderDebugProperties();
 	}
 
@@ -1185,6 +1204,26 @@ void KX_KetsjiEngine::RenderDebugProperties()
 			ycoord += const_ysize;
 		}
 	}
+
+	if (m_flags & SHOW_RENDER_QUERIES) {
+		debugDraw.RenderText2D("Render Queries :", MT_Vector2(xcoord + const_xindent + title_xmargin, ycoord), white);
+		ycoord += const_ysize;
+
+		for (unsigned short i = 0; i < QUERY_MAX; ++i) {
+			debugDraw.RenderText2D(m_renderQueriesLabels[i], MT_Vector2(xcoord + const_xindent, ycoord), white);
+
+			if (i == QUERY_TIME) {
+				debugtxt = (boost::format("%.2fms") % (((float)m_renderQueries[i].Result()) / 1e6)).str();
+			}
+			else {
+				debugtxt = (boost::format("%i") % m_renderQueries[i].Result()).str();
+			}
+
+			debugDraw.RenderText2D(debugtxt, MT_Vector2(xcoord + const_xindent + profile_indent, ycoord), white);
+			ycoord += const_ysize;
+		}
+	}
+
 	// Add the ymargin for titles below the other section of debug info
 	ycoord += title_y_top_margin;
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -50,6 +50,7 @@ class BL_BlenderConverter;
 class KX_NetworkMessageManager;
 class RAS_ICanvas;
 class RAS_OffScreen;
+class RAS_Query;
 class SCA_IInputDevice;
 
 enum class KX_ExitRequest
@@ -88,18 +89,20 @@ public:
 		SHOW_PROFILE = (1 << 0),
 		/// Show the framerate on the game display?
 		SHOW_FRAMERATE = (1 << 1),
+		/// Process and show render queries?
+		SHOW_RENDER_QUERIES = (1 << 2),
 		/// Show debug properties on the game display.
-		SHOW_DEBUG_PROPERTIES = (1 << 2),
+		SHOW_DEBUG_PROPERTIES = (1 << 3),
 		/// Whether or not to lock animation updates to the animation framerate?
-		RESTRICT_ANIMATION = (1 << 3),
+		RESTRICT_ANIMATION = (1 << 4),
 		/// Display of fixed frames?
-		FIXED_FRAMERATE = (1 << 4),
+		FIXED_FRAMERATE = (1 << 5),
 		/// BGE relies on a external clock or its own internal clock?
-		USE_EXTERNAL_CLOCK = (1 << 5),
+		USE_EXTERNAL_CLOCK = (1 << 6),
 		/// Automatic add debug properties to the debug list.
-		AUTO_ADD_DEBUG_PROPERTIES = (1 << 6),
+		AUTO_ADD_DEBUG_PROPERTIES = (1 << 7),
 		/// Use override camera?
-		CAMERA_OVERRIDE = (1 << 7)
+		CAMERA_OVERRIDE = (1 << 8)
 	};
 
 private:
@@ -227,9 +230,19 @@ private:
 
 	/// Time logger.
 	KX_TimeCategoryLogger m_logger;
-
 	/// Labels for profiling display.
 	static const std::string m_profileLabels[tc_numCategories];
+
+	enum QueryCategory {
+		QUERY_SAMPLES = 0,
+		QUERY_PRIMITIVES,
+		QUERY_TIME,
+		QUERY_MAX
+	};
+
+	std::vector<RAS_Query> m_renderQueries;
+	static const std::string m_renderQueriesLabels[QUERY_MAX];
+
 	/// Last estimated framerate
 	double m_average_framerate;
 

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -147,6 +147,7 @@ void LA_Launcher::InitEngine()
 	// WARNING: Fixed time is the opposite of fixed framerate.
 	bool fixed_framerate = (SYS_GetCommandLineInt(syshandle, "fixedtime", (gm.flag & GAME_ENABLE_ALL_FRAMES)) == 0);
 	bool frameRate = (SYS_GetCommandLineInt(syshandle, "show_framerate", 0) != 0);
+	bool renderQueries = (SYS_GetCommandLineInt(syshandle, "show_render_queries", 0) != 0);
 	short showBoundingBox = SYS_GetCommandLineInt(syshandle, "show_bounding_box", gm.showBoundingBox);
 	short showArmatures = SYS_GetCommandLineInt(syshandle, "show_armatures", gm.showArmatures);
 	short showCameraFrustum = SYS_GetCommandLineInt(syshandle, "show_camera_frustum", gm.showCameraFrustum);
@@ -157,6 +158,7 @@ void LA_Launcher::InitEngine()
 	const KX_KetsjiEngine::FlagType flags = (KX_KetsjiEngine::FlagType)
 		((fixed_framerate ? KX_KetsjiEngine::FIXED_FRAMERATE : 0) |
 		(frameRate ? KX_KetsjiEngine::SHOW_FRAMERATE : 0) |
+		(renderQueries ? KX_KetsjiEngine::SHOW_RENDER_QUERIES : 0) |
 		(restrictAnimFPS ? KX_KetsjiEngine::RESTRICT_ANIMATION : 0) |
 		(properties ? KX_KetsjiEngine::SHOW_DEBUG_PROPERTIES : 0) |
 		(profile ? KX_KetsjiEngine::SHOW_PROFILE : 0));

--- a/source/gameengine/Rasterizer/RAS_Query.cpp
+++ b/source/gameengine/Rasterizer/RAS_Query.cpp
@@ -41,7 +41,10 @@ RAS_Query::RAS_Query(QueryType type)
 
 RAS_Query::~RAS_Query() = default;
 
-RAS_Query::RAS_Query(RAS_Query&& other) = default;
+RAS_Query::RAS_Query(RAS_Query&& other)
+: m_impl(std::move(other.m_impl))
+{
+}
 
 void RAS_Query::Begin()
 {

--- a/source/gameengine/Rasterizer/RAS_Query.cpp
+++ b/source/gameengine/Rasterizer/RAS_Query.cpp
@@ -29,12 +29,19 @@
 #include "RAS_Query.h"
 #include "RAS_OpenGLQuery.h"
 
+RAS_Query::RAS_Query()
+{
+}
+
+
 RAS_Query::RAS_Query(QueryType type)
 	:m_impl(new RAS_OpenGLQuery(type))
 {
 }
 
 RAS_Query::~RAS_Query() = default;
+
+RAS_Query::RAS_Query(RAS_Query&& other) = default;
 
 void RAS_Query::Begin()
 {

--- a/source/gameengine/Rasterizer/RAS_Query.h
+++ b/source/gameengine/Rasterizer/RAS_Query.h
@@ -51,8 +51,12 @@ public:
 		TIME
 	};
 
+	RAS_Query();
 	RAS_Query(QueryType type);
 	~RAS_Query();
+
+	RAS_Query(const RAS_Query& other) = delete;
+	RAS_Query(RAS_Query&& other);
 
 	/// Begin the query.
 	void Begin();


### PR DESCRIPTION
This branch allow the user to see OpenGL render queries for numbers of samples/primitives and render time on GPU.

The user just have to enable the "Render Queries" option in UI.

Note: the framerate is affect by the queries as they request flush of OpenGL draw calls before reading their result.