### PR TITLE
 UPBGE: Improve frustum culling performance.

### DIFF
--- a/build_files/cmake/macros.cmake
+++ b/build_files/cmake/macros.cmake
@@ -518,6 +518,8 @@ function(setup_liblinks
 
 	#target_link_libraries(${target} ${PLATFORM_LINKLIBS} ${CMAKE_DL_LIBS})
 	target_link_libraries(${target} ${PLATFORM_LINKLIBS})
+
+	target_link_libraries(${target} ${TBB_LIBRARIES})
 endfunction()
 
 

--- a/build_files/cmake/platform/platform_unix.cmake
+++ b/build_files/cmake/platform/platform_unix.cmake
@@ -35,6 +35,7 @@ find_package_wrapper(JPEG REQUIRED)
 find_package_wrapper(PNG REQUIRED)
 find_package_wrapper(ZLIB REQUIRED)
 find_package_wrapper(Freetype REQUIRED)
+find_package_wrapper(TBB REQUIRED)
 
 if(WITH_LZO AND WITH_SYSTEM_LZO)
 	find_package_wrapper(LZO)

--- a/build_files/cmake/platform/platform_win32.cmake
+++ b/build_files/cmake/platform/platform_win32.cmake
@@ -494,6 +494,11 @@ if(WITH_SDL)
 	set(SDL_LIBRARY ${SDL_LIBPATH}/SDL2.lib)
 endif()
 
+if(WITH_GAMEENGINE)
+	set(TBB_LIBRARIES optimized ${LIBDIR}/tbb/lib/tbb.lib debug ${LIBDIR}/tbb/lib/tbb_debug.lib)
+	set(TBB_INCLUDE_DIR ${LIBDIR}/tbb/include)
+endif()
+
 # Audio IO
 if(WITH_SYSTEM_AUDASPACE)
 	set(AUDASPACE_INCLUDE_DIRS ${LIBDIR}/audaspace/include/audaspace)

--- a/source/gameengine/CMakeLists.txt
+++ b/source/gameengine/CMakeLists.txt
@@ -25,6 +25,8 @@
 
 remove_extra_strict_flags()
 
+blender_include_dirs_sys("${TBB_INCLUDE_DIR}")
+
 # there are too many inter-includes so best define here
 if(WITH_PYTHON)
 	blender_include_dirs_sys("${PYTHON_INCLUDE_DIRS}")

--- a/source/gameengine/Ketsji/KX_BoundingBox.cpp
+++ b/source/gameengine/Ketsji/KX_BoundingBox.cpp
@@ -65,7 +65,7 @@ const mt::vec3& KX_BoundingBox::GetMax() const
 {
 	// Update AABB to make sure we have the last one.
 	m_owner->UpdateBounds(false);
-	const SG_BBox& box = m_owner->GetCullingNode()->GetAabb();
+	const SG_BBox& box = m_owner->GetCullingNode().GetAabb();
 	return box.GetMax();
 }
 
@@ -73,7 +73,7 @@ const mt::vec3& KX_BoundingBox::GetMin() const
 {
 	// Update AABB to make sure we have the last one.
 	m_owner->UpdateBounds(false);
-	const SG_BBox& box = m_owner->GetCullingNode()->GetAabb();
+	const SG_BBox& box = m_owner->GetCullingNode().GetAabb();
 	return box.GetMin();
 }
 
@@ -81,7 +81,7 @@ const mt::vec3 KX_BoundingBox::GetCenter() const
 {
 	// Update AABB to make sure we have the last one.
 	m_owner->UpdateBounds(false);
-	const SG_BBox& box = m_owner->GetCullingNode()->GetAabb();
+	const SG_BBox& box = m_owner->GetCullingNode().GetAabb();
 	return box.GetCenter();
 }
 
@@ -89,7 +89,7 @@ float KX_BoundingBox::GetRadius() const
 {
 	// Update AABB to make sure we have the last one.
 	m_owner->UpdateBounds(false);
-	const SG_BBox& box = m_owner->GetCullingNode()->GetAabb();
+	const SG_BBox& box = m_owner->GetCullingNode().GetAabb();
 	return box.GetRadius();
 }
 

--- a/source/gameengine/Ketsji/KX_CullingHandler.h
+++ b/source/gameengine/Ketsji/KX_CullingHandler.h
@@ -2,26 +2,31 @@
 #define __KX_CULLING_HANDLER_H__
 
 #include "SG_Frustum.h"
-#include <vector>
+#include "SG_BBox.h"
+
+#include "EXP_ListValue.h"
 
 class KX_GameObject;
 
 class KX_CullingHandler
 {
 private:
-	/// List of all objects to render after the culling pass.
-	std::vector<KX_GameObject *>& m_activeObjects;
+	/// List of all objects to test.
+	EXP_ListValue<KX_GameObject> *m_objects;
 	/// The camera frustum data.
 	const SG_Frustum& m_frustum;
+	/// Layer to ignore some objects.
+	int m_layer;
+
 
 public:
-	KX_CullingHandler(std::vector<KX_GameObject *>& objects, const SG_Frustum& frustum);
+	KX_CullingHandler(EXP_ListValue<KX_GameObject> *objects, const SG_Frustum& frustum, int layer);
 	~KX_CullingHandler() = default;
 
-	/** Process the culling of a new object, if the culling succeeded the
-	 * object is added in m_activeObjects.
-	 */
-	void Process(KX_GameObject *object);
+	bool Test(const mt::mat3x4& trans, const mt::vec3& scale, const SG_BBox& aabb) const;
+
+	/// Process the culling of all object and return a list of non-culled objects.
+	std::vector<KX_GameObject *> Process();
 };
 
 #endif  // __KX_CULLING_HANDLER_H__

--- a/source/gameengine/Ketsji/KX_CullingHandler.h
+++ b/source/gameengine/Ketsji/KX_CullingHandler.h
@@ -6,6 +6,12 @@
 
 #include "EXP_ListValue.h"
 
+#ifdef WIN32
+#	ifndef NOMINMAX
+#		define NOMINMAX
+#	endif
+#endif
+
 class KX_GameObject;
 
 class KX_CullingHandler

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -716,8 +716,8 @@ public:
 	/// Return the mesh user of this game object.
 	RAS_MeshUser *GetMeshUser() const;
 
-	/// Return true when the object can be culled.
-	bool UseCulling() const;
+	/// Return true when the object can be rendered.
+	bool Renderable(int layer) const;
 
 	/**
 	 * Was this object marked visible? (only for the explicit
@@ -737,22 +737,6 @@ public:
 		bool recursive
 	);
 
-	/**
-	 * Was this object culled?
-	 */
-	inline bool
-	GetCulled(
-		void
-	) { return m_cullingNode.GetCulled(); }
-
-	/**
-	 * Set culled flag of this object
-	 */
-	inline void
-	SetCulled(
-		bool c
-	) { m_cullingNode.SetCulled(c); }
-	
 	/**
 	 * Is this object an occluder?
 	 */
@@ -809,7 +793,7 @@ public:
 	void SetBoundsAabb(const mt::vec3 &aabbMin, const mt::vec3 &aabbMax);
 	void GetBoundsAabb(mt::vec3 &aabbMin, mt::vec3 &aabbMax) const;
 
-	SG_CullingNode *GetCullingNode();
+	SG_CullingNode& GetCullingNode();
 
 	ActivityCullingInfo& GetActivityCullingInfo();
 	void SetActivityCullingInfo(const ActivityCullingInfo& cullingInfo);

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -867,9 +867,7 @@ void KX_KetsjiEngine::RenderShadowBuffers(KX_Scene *scene)
 				/* binds framebuffer object, sets up camera .. */
 				raslight->BindShadowBuffer(m_canvas, cam, camtrans);
 
-				std::vector<KX_GameObject *> objects;
-				/* update scene */
-				scene->CalculateVisibleMeshes(objects, cam, raslight->GetShadowLayer());
+				const std::vector<KX_GameObject *> objects = scene->CalculateVisibleMeshes(cam, raslight->GetShadowLayer());
 
 				m_logger.StartLog(tc_animations, m_kxsystem->GetTimeInSeconds());
 				UpdateAnimations(scene);
@@ -1013,8 +1011,7 @@ void KX_KetsjiEngine::RenderCamera(KX_Scene *scene, const CameraRenderData& came
 
 	m_logger.StartLog(tc_scenegraph, m_kxsystem->GetTimeInSeconds());
 
-	std::vector<KX_GameObject *> objects;
-	scene->CalculateVisibleMeshes(objects, cullingcam, 0);
+	const std::vector<KX_GameObject *> objects = scene->CalculateVisibleMeshes(cullingcam, 0);
 
 	// update levels of detail
 	scene->UpdateObjectLods(cullingcam, objects);

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -351,8 +351,8 @@ public:
 	void SetWorldInfo(KX_WorldInfo *wi);
 	KX_WorldInfo *GetWorldInfo() const;
 
-	void CalculateVisibleMeshes(std::vector<KX_GameObject *>& objects, KX_Camera *cam, int layer);
-	void CalculateVisibleMeshes(std::vector<KX_GameObject *>& objects, const SG_Frustum& frustum, int layer);
+	std::vector<KX_GameObject *> CalculateVisibleMeshes(KX_Camera *cam, int layer);
+	std::vector<KX_GameObject *> CalculateVisibleMeshes(const SG_Frustum& frustum, int layer);
 
 	/// \section Debug draw.
 	void DrawDebug(RAS_DebugDraw& debugDraw, const std::vector<KX_GameObject *>& objects,

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -159,8 +159,7 @@ bool KX_TextureRendererManager::RenderRenderer(RAS_Rasterizer *rasty, KX_Texture
 		rasty->SetViewMatrix(viewmat, m_camera->NodeGetWorldPosition(), mt::one3);
 		m_camera->SetModelviewMatrix(viewmat);
 
-		std::vector<KX_GameObject *> objects;
-		m_scene->CalculateVisibleMeshes(objects, m_camera, ~renderer->GetIgnoreLayers());
+		const std::vector<KX_GameObject *> objects = m_scene->CalculateVisibleMeshes(m_camera, ~renderer->GetIgnoreLayers());
 
 		/* Updating the lod per face is normally not expensive because a cube map normally show every objects
 		 * but here we update only visible object of a face including the clip end and start.

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -395,8 +395,7 @@ bool ImageRender::Render()
 		m_scene->GetWorldInfo()->setZenithColor(zen);
 	}
 
-	std::vector<KX_GameObject *> objects;
-	m_scene->CalculateVisibleMeshes(objects, m_camera, 0);
+	const std::vector<KX_GameObject *> objects = m_scene->CalculateVisibleMeshes(m_camera, 0);
 
 	m_engine->UpdateAnimations(m_scene);
 


### PR DESCRIPTION
Frustum culling was improved in two ways. First, simplificate the bounding
box update. Second the test are parallelized using TBB range loop.

The bounding box update is simplified by adding the call to RAS_Deformer::UpdateBuckets
in KX_GameObject::UpdateBounds after we checked that the objects as a
bounding box. By doing this we avoid a call to GetDeformer for all objects
without a bounding box, with an unmodified bounding box or without auto
update.

All the computation of culling objects is moved into KX_CullingHandler,
this class construct it's own objects list and returns it in Process function.
Process function build a CullTask and launch it usign tbb::parallal_reduce.

Each CullTask have an operator() to test a range of object, any objects passing
the culling test is added in a task local objects list. Once the tests
finished the CullTask merge these objects list in function join to end
up with the list of all non-culled objects.
This technique of reduce of list is way better than using a shared object
list for all tasks and lock a mutex before adding an object. The method
with mutex was always slower than without parallelization.

This patch was tested with cube meshes :
number of object | previous time | new time
1000 | 0.06 | 0.07
8000 | 1.04 | 0.55
27000 | 3.81 | 1.90
125000 | 16.16 | 8.31