### PR TITLE
Implement SCA_InputEvent attribute helpers.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.SCA_InputEvent.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_InputEvent.rst
@@ -46,6 +46,30 @@ base class --- :class:`PyObjectPlus`
 
       :type: list of integer.
 
+   .. attribute:: up
+
+      True if the input was up from the last frame.
+
+      :type: boolean
+
+   .. attribute:: down
+
+      True if the input was down from the last frame.
+
+      :type: boolean
+
+   .. attribute:: pressed
+
+      True if the input was pressed from the last frame.
+
+      :type: boolean
+
+   .. attribute:: released
+
+      True if the input was released from the last frame.
+
+      :type: boolean
+
    .. attribute:: type
 
       The type of the input.

--- a/source/gameengine/GameLogic/SCA_InputEvent.cpp
+++ b/source/gameengine/GameLogic/SCA_InputEvent.cpp
@@ -121,6 +121,10 @@ PyAttributeDef SCA_InputEvent::Attributes[] = {
 	KX_PYATTRIBUTE_RO_FUNCTION("status", SCA_InputEvent, pyattr_get_status),
 	KX_PYATTRIBUTE_RO_FUNCTION("queue", SCA_InputEvent, pyattr_get_queue),
 	KX_PYATTRIBUTE_RO_FUNCTION("values", SCA_InputEvent, pyattr_get_values),
+	KX_PYATTRIBUTE_RO_FUNCTION("up", SCA_InputEvent, pyattr_get_up),
+	KX_PYATTRIBUTE_RO_FUNCTION("down", SCA_InputEvent, pyattr_get_down),
+	KX_PYATTRIBUTE_RO_FUNCTION("pressed", SCA_InputEvent, pyattr_get_pressed),
+	KX_PYATTRIBUTE_RO_FUNCTION("released", SCA_InputEvent, pyattr_get_released),
 	KX_PYATTRIBUTE_INT_RO("type", SCA_InputEvent, m_type),
 	KX_PYATTRIBUTE_NULL //Sentinel
 };
@@ -189,6 +193,34 @@ PyObject *SCA_InputEvent::pyattr_get_values(PyObjectPlus *self_v, const KX_PYATT
 							 nullptr,
 							 nullptr,
 							 CListWrapper::FLAG_FIND_VALUE))->NewProxy(true);
+}
+
+PyObject *SCA_InputEvent::pyattr_get_up(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_InputEvent *self = static_cast<SCA_InputEvent *>(self_v);
+
+	return PyBool_FromLong(self->Find(SCA_InputEvent::NONE));
+}
+
+PyObject *SCA_InputEvent::pyattr_get_down(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_InputEvent *self = static_cast<SCA_InputEvent *>(self_v);
+
+	return PyBool_FromLong(self->Find(SCA_InputEvent::ACTIVE));
+}
+
+PyObject *SCA_InputEvent::pyattr_get_pressed(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_InputEvent *self = static_cast<SCA_InputEvent *>(self_v);
+
+	return PyBool_FromLong(self->Find(SCA_InputEvent::JUSTACTIVATED));
+}
+
+PyObject *SCA_InputEvent::pyattr_get_released(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
+{
+	SCA_InputEvent *self = static_cast<SCA_InputEvent *>(self_v);
+
+	return PyBool_FromLong(self->Find(SCA_InputEvent::JUSTRELEASED));
 }
 
 #endif  // WITH_PYTHON

--- a/source/gameengine/GameLogic/SCA_InputEvent.h
+++ b/source/gameengine/GameLogic/SCA_InputEvent.h
@@ -78,6 +78,10 @@ public:
 	static PyObject *pyattr_get_status(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_queue(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_values(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_up(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_down(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_pressed(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_released(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef);
 #endif
 };
 


### PR DESCRIPTION
Previously the user needed to read the values or queue list
in an input to know if it was up, down, pressed or released.
To simplify this and avoid the lookup in list from python
attributes are added in SCA_InputEvent to do the same, they
are:
up
down
pressed
released

Note that when they are the status of the input from the last
frame so when an input is released then it is both up and down.