### PR TITLE
Add component script generation.

### DIFF
--- a/release/scripts/startup/bl_ui/space_logic.py
+++ b/release/scripts/startup/bl_ui/space_logic.py
@@ -39,14 +39,15 @@ class LOGIC_PT_components(bpy.types.Panel):
         st = context.space_data
 
         row = layout.row()
-        row.operator("logic.add_python_component", text="Add Component", icon="ZOOMIN")
+        row.operator("logic.python_component_register", text="Register Component", icon="ZOOMIN")
+        row.operator("logic.python_component_create", text="Create Component", icon="ZOOMIN")
 
         for i, c in enumerate(game.components):
             box = layout.box()
             row = box.row()
             row.prop(c, "name", text="")
-            row.operator("logic.component_reload", text="", icon='RECOVER_LAST').index = i
-            row.operator("logic.component_remove", text="", icon='X').index = i
+            row.operator("logic.python_component_reload", text="", icon='RECOVER_LAST').index = i
+            row.operator("logic.python_component_remove", text="", icon='X').index = i
 
             for prop in c.properties:
                 row = box.row()

--- a/release/scripts/templates_py/python_component.py
+++ b/release/scripts/templates_py/python_component.py
@@ -2,8 +2,8 @@ import bge
 from collections import OrderedDict
 
 if not hasattr(bge, "__component__"):
-	# Put shared definitions here executed only in game engine.
-	# e.g:
+    # Put shared definitions here executed only in game engine.
+    # e.g:
     # scene = bge.logic.getCurrentScene()
     pass
 

--- a/release/scripts/templates_py/python_component.py
+++ b/release/scripts/templates_py/python_component.py
@@ -1,0 +1,24 @@
+import bge
+from collections import OrderedDict
+
+if not hasattr(bge, "__component__"):
+	# Put shared definitions here executed only in game engine.
+	# e.g:
+    # scene = bge.logic.getCurrentScene()
+    pass
+
+class %Name%(bge.types.KX_PythonComponent):
+    # Put your arguments here of the format ("key", default_value).
+    # These values are exposed to the UI.
+    args = OrderedDict([
+    ])
+
+    def start(self, args):
+        # Put your initialization code here, args stores the values from the UI.
+        # self.object is the owner object of this component.
+        pass
+
+    def update(self):
+        # Put your code executed every logic step here.
+        # self.object is the owner object of this component.
+        pass

--- a/source/blender/blenkernel/BKE_python_component.h
+++ b/source/blender/blenkernel/BKE_python_component.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 struct PythonComponent *BKE_python_component_new(char *import, struct ReportList *reports, struct bContext *context);
+struct PythonComponent *BKE_python_component_create_file(char *import, struct ReportList *reports, struct bContext *context);
 void BKE_python_component_reload(struct PythonComponent *pc, struct ReportList *reports, struct bContext *context);
 void BKE_python_component_copy_list(struct ListBase *lbn, const struct ListBase *lbo);
 void BKE_python_component_free(struct PythonComponent *pc);


### PR DESCRIPTION
To ease the definition of a component a button named "Create Component" is added.
This button ask for a path module.Class and generates a script named module.py
with a component class Class inside.
This template class contains a start and update function commented
and a definition block before the class for global game engine variable.

If the file already exists an error is raised.

The previous button named Add Component is now renamed Register Component.