### PR TITLE
Implement custom camera viewport in UI.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_data_camera.py
+++ b/release/scripts/startup/bl_ui/properties_data_camera.py
@@ -168,6 +168,36 @@ class DATA_PT_frustum_culling(CameraButtonsPanel, Panel):
         row.prop(cam, "override_culling")
 
 
+class DATA_PT_game_viewport(CameraButtonsPanel, Panel):
+    bl_label = "Custom Viewport"
+    COMPAT_ENGINES = {'BLENDER_GAME'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.camera and context.scene.render.engine in cls.COMPAT_ENGINES
+
+    def draw_header(self, context):
+        cam = context.camera
+
+        self.layout.prop(cam, "use_viewport", text="")
+
+    def draw(self, context):
+        layout = self.layout
+        cam = context.camera
+        viewport = cam.viewport
+
+        split = layout.split()
+        split.active = cam.use_viewport
+
+        col = split.column()
+        col.prop(viewport, "left_ratio")
+        col.prop(viewport, "right_ratio")
+
+        col = split.column()
+        col.prop(viewport, "bottom_ratio")
+        col.prop(viewport, "top_ratio")
+
+
 class DATA_PT_camera_stereoscopy(CameraButtonsPanel, Panel):
     bl_label = "Stereoscopy"
     COMPAT_ENGINES = {'BLENDER_RENDER'}
@@ -366,6 +396,7 @@ classes = (
     DATA_PT_camera,
     DATA_PT_levels_of_detail,
     DATA_PT_frustum_culling,
+    DATA_PT_game_viewport,
     DATA_PT_camera_stereoscopy,
     DATA_PT_camera_dof,
     DATA_PT_camera_display,

--- a/source/blender/blenkernel/intern/camera.c
+++ b/source/blender/blenkernel/intern/camera.c
@@ -81,6 +81,10 @@ void BKE_camera_init(Camera *cam)
 	cam->stereo.convergence_distance = 30.f * 0.065f;
 	cam->stereo.pole_merge_angle_from = DEG2RADF(60.0f);
 	cam->stereo.pole_merge_angle_to = DEG2RADF(75.0f);
+
+	/* game viewport */
+	cam->gameviewport.rightratio = 1.0f;
+	cam->gameviewport.topratio = 1.0f;
 }
 
 void *BKE_camera_add(Main *bmain, const char *name)

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -242,4 +242,11 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
 			}
 		}
 	}
+	if (!MAIN_VERSION_UPBGE_ATLEAST(main, 2, 0)) {
+		if (!DNA_struct_elem_find(fd->filesdna, "Camera", "GameCameraViewportSettings", "viewport")) {
+			for (Scene *scene = main->scene.first; scene; scene = scene->id.next) {
+				scene->gm.timeScale = 1.0f;
+			}
+		}
+	}
 }

--- a/source/blender/makesdna/DNA_camera_types.h
+++ b/source/blender/makesdna/DNA_camera_types.h
@@ -59,6 +59,13 @@ typedef struct CameraStereoSettings {
 	float pole_merge_angle_to;
 } CameraStereoSettings;
 
+typedef struct GameCameraViewportSettings {
+	float leftratio;
+	float rightratio;
+	float bottomratio;
+	float topratio;
+} GameCameraViewportSettings;
+
 typedef struct Camera {
 	ID id;
 	struct AnimData *adt;	/* animation data (must be immediately after id for utilities to use it) */ 
@@ -68,6 +75,7 @@ typedef struct Camera {
 	short flag;
 	short gameflag;
 	short pad2;
+	struct GameCameraViewportSettings gameviewport;
 	float passepartalpha;
 	float clipsta, clipend;
 	float lens, ortho_scale, drawsize;
@@ -134,6 +142,7 @@ enum {
 enum {
 	GAME_CAM_SHOW_FRUSTUM		= (1 << 0),
 	GAME_CAM_OVERRIDE_CULLING	= (1 << 1),
+	GAME_CAM_VIEWPORT			= (1 << 2),
 };
 
 /* yafray: dof sampling switch */

--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -171,6 +171,35 @@ static void rna_def_camera_stereo_data(BlenderRNA *brna)
 	RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, NULL);
 }
 
+static void rna_def_game_camera_viewport_data(BlenderRNA *brna)
+{
+	StructRNA *srna;
+	PropertyRNA *prop;
+
+	srna = RNA_def_struct(brna, "GameCameraViewportData", NULL);
+	RNA_def_struct_sdna(srna, "GameCameraViewportSettings");
+	RNA_def_struct_nested(brna, srna, "Camera");
+	RNA_def_struct_ui_text(srna, "Viewport", "Game custom camera viewport settings");
+
+	prop = RNA_def_property(srna, "left_ratio", PROP_FLOAT, PROP_FACTOR);
+	RNA_def_property_float_sdna(prop, NULL, "leftratio");
+	RNA_def_property_ui_text(prop, "Left Ratio", "Set camera viewport left to a ratio of the entire viewport");
+
+	prop = RNA_def_property(srna, "right_ratio", PROP_FLOAT, PROP_FACTOR);
+	RNA_def_property_float_sdna(prop, NULL, "rightratio");
+	RNA_def_property_float_default(prop, 1.0f);
+	RNA_def_property_ui_text(prop, "Right Ratio", "Set camera viewport right to a ratio of the entire viewport");
+
+	prop = RNA_def_property(srna, "bottom_ratio", PROP_FLOAT, PROP_FACTOR);
+	RNA_def_property_float_sdna(prop, NULL, "bottomratio");
+	RNA_def_property_ui_text(prop, "Bottom Ratio", "Set camera viewport bottom to a ratio of the entire viewport");
+
+	prop = RNA_def_property(srna, "top_ratio", PROP_FLOAT, PROP_FACTOR);
+	RNA_def_property_float_sdna(prop, NULL, "topratio");
+	RNA_def_property_float_default(prop, 1.0f);
+	RNA_def_property_ui_text(prop, "Top Ratio", "Set camera viewport top to a ratio of the entire viewport");
+}
+
 void RNA_def_camera(BlenderRNA *brna)
 {
 	StructRNA *srna;
@@ -339,6 +368,12 @@ void RNA_def_camera(BlenderRNA *brna)
 	RNA_def_property_struct_type(prop, "CameraStereoData");
 	RNA_def_property_ui_text(prop, "Stereo", "");
 
+	/* Stereo Settings */
+	prop = RNA_def_property(srna, "viewport", PROP_POINTER, PROP_NONE);
+	RNA_def_property_flag(prop, PROP_NEVER_NULL);
+	RNA_def_property_pointer_sdna(prop, NULL, "gameviewport");
+	RNA_def_property_struct_type(prop, "GameCameraViewportData");
+
 	/* flag */
 	prop = RNA_def_property(srna, "override_culling", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_OVERRIDE_CULLING);
@@ -347,6 +382,11 @@ void RNA_def_camera(BlenderRNA *brna)
 
 	prop = RNA_def_property(srna, "show_frustum", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_SHOW_FRUSTUM);
+	RNA_def_property_ui_text(prop, "Show Frustum", "Show a visualization of frustum in Game Engine");
+	RNA_def_property_update(prop, NC_CAMERA, NULL);
+
+	prop = RNA_def_property(srna, "use_viewport", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_VIEWPORT);
 	RNA_def_property_ui_text(prop, "Show Frustum", "Show a visualization of frustum in Game Engine");
 	RNA_def_property_update(prop, NC_CAMERA, NULL);
 
@@ -412,6 +452,9 @@ void RNA_def_camera(BlenderRNA *brna)
 
 	/* *** Animated *** */
 	rna_def_camera_stereo_data(brna);
+
+	/* Game Data */
+	rna_def_game_camera_viewport_data(brna);
 
 	/* Camera API */
 	RNA_api_camera(srna);


### PR DESCRIPTION
Previously the camera were able to use custom viewport only
in python.
An UI is created to do the same based on entire viewport
ratios. The UI expose an option named "Custom Viewport"
and four ratio for left, right, bottom and top. These ratio
correspond with the width or height of the canvas multiplied
by the ratio.