### PR TITLE
Corrected reversed values.

### DIFF
--- a/source/blender/python/generic/bgl.c
+++ b/source/blender/python/generic/bgl.c
@@ -869,7 +869,7 @@ static int Buffer_ass_slice(Buffer *self, int begin, int end, PyObject *seq)
 	if ((count = PySequence_Size(seq)) != (end - begin)) {
 		PyErr_Format(PyExc_TypeError,
 		             "buffer[:] = value, size mismatch in assignment. "
-		             "Expected: %d (given: %d)", count, end - begin);
+		             "Expected: %d (given: %d)", end - begin, count);
 		return -1;
 	}
 	


### PR DESCRIPTION
Previously, input was displayed after 'expected' and expected value was displayed after 'given'