### PR TITLE
Simplify SG_Controller interaction with SG_Node.

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -620,7 +620,7 @@ static void BL_CreateGraphicObjectNew(KX_GameObject *gameobj, KX_Scene *kxscene,
 		{
 			CcdPhysicsEnvironment *env = (CcdPhysicsEnvironment *)kxscene->GetPhysicsEnvironment();
 			BLI_assert(env);
-			PHY_IMotionState *motionstate = new KX_MotionState(gameobj->GetSGNode());
+			PHY_IMotionState *motionstate = new KX_MotionState(gameobj->GetNode());
 			CcdGraphicController *ctrl = new CcdGraphicController(env, motionstate);
 			gameobj->SetGraphicController(ctrl);
 			ctrl->SetNewClientInfo(&gameobj->GetClientInfo());
@@ -676,7 +676,7 @@ static void BL_CreatePhysicsObjectNew(KX_GameObject *gameobj, Object *blenderobj
 		return;
 	}
 
-	PHY_IMotionState *motionstate = new KX_MotionState(gameobj->GetSGNode());
+	PHY_IMotionState *motionstate = new KX_MotionState(gameobj->GetNode());
 
 	PHY_IPhysicsEnvironment *phyenv = kxscene->GetPhysicsEnvironment();
 	phyenv->ConvertObject(converter, gameobj, meshobj, kxscene, motionstate, activeLayerBitInfo,
@@ -1117,7 +1117,7 @@ static void bl_ConvertBlenderObject_Single(BL_SceneConverter& converter,
 	gameobj->NodeSetLocalPosition(pos);
 	gameobj->NodeSetLocalOrientation(rotation);
 	gameobj->NodeSetLocalScale(scale);
-	gameobj->NodeUpdateGS();
+	gameobj->NodeUpdate();
 
 	sumolist->Add(CM_AddRef(gameobj));
 
@@ -1147,7 +1147,7 @@ static void bl_ConvertBlenderObject_Single(BL_SceneConverter& converter,
 		parentinversenode->SetLocalPosition(mt::vec3(invp_loc));
 		parentinversenode->SetLocalOrientation(mt::mat3(invp_rot));
 		parentinversenode->SetLocalScale(mt::vec3(invp_size));
-		parentinversenode->AddChild(gameobj->GetSGNode());
+		parentinversenode->AddChild(gameobj->GetNode());
 	}
 
 	// Needed for python scripting.
@@ -1167,7 +1167,7 @@ static void bl_ConvertBlenderObject_Single(BL_SceneConverter& converter,
 	if (isInActiveLayer) {
 		objectlist->Add(CM_AddRef(gameobj));
 
-		gameobj->NodeUpdateGS();
+		gameobj->NodeUpdate();
 	}
 	else {
 		// We must store this object otherwise it will be deleted at the end of this function if it is not a root object.
@@ -1409,7 +1409,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
 			 * This weird situation is used in Apricot for test purposes.
 			 * Resolve it by not converting the child
 			 */
-			childobj->GetSGNode()->DisconnectFromParent();
+			childobj->GetNode()->DisconnectFromParent();
 			delete link.m_gamechildnode;
 			/* Now destroy the child object but also all its descendent that may already be linked
 			 * Remove the child reference in the local list!
@@ -1472,15 +1472,15 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
 			}
 		}
 
-		parentobj->GetSGNode()->AddChild(link.m_gamechildnode);
+		parentobj->GetNode()->AddChild(link.m_gamechildnode);
 	}
 	vec_parent_child.clear();
 
 	// Find 'root' parents (object that has not parents in SceneGraph).
 	for (KX_GameObject *gameobj : sumolist) {
-		if (!gameobj->GetSGNode()->GetSGParent()) {
+		if (!gameobj->GetNode()->GetParent()) {
 			parentlist->Add(CM_AddRef(gameobj));
-			gameobj->NodeUpdateGS();
+			gameobj->NodeUpdate();
 		}
 	}
 

--- a/source/gameengine/Converter/BL_IpoConvert.cpp
+++ b/source/gameengine/Converter/BL_IpoConvert.cpp
@@ -82,7 +82,6 @@ static BL_InterpolatorList *GetAdtList(struct bAction *for_act, KX_Scene *scene)
 SG_Controller *BL_CreateIPO(struct bAction *action, KX_GameObject *gameobj, KX_Scene *scene)
 {
 	KX_IpoController *ipocontr = new KX_IpoController();
-	ipocontr->SetGameObject(gameobj);
 
 	Object *blenderobject = gameobj->GetBlenderObject();
 

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -108,7 +108,7 @@ void BL_Action::ClearControllerList()
 	std::vector<SG_Controller *>::iterator it;
 	for (it = m_sg_contr_list.begin(); it != m_sg_contr_list.end(); it++)
 	{
-		m_obj->GetSGNode()->RemoveSGController((*it));
+		m_obj->GetNode()->RemoveController((*it));
 		delete *it;
 	}
 
@@ -169,23 +169,23 @@ bool BL_Action::Play(const std::string& name,
 	// Create an SG_Controller
 	SG_Controller *sg_contr = BL_CreateIPO(m_action, m_obj, kxscene);
 	m_sg_contr_list.push_back(sg_contr);
-	m_obj->GetSGNode()->AddSGController(sg_contr);
-	sg_contr->SetNode(m_obj->GetSGNode());
+	m_obj->GetNode()->AddController(sg_contr);
+	sg_contr->SetNode(m_obj->GetNode());
 
 	// World
 	sg_contr = BL_CreateWorldIPO(m_action, kxscene->GetBlenderScene()->world, kxscene);
 	if (sg_contr) {
 		m_sg_contr_list.push_back(sg_contr);
-		m_obj->GetSGNode()->AddSGController(sg_contr);
-		sg_contr->SetNode(m_obj->GetSGNode());
+		m_obj->GetNode()->AddController(sg_contr);
+		sg_contr->SetNode(m_obj->GetNode());
 	}
 
 	// Try obcolor
 	sg_contr = BL_CreateObColorIPO(m_action, m_obj, kxscene);
 	if (sg_contr) {
 		m_sg_contr_list.push_back(sg_contr);
-		m_obj->GetSGNode()->AddSGController(sg_contr);
-		sg_contr->SetNode(m_obj->GetSGNode());
+		m_obj->GetNode()->AddController(sg_contr);
+		sg_contr->SetNode(m_obj->GetNode());
 	}
 
 	// Now try materials
@@ -196,8 +196,8 @@ bool BL_Action::Play(const std::string& name,
 			sg_contr = BL_CreateMaterialIpo(m_action, polymat, m_obj, kxscene);
 			if (sg_contr) {
 				m_sg_contr_list.push_back(sg_contr);
-				m_obj->GetSGNode()->AddSGController(sg_contr);
-				sg_contr->SetNode(m_obj->GetSGNode());
+				m_obj->GetNode()->AddController(sg_contr);
+				sg_contr->SetNode(m_obj->GetNode());
 			}
 		}
 	}
@@ -206,14 +206,14 @@ bool BL_Action::Play(const std::string& name,
 	if (m_obj->GetGameObjectType() == SCA_IObject::OBJ_LIGHT) {
 		sg_contr = BL_CreateLampIPO(m_action, m_obj, kxscene);
 		m_sg_contr_list.push_back(sg_contr);
-		m_obj->GetSGNode()->AddSGController(sg_contr);
-		sg_contr->SetNode(m_obj->GetSGNode());
+		m_obj->GetNode()->AddController(sg_contr);
+		sg_contr->SetNode(m_obj->GetNode());
 	}
 	else if (m_obj->GetGameObjectType() == SCA_IObject::OBJ_CAMERA) {
 		sg_contr = BL_CreateCameraIPO(m_action, m_obj, kxscene);
 		m_sg_contr_list.push_back(sg_contr);
-		m_obj->GetSGNode()->AddSGController(sg_contr);
-		sg_contr->SetNode(m_obj->GetSGNode());
+		m_obj->GetNode()->AddController(sg_contr);
+		sg_contr->SetNode(m_obj->GetNode());
 	}
 
 	m_ipo_flags = ipo_flags;

--- a/source/gameengine/Ketsji/BL_Action.h
+++ b/source/gameengine/Ketsji/BL_Action.h
@@ -77,6 +77,7 @@ private:
 	float m_prevUpdate;
 
 	void ClearControllerList();
+	void AddController(SG_Controller *cont);
 	void InitIPO();
 	void SetLocalTime(float curtime);
 	void ResetStartTime(float curtime);

--- a/source/gameengine/Ketsji/KX_BoneParentNodeRelationship.cpp
+++ b/source/gameengine/Ketsji/KX_BoneParentNodeRelationship.cpp
@@ -57,7 +57,7 @@ bool KX_BoneParentRelation::UpdateChildCoordinates(SG_Node *child, const SG_Node
 	bool valid_parent_transform = false;
 
 	if (parent) {
-		BL_ArmatureObject *armature = (BL_ArmatureObject *)(parent->GetSGClientObject());
+		BL_ArmatureObject *armature = (BL_ArmatureObject *)(parent->GetClientObject());
 		if (armature) {
 			mt::mat3x4 bonetrans;
 			if (armature->GetBoneTransform(m_bone, bonetrans)) {

--- a/source/gameengine/Ketsji/KX_CameraIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_CameraIpoSGController.cpp
@@ -34,13 +34,13 @@
 #include "KX_Camera.h"
 #include "RAS_CameraData.h"
 
-bool KX_CameraIpoSGController::Update()
+bool KX_CameraIpoSGController::Update(SG_Node *node)
 {
-	if (!SG_Controller::Update()) {
+	if (!SG_Controller::Update(node)) {
 		return false;
 	}
 
-	KX_Camera *kxcamera = (KX_Camera *)m_node->GetClientObject();
+	KX_Camera *kxcamera = static_cast<KX_Camera *>(node->GetClientObject());
 	RAS_CameraData *camdata = kxcamera->GetCameraData();
 
 	if (m_modify_lens) {

--- a/source/gameengine/Ketsji/KX_CameraIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_CameraIpoSGController.cpp
@@ -40,7 +40,7 @@ bool KX_CameraIpoSGController::Update()
 		return false;
 	}
 
-	KX_Camera *kxcamera = (KX_Camera *)m_node->GetSGClientObject();
+	KX_Camera *kxcamera = (KX_Camera *)m_node->GetClientObject();
 	RAS_CameraData *camdata = kxcamera->GetCameraData();
 
 	if (m_modify_lens) {

--- a/source/gameengine/Ketsji/KX_CameraIpoSGController.h
+++ b/source/gameengine/Ketsji/KX_CameraIpoSGController.h
@@ -59,7 +59,7 @@ public:
 		{}
 
 	virtual ~KX_CameraIpoSGController() = default;
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 
 	void	SetModifyLens(bool modify) {
 		m_modify_lens = modify;

--- a/source/gameengine/Ketsji/KX_ConstraintActuator.cpp
+++ b/source/gameengine/Ketsji/KX_ConstraintActuator.cpp
@@ -531,7 +531,7 @@ bool KX_ConstraintActuator::Update(double curtime)
 			case KX_ACT_CONSTRAINT_LOCX:
 			case KX_ACT_CONSTRAINT_LOCY:
 			case KX_ACT_CONSTRAINT_LOCZ:
-				newposition = position = obj->GetSGNode()->GetLocalPosition();
+				newposition = position = obj->GetNode()->GetLocalPosition();
 				switch (m_locrot) {
 					case KX_ACT_CONSTRAINT_LOCX:
 					{

--- a/source/gameengine/Ketsji/KX_CullingHandler.cpp
+++ b/source/gameengine/Ketsji/KX_CullingHandler.cpp
@@ -11,7 +11,7 @@ KX_CullingHandler::KX_CullingHandler(std::vector<KX_GameObject *>& objects, cons
 
 void KX_CullingHandler::Process(KX_GameObject *object)
 {
-	SG_Node *sgnode = object->GetSGNode();
+	SG_Node *sgnode = object->GetNode();
 	SG_CullingNode *node = object->GetCullingNode();
 
 	const mt::mat3x4 trans = sgnode->GetWorldTransform();

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -490,7 +490,7 @@ public:
 	// adapt local position so that world position is set to desired position
 	void	NodeSetWorldPosition(const mt::vec3& trans);
 
-	void NodeUpdateGS();
+	void NodeUpdate();
 
 	const mt::mat3& NodeGetWorldOrientation(  ) const;
 	const mt::vec3& NodeGetWorldScaling(  ) const;
@@ -506,12 +506,12 @@ public:
 	 * \section scene graph node accessor functions.
 	 */
 
-	SG_Node*	GetSGNode(	) 
+	SG_Node*	GetNode(	) 
 	{ 
 		return m_sgNode.get();
 	}
 
-	const 	SG_Node* GetSGNode(	) const
+	const 	SG_Node* GetNode(	) const
 	{ 
 		return m_sgNode.get();
 	}
@@ -537,7 +537,7 @@ public:
 	 * old node. This class takes ownership of the new
 	 * node.
 	 */
-	void SetSGNode(SG_Node *node);
+	void SetNode(SG_Node *node);
 	
 	/// Is it a dynamic/physics object ?
 	bool IsDynamic() const;
@@ -549,7 +549,7 @@ public:
 	 */
 	bool IsVertexParent( )
 	{
-		return (m_sgNode && m_sgNode->GetSGParent() && m_sgNode->GetSGParent()->IsVertexParent());
+		return (m_sgNode && m_sgNode->GetParent() && m_sgNode->GetParent()->IsVertexParent());
 	}
 
 	/// \see KX_RayCast

--- a/source/gameengine/Ketsji/KX_IpoController.h
+++ b/source/gameengine/Ketsji/KX_IpoController.h
@@ -74,17 +74,11 @@ class KX_IpoController : public SG_Controller, public mt::SimdClassAllocator
 	/** true is m_ipo_start_euler has been initialized */
 	bool m_ipo_euler_initialized;
 
-	/** A reference to the original game object. */
-	class KX_GameObject *m_game_object;
-
 public:
 	KX_IpoController();
 	virtual ~KX_IpoController() = default;
 
 	virtual void SetOption(SG_ControllerOption option, bool value);
-
-	/** Set reference to the corresponding game object. */
-	void SetGameObject(class KX_GameObject *go);
 
 	void SetIPOChannelActive(int index, bool value) {
 		//indexes found in makesdna\DNA_ipo_types.h
@@ -96,7 +90,7 @@ public:
 		return m_ipo_xform;
 	}
 
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 };
 
 #endif  /* __KX_IPO_SGCONTROLLER_H__ */

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -510,7 +510,7 @@ KX_KetsjiEngine::CameraRenderData KX_KetsjiEngine::GetCameraRenderData(KX_Scene 
 		rendercam->NodeSetGlobalOrientation(camera->NodeGetWorldOrientation());
 		rendercam->NodeSetWorldPosition(camera->NodeGetWorldPosition());
 		rendercam->NodeSetWorldScale(camera->NodeGetWorldScaling());
-		rendercam->NodeUpdateGS();
+		rendercam->NodeUpdate();
 	}
 	// Else use the native camera.
 	else {
@@ -1128,7 +1128,7 @@ void KX_KetsjiEngine::PostProcessScene(KX_Scene *scene)
 			activecam->NodeSetLocalOrientation(mt::mat3::Identity());
 		}
 
-		activecam->NodeUpdateGS();
+		activecam->NodeUpdate();
 
 		scene->GetCameraList()->Add(CM_AddRef(activecam));
 		scene->SetActiveCamera(activecam);

--- a/source/gameengine/Ketsji/KX_LightIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_LightIpoSGController.cpp
@@ -34,13 +34,15 @@
 #include "KX_LightObject.h"
 #include "RAS_ILightObject.h"
 
-bool KX_LightIpoSGController::Update()
+#include "BLI_math_vector.h"
+
+bool KX_LightIpoSGController::Update(SG_Node *node)
 {
-	if (!SG_Controller::Update()) {
+	if (!SG_Controller::Update(node)) {
 		return false;
 	}
 
-	KX_LightObject *kxlight = (KX_LightObject *)m_node->GetClientObject();
+	KX_LightObject *kxlight = static_cast<KX_LightObject *>(node->GetClientObject());
 	RAS_ILightObject *lightobj = kxlight->GetLightData();
 
 	if (m_modify_energy) {
@@ -48,9 +50,7 @@ bool KX_LightIpoSGController::Update()
 	}
 
 	if (m_modify_color) {
-		lightobj->m_color[0] = m_col_rgb[0];
-		lightobj->m_color[1] = m_col_rgb[1];
-		lightobj->m_color[2] = m_col_rgb[2];
+		copy_v3_v3(lightobj->m_color, m_col_rgb);
 	}
 
 	if (m_modify_dist) {

--- a/source/gameengine/Ketsji/KX_LightIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_LightIpoSGController.cpp
@@ -40,7 +40,7 @@ bool KX_LightIpoSGController::Update()
 		return false;
 	}
 
-	KX_LightObject *kxlight = (KX_LightObject *)m_node->GetSGClientObject();
+	KX_LightObject *kxlight = (KX_LightObject *)m_node->GetClientObject();
 	RAS_ILightObject *lightobj = kxlight->GetLightData();
 
 	if (m_modify_energy) {

--- a/source/gameengine/Ketsji/KX_LightIpoSGController.h
+++ b/source/gameengine/Ketsji/KX_LightIpoSGController.h
@@ -60,7 +60,7 @@ public:
 
 	virtual ~KX_LightIpoSGController() = default;
 
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 
 	void	SetModifyEnergy(bool modify) {
 		m_modify_energy = modify;

--- a/source/gameengine/Ketsji/KX_MaterialIpoController.cpp
+++ b/source/gameengine/Ketsji/KX_MaterialIpoController.cpp
@@ -27,9 +27,9 @@
 
 #include "RAS_IPolygonMaterial.h"
 
-bool KX_MaterialIpoController::Update()
+bool KX_MaterialIpoController::Update(SG_Node *node)
 {
-	if (!SG_Controller::Update()) {
+	if (!SG_Controller::Update(node)) {
 		return false;
 	}
 

--- a/source/gameengine/Ketsji/KX_MaterialIpoController.h
+++ b/source/gameengine/Ketsji/KX_MaterialIpoController.h
@@ -36,7 +36,7 @@ public:
 				m_material(polymat)
 		{}
 	virtual ~KX_MaterialIpoController() = default;
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 };
 
 #endif /* __KX_MATERIALIPOCONTROLLER_H__ */

--- a/source/gameengine/Ketsji/KX_ObColorIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_ObColorIpoSGController.cpp
@@ -39,7 +39,7 @@ bool KX_ObColorIpoSGController::Update()
 		return false;
 	}
 
-	KX_GameObject *kxgameobj = (KX_GameObject *)m_node->GetSGClientObject();
+	KX_GameObject *kxgameobj = (KX_GameObject *)m_node->GetClientObject();
 
 	kxgameobj->SetObjectColor(m_rgba);
 

--- a/source/gameengine/Ketsji/KX_ObColorIpoSGController.cpp
+++ b/source/gameengine/Ketsji/KX_ObColorIpoSGController.cpp
@@ -33,13 +33,13 @@
 #include "KX_ObColorIpoSGController.h"
 #include "KX_GameObject.h"
 
-bool KX_ObColorIpoSGController::Update()
+bool KX_ObColorIpoSGController::Update(SG_Node *node)
 {
-	if (!SG_Controller::Update()) {
+	if (!SG_Controller::Update(node)) {
 		return false;
 	}
 
-	KX_GameObject *kxgameobj = (KX_GameObject *)m_node->GetClientObject();
+	KX_GameObject *kxgameobj = static_cast<KX_GameObject *>(node->GetClientObject());
 
 	kxgameobj->SetObjectColor(m_rgba);
 

--- a/source/gameengine/Ketsji/KX_ObColorIpoSGController.h
+++ b/source/gameengine/Ketsji/KX_ObColorIpoSGController.h
@@ -45,7 +45,7 @@ public:
 public:
 	KX_ObColorIpoSGController() = default;
 	virtual ~KX_ObColorIpoSGController() = default;
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 };
 
 #endif  /* __KX_OBCOLORIPOSGCONTROLLER_H__ */

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -149,7 +149,7 @@ bool KX_TextureRendererManager::RenderRenderer(RAS_Rasterizer *rasty, KX_Texture
 			continue;
 		}
 
-		m_camera->NodeUpdateGS();
+		m_camera->NodeUpdate();
 
 		renderer->BindFace(i);
 

--- a/source/gameengine/Ketsji/KX_TrackToActuator.cpp
+++ b/source/gameengine/Ketsji/KX_TrackToActuator.cpp
@@ -75,7 +75,7 @@ KX_TrackToActuator::KX_TrackToActuator(SCA_IObject *gameobj,
 			if (m_parentobj) {
 				// if so, store the initial local rotation
 				// this is needed to revert the effect of the parent inverse node (TBC)
-				m_parentlocalmat = m_parentobj->GetSGNode()->GetLocalOrientation();
+				m_parentlocalmat = m_parentobj->GetNode()->GetLocalOrientation();
 				// use registration mechanism rather than AddRef, it creates zombie objects
 				m_parentobj->RegisterActuator(this);
 			}
@@ -351,7 +351,7 @@ bool KX_TrackToActuator::Update(double curtime)
 		if (m_parentobj) {
 
 			mt::vec3 localpos;
-			localpos = curobj->GetSGNode()->GetLocalPosition();
+			localpos = curobj->GetNode()->GetLocalPosition();
 			// Get the inverse of the parent matrix
 			mt::mat3 parentmatinv;
 			parentmatinv = m_parentobj->NodeGetWorldOrientation().Inverse();

--- a/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
+++ b/source/gameengine/Ketsji/KX_VehicleWrapper.cpp
@@ -79,7 +79,7 @@ PyObject *KX_VehicleWrapper::PyAddWheel(PyObject *args)
 			return nullptr;
 		}
 
-		if (gameOb->GetSGNode()) {
+		if (gameOb->GetNode()) {
 			mt::vec3 attachPos, attachDir, attachAxle;
 			if (!PyVecTo(pylistPos, attachPos)) {
 				PyErr_SetString(PyExc_AttributeError,
@@ -106,7 +106,7 @@ PyObject *KX_VehicleWrapper::PyAddWheel(PyObject *args)
 				return nullptr;
 			}
 
-			PHY_IMotionState *motionState = new KX_MotionState(gameOb->GetSGNode());
+			PHY_IMotionState *motionState = new KX_MotionState(gameOb->GetNode());
 			m_vehicle->AddWheel(motionState, attachPos, attachDir, attachAxle, suspensionRestLength, wheelRadius, hasSteering);
 		}
 

--- a/source/gameengine/Ketsji/KX_WorldIpoController.cpp
+++ b/source/gameengine/Ketsji/KX_WorldIpoController.cpp
@@ -35,9 +35,9 @@
 #include "KX_Globals.h"
 #include "KX_Scene.h"
 
-bool KX_WorldIpoController::Update()
+bool KX_WorldIpoController::Update(SG_Node *node)
 {
-	if (!SG_Controller::Update()) {
+	if (!SG_Controller::Update(node)) {
 		return false;
 	}
 

--- a/source/gameengine/Ketsji/KX_WorldIpoController.h
+++ b/source/gameengine/Ketsji/KX_WorldIpoController.h
@@ -66,7 +66,7 @@ public:
 
 	virtual ~KX_WorldIpoController() = default;
 
-	virtual bool Update();
+	virtual bool Update(SG_Node *node);
 
 	void	SetModifyMistStart(bool modify) {
 		m_modify_mist_start = modify;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -1460,7 +1460,7 @@ void CcdPhysicsController::SetNewClientInfo(void *clientinfo)
 	if (m_cci.m_bSensor) {
 		// use a different callback function for sensor object,
 		// bullet will not synchronize, we must do it explicitly
-		SG_Callbacks& callbacks = KX_GameObject::GetClientObject((KX_ClientObjectInfo *)clientinfo)->GetSGNode()->GetCallBackFunctions();
+		SG_Callbacks& callbacks = KX_GameObject::GetClientObject((KX_ClientObjectInfo *)clientinfo)->GetNode()->GetCallBackFunctions();
 		callbacks.m_updatefunc = KX_GameObject::SynchronizeTransformFunc;
 	}
 }

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -3011,8 +3011,8 @@ void CcdPhysicsEnvironment::ConvertObject(BL_SceneConverter& converter, KX_GameO
 			btCompoundShape *compoundShape = (btCompoundShape *)colShape;
 
 			// compute the local transform from parent, this may include several node in the chain
-			SG_Node *gameNode = gameobj->GetSGNode();
-			SG_Node *parentNode = compoundParent->GetSGNode();
+			SG_Node *gameNode = gameobj->GetNode();
+			SG_Node *parentNode = compoundParent->GetNode();
 			// relative transform
 			mt::vec3 parentScale = parentNode->GetWorldScaling();
 			parentScale[0] = 1.0f / parentScale[0];

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
@@ -266,7 +266,7 @@ void RAS_OpenGLLight::BindShadowBuffer(RAS_ICanvas *canvas, KX_Camera *cam, mt::
 
 	cam->NodeSetLocalPosition(camtrans.TranslationVector3D());
 	cam->NodeSetLocalOrientation(camtrans.RotationMatrix());
-	cam->NodeUpdateGS();
+	cam->NodeUpdate();
 
 	/* setup rasterizer transformations */
 	m_rasterizer->SetProjectionMatrix(projectionmat);

--- a/source/gameengine/SceneGraph/SG_Controller.cpp
+++ b/source/gameengine/SceneGraph/SG_Controller.cpp
@@ -36,12 +36,11 @@
 
 SG_Controller::SG_Controller()
 	:m_modified(true),
-	m_node(nullptr),
 	m_time(0.0)
 {
 }
 
-bool SG_Controller::Update()
+bool SG_Controller::Update(SG_Node *node)
 {
 	if (!m_modified) {
 		return false;
@@ -54,16 +53,6 @@ bool SG_Controller::Update()
 	}
 
 	return true;
-}
-
-void SG_Controller::SetNode(SG_Node *node)
-{
-	m_node = node;
-}
-
-void SG_Controller::ClearNode()
-{
-	m_node = nullptr;
 }
 
 void SG_Controller::SetSimulatedTime(double time)
@@ -79,4 +68,9 @@ void SG_Controller::SetOption(SG_Controller::SG_ControllerOption option, bool va
 void SG_Controller::AddInterpolator(const SG_Interpolator& interp)
 {
 	m_interpolators.push_back(interp);
+}
+
+bool SG_Controller::Empty() const
+{
+	return m_interpolators.empty();
 }

--- a/source/gameengine/SceneGraph/SG_Controller.h
+++ b/source/gameengine/SceneGraph/SG_Controller.h
@@ -44,6 +44,7 @@ class SG_Node;
  */
 class SG_Controller
 {
+	friend SG_Node;
 public:
 	/**
 	 * Option-identifiers: SG_CONTR_<controller-type>_<option>.
@@ -56,9 +57,6 @@ public:
 		SG_CONTR_IPO_IPO_ADD,
 		SG_CONTR_IPO_LOCAL,
 		SG_CONTR_IPO_RESET,
-		SG_CONTR_CAMIPO_LENS,
-		SG_CONTR_CAMIPO_CLIPEND,
-		SG_CONTR_CAMIPO_CLIPSTART,
 		SG_CONTR_MAX
 	};
 
@@ -66,34 +64,25 @@ public:
 	virtual ~SG_Controller() = default;
 
 	/// Perform an update, returns true when the update was performed.
-	virtual bool Update();
-
-	void SetNode(SG_Node *node);
-
-	void ClearNode();
+	virtual bool Update(SG_Node *node);
 
 	void SetSimulatedTime(double time);
 
 	/**
-	 * Hacky way of passing options to specific controllers
+	 * Pass options to specific controllers
 	 * \param option An integer identifying the option.
 	 * \param value  The value of this option.
-	 * \attention This has been placed here to give sca-elements
-	 * \attention some control over the controllers. This is
-	 * \attention necessary because the identity of the controller
-	 * \attention is lost on the way here.
 	 */
 	virtual void SetOption(SG_ControllerOption option, bool value);
 
 	void AddInterpolator(const SG_Interpolator& interp);
 
+	bool Empty() const;
 
 protected:
 	SG_InterpolatorList m_interpolators;
 	/// Were settings altered since the last update?
 	bool m_modified;
-
-	SG_Node *m_node;
 	/// Local time of this ipo.
 	double m_time;
 

--- a/source/gameengine/SceneGraph/SG_Node.cpp
+++ b/source/gameengine/SceneGraph/SG_Node.cpp
@@ -87,7 +87,7 @@ SG_Node::~SG_Node()
 	}
 }
 
-SG_Node *SG_Node::GetSGReplica()
+SG_Node *SG_Node::GetReplica()
 {
 	SG_Node *replica = new SG_Node(*this);
 	if (replica == nullptr) {
@@ -116,7 +116,7 @@ void SG_Node::ProcessSGReplica(SG_Node **replica)
 		(*replica)->ClearSGChildren();
 
 		for (SG_Node *childnode : m_children) {
-			SG_Node *replicanode = childnode->GetSGReplica();
+			SG_Node *replicanode = childnode->GetReplica();
 			if (replicanode) {
 				(*replica)->AddChild(replicanode);
 			}
@@ -127,7 +127,7 @@ void SG_Node::ProcessSGReplica(SG_Node **replica)
 	// This can happen in partial replication of hierarchy
 	// during group duplication.
 	if ((*replica)->m_children.empty() &&
-	    (*replica)->GetSGClientObject() == nullptr) {
+	    (*replica)->GetClientObject() == nullptr) {
 		delete (*replica);
 		*replica = nullptr;
 	}
@@ -162,7 +162,7 @@ bool SG_Node::IsAncessor(const SG_Node *child) const
 	       (child->m_SGparent == this) ? true : IsAncessor(child->m_SGparent);
 }
 
-const NodeList& SG_Node::GetSGChildren() const
+const NodeList& SG_Node::GetChildren() const
 {
 	return m_children;
 }
@@ -172,12 +172,12 @@ void SG_Node::ClearSGChildren()
 	m_children.clear();
 }
 
-SG_Node *SG_Node::GetSGParent() const
+SG_Node *SG_Node::GetParent() const
 {
 	return m_SGparent;
 }
 
-void SG_Node::SetSGParent(SG_Node *parent)
+void SG_Node::SetParent(SG_Node *parent)
 {
 	m_SGparent = parent;
 	if (parent) {
@@ -213,7 +213,7 @@ bool SG_Node::IsSlowParent()
 void SG_Node::AddChild(SG_Node *child)
 {
 	m_children.push_back(child);
-	child->SetSGParent(this);
+	child->SetParent(this);
 }
 
 void SG_Node::RemoveChild(SG_Node *child)
@@ -331,12 +331,12 @@ SG_Node *SG_Node::GetNextRescheduled(SG_QList& head)
 	return result;
 }
 
-void SG_Node::AddSGController(SG_Controller *cont)
+void SG_Node::AddController(SG_Controller *cont)
 {
 	m_SGcontrollers.push_back(cont);
 }
 
-void SG_Node::RemoveSGController(SG_Controller *cont)
+void SG_Node::RemoveController(SG_Controller *cont)
 {
 	m_mutex.Lock();
 	CM_ListRemoveIfFound(m_SGcontrollers, cont);
@@ -348,7 +348,7 @@ void SG_Node::RemoveAllControllers()
 	m_SGcontrollers.clear();
 }
 
-SGControllerList& SG_Node::GetSGControllerList()
+SGControllerList& SG_Node::GetControllerList()
 {
 	return m_SGcontrollers;
 }
@@ -358,21 +358,21 @@ SG_Callbacks& SG_Node::GetCallBackFunctions()
 	return m_callbacks;
 }
 
-void *SG_Node::GetSGClientObject() const
+void *SG_Node::GetClientObject() const
 {
 	return m_SGclientObject;
 }
 
-void SG_Node::SetSGClientObject(void *clientObject)
+void SG_Node::SetClientObject(void *clientObject)
 {
 	m_SGclientObject = clientObject;
 }
 
-void *SG_Node::GetSGClientInfo() const
+void *SG_Node::GetClientInfo() const
 {
 	return m_SGclientInfo;
 }
-void SG_Node::SetSGClientInfo(void *clientInfo)
+void SG_Node::SetClientInfo(void *clientInfo)
 {
 	m_SGclientInfo = clientInfo;
 }

--- a/source/gameengine/SceneGraph/SG_Node.h
+++ b/source/gameengine/SceneGraph/SG_Node.h
@@ -369,10 +369,10 @@ private:
 
 	void ProcessSGReplica(SG_Node **replica);
 
-	void *m_SGclientObject;
-	void *m_SGclientInfo;
+	void *m_clientObject;
+	void *m_clientInfo;
 	SG_Callbacks m_callbacks;
-	SGControllerList m_SGcontrollers;
+	SGControllerList m_controllers;
 
 	/**
 	 * The list of children of this node.
@@ -382,7 +382,7 @@ private:
 	/**
 	 * The parent of this node may be nullptr
 	 */
-	SG_Node *m_SGparent;
+	SG_Node *m_parent;
 
 	mt::vec3 m_localPosition;
 	mt::mat3 m_localRotation;

--- a/source/gameengine/SceneGraph/SG_Node.h
+++ b/source/gameengine/SceneGraph/SG_Node.h
@@ -145,7 +145,7 @@ public:
 	 * that.
 	 * \return a reference to the list of children of this node.
 	 */
-	const NodeList& GetSGChildren() const;
+	const NodeList& GetChildren() const;
 
 	/**
 	 * Clear the list of children associated with this node
@@ -155,12 +155,12 @@ public:
 	/**
 	 * return the parent of this node if it exists.
 	 */
-	SG_Node *GetSGParent() const;
+	SG_Node *GetParent() const;
 
 	/**
 	 * Set the parent of this node.
 	 */
-	void SetSGParent(SG_Node *parent);
+	void SetParent(SG_Node *parent);
 
 	/**
 	 * Return the top node in this node's Scene graph hierarchy
@@ -220,7 +220,7 @@ public:
 	/**
 	 * Node replication functions.
 	 */
-	SG_Node *GetSGReplica();
+	SG_Node *GetReplica();
 
 	void Destruct();
 
@@ -230,14 +230,14 @@ public:
 	 * responsibility of this class. It will be deleted when
 	 * this object is deleted.
 	 */
-	void AddSGController(SG_Controller *cont);
+	void AddController(SG_Controller *cont);
 
 	/**
 	 * Remove a pointer to a controller from this node.
 	 * This does not delete the controller itself! Be careful to
 	 * avoid memory leaks.
 	 */
-	void RemoveSGController(SG_Controller *cont);
+	void RemoveController(SG_Controller *cont);
 
 	/**
 	 * Clear the array of pointers to controllers associated with
@@ -256,7 +256,7 @@ public:
 	 * on pointers in the container. C++ topic: how to do this in
 	 * using STL?
 	 */
-	SGControllerList& GetSGControllerList();
+	SGControllerList& GetControllerList();
 
 	SG_Callbacks& GetCallBackFunctions();
 
@@ -269,7 +269,7 @@ public:
 	 * upon replication and destruction
 	 * This may be nullptr.
 	 */
-	void *GetSGClientObject() const;
+	void *GetClientObject() const;
 
 	/**
 	 * Set the client object for this node. This is just a
@@ -277,9 +277,9 @@ public:
 	 * the duration of the lifetime of this object, or until
 	 * this function is called again.
 	 */
-	void SetSGClientObject(void *clientObject);
-	void *GetSGClientInfo() const;
-	void SetSGClientInfo(void *clientInfo);
+	void SetClientObject(void *clientObject);
+	void *GetClientInfo() const;
+	void SetClientInfo(void *clientInfo);
 
 	/**
 	 * Set the current simulation time for this node.

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -239,14 +239,14 @@ bool ImageRender::Render()
 	if (m_mirror) {
 		// mirror mode, compute camera frustum, position and orientation
 		// convert mirror position and normal in world space
-		const mt::mat3 & mirrorObjWorldOri = m_mirror->GetSGNode()->GetWorldOrientation();
-		const mt::vec3 & mirrorObjWorldPos = m_mirror->GetSGNode()->GetWorldPosition();
-		const mt::vec3 & mirrorObjWorldScale = m_mirror->GetSGNode()->GetWorldScaling();
+		const mt::mat3 & mirrorObjWorldOri = m_mirror->GetNode()->GetWorldOrientation();
+		const mt::vec3 & mirrorObjWorldPos = m_mirror->GetNode()->GetWorldPosition();
+		const mt::vec3 & mirrorObjWorldScale = m_mirror->GetNode()->GetWorldScaling();
 		mt::vec3 mirrorWorldPos =
 			mirrorObjWorldPos + mirrorObjWorldScale * (mirrorObjWorldOri * m_mirrorPos);
 		mt::vec3 mirrorWorldZ = mirrorObjWorldOri * m_mirrorZ;
 		// get observer world position
-		const mt::vec3 & observerWorldPos = m_observer->GetSGNode()->GetWorldPosition();
+		const mt::vec3 & observerWorldPos = m_observer->GetNode()->GetWorldPosition();
 		// get plane D term = mirrorPos . normal
 		float mirrorPlaneDTerm = mt::dot(mirrorWorldPos, mirrorWorldZ);
 		// compute distance of observer to mirror = D - observerPos . normal
@@ -257,7 +257,7 @@ bool ImageRender::Render()
 		}
 		// set camera world position = observerPos + normal * 2 * distance
 		mt::vec3 cameraWorldPos = observerWorldPos + (2.0f * observerDistance) * mirrorWorldZ;
-		m_camera->GetSGNode()->SetLocalPosition(cameraWorldPos);
+		m_camera->GetNode()->SetLocalPosition(cameraWorldPos);
 		// set camera orientation: z=normal, y=mirror_up in world space, x= y x z
 		mt::vec3 mirrorWorldY = mirrorObjWorldOri * m_mirrorY;
 		mt::vec3 mirrorWorldX = mirrorObjWorldOri * m_mirrorX;
@@ -265,8 +265,8 @@ bool ImageRender::Render()
 			mirrorWorldX[0], mirrorWorldY[0], mirrorWorldZ[0],
 			mirrorWorldX[1], mirrorWorldY[1], mirrorWorldZ[1],
 			mirrorWorldX[2], mirrorWorldY[2], mirrorWorldZ[2]);
-		m_camera->GetSGNode()->SetLocalOrientation(cameraWorldOri);
-		m_camera->GetSGNode()->UpdateWorldData();
+		m_camera->GetNode()->SetLocalOrientation(cameraWorldOri);
+		m_camera->GetNode()->UpdateWorldData();
 		// compute camera frustum:
 		//   get position of mirror relative to camera: offset = mirrorPos-cameraPos
 		mt::vec3 mirrorOffset = mirrorWorldPos - cameraWorldPos;


### PR DESCRIPTION
Previously the SG_Controller were helding a pointer to the node owning them,
but this pointer was used only in Update function called by the node.
So the member is removed and the function Update receive the node pointer
instead.

Also BL_Action use an helper function AddController to add a valid controller,
controllers without any interpolators (Empty()) are ignored.