### PR TITLE
UPBGE: Move SG_Controller entirely in BL_Action.

### DIFF
--- a/source/blender/editors/space_logic/logic_window.c
+++ b/source/blender/editors/space_logic/logic_window.c
@@ -1415,8 +1415,6 @@ static void draw_actuator_action(uiLayout *layout, PointerRNA *ptr)
 		uiItemR(row, ptr, "frame_end", 0, NULL, ICON_NONE);
 	}
 
-	uiItemR(row, ptr, "apply_to_children", 0, NULL, ICON_NONE);
-
 	row = uiLayoutRow(layout, false);
 	uiItemR(row, ptr, "frame_blend_in", 0, NULL, ICON_NONE);
 	uiItemR(row, ptr, "priority", 0, NULL, ICON_NONE);

--- a/source/blender/makesdna/DNA_actuator_types.h
+++ b/source/blender/makesdna/DNA_actuator_types.h
@@ -392,7 +392,6 @@ typedef struct bActuator {
 #define ACT_IPOFORCE        (1 << 0)
 #define ACT_IPOEND          (1 << 1)
 #define ACT_IPOLOCAL		(1 << 2)
-#define ACT_IPOCHILD        (1 << 4)	
 #define ACT_IPOADD			(1 << 5)
 
 /* property actuator->type */

--- a/source/blender/makesrna/intern/rna_actuator.c
+++ b/source/blender/makesrna/intern/rna_actuator.c
@@ -693,11 +693,6 @@ static void rna_def_action_actuator(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "L", "Let the Action act in local coordinates, used in Force and Add mode");
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 
-	prop = RNA_def_property(srna, "apply_to_children", PROP_BOOLEAN, PROP_NONE);
-	RNA_def_property_boolean_sdna(prop, NULL, "flag", ACT_IPOCHILD);
-	RNA_def_property_ui_text(prop, "Child", "Update Action on all children Objects as well");
-	RNA_def_property_update(prop, NC_LOGIC, NULL);
-
 	prop = RNA_def_property(srna, "blend_mode", PROP_ENUM, PROP_NONE);
 	RNA_def_property_enum_sdna(prop, NULL, "blend_mode");
 	RNA_def_property_enum_items(prop, prop_blend_items);

--- a/source/gameengine/Converter/BL_ConvertActuators.cpp
+++ b/source/gameengine/Converter/BL_ConvertActuators.cpp
@@ -221,9 +221,6 @@ void BL_ConvertActuators(const char *maggiename,
 				if (actact->flag & ACT_IPOADD) {
 					ipo_flags |= BL_Action::ACT_IPOFLAG_ADD;
 				}
-				if (actact->flag & ACT_IPOCHILD) {
-					ipo_flags |= BL_Action::ACT_IPOFLAG_CHILD;
-				}
 
 				BL_ActionActuator *tmpbaseact = new BL_ActionActuator(
 					gameobj,

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -60,7 +60,7 @@ extern "C" {
 #include "BKE_library.h"
 #include "BKE_global.h"
 
-BL_Action::BL_Action(class KX_GameObject *gameobj)
+BL_Action::BL_Action(KX_GameObject *gameobj)
 	:m_action(nullptr),
 	m_tmpaction(nullptr),
 	m_blendpose(nullptr),
@@ -107,21 +107,17 @@ void BL_Action::AddController(SG_Controller *cont)
 		return;
 	}
 
-	m_sg_contr_list.push_back(cont);
-	m_obj->GetNode()->AddController(cont);
+	m_controllers.push_back(cont);
 }
 
 void BL_Action::ClearControllerList()
 {
-	SG_Node *node = m_obj->GetNode();
-
 	// Clear out the controller list
-	for (SG_Controller *cont : m_sg_contr_list) {
-		node->RemoveController(cont);
+	for (SG_Controller *cont : m_controllers) {
 		delete cont;
 	}
 
-	m_sg_contr_list.clear();
+	m_controllers.clear();
 }
 
 bool BL_Action::Play(const std::string& name,
@@ -174,8 +170,6 @@ bool BL_Action::Play(const std::string& name,
 
 	// First get rid of any old controllers
 	ClearControllerList();
-
-	SG_Node *node = m_obj->GetNode();
 
 	// Create an SG_Controller
 	AddController(BL_CreateIPO(m_action, m_obj, kxscene));
@@ -253,7 +247,7 @@ bool BL_Action::IsDone()
 void BL_Action::InitIPO()
 {
 	// Initialize the IPOs
-	for (SG_Controller *cont : m_sg_contr_list) {
+	for (SG_Controller *cont : m_controllers) {
 		cont->SetOption(SG_Controller::SG_CONTR_IPO_RESET, true);
 		cont->SetOption(SG_Controller::SG_CONTR_IPO_IPO_AS_FORCE, m_ipo_flags & ACT_IPOFLAG_FORCE);
 		cont->SetOption(SG_Controller::SG_CONTR_IPO_IPO_ADD, m_ipo_flags & ACT_IPOFLAG_ADD);
@@ -417,6 +411,13 @@ void BL_Action::Update(float curtime, bool applyToObject)
 
 	m_requestIpo = true;
 
+	SG_Node *node = m_obj->GetNode();
+	// Update controllers time.
+	for (SG_Controller *cont : m_controllers) {
+        cont->SetSimulatedTime(m_localframe);        // update spatial controllers
+        cont->Update(node);
+    }
+
 	if (m_obj->GetGameObjectType() == SCA_IObject::OBJ_ARMATURE) {
 		BL_ArmatureObject *obj = (BL_ArmatureObject *)m_obj;
 
@@ -485,22 +486,17 @@ void BL_Action::Update(float curtime, bool applyToObject)
 			obj->SetLastFrame(curtime);
 		}
 	}
-}
-
-void BL_Action::UpdateIPOs()
-{
-	if (m_sg_contr_list.empty()) {
-		// Nothing to update or remove.
-		return;
-	}
-
-	if (m_requestIpo) {
-		m_obj->UpdateIPO(m_localframe, m_ipo_flags & ACT_IPOFLAG_CHILD);
-		m_requestIpo = false;
-	}
 
 	// If the action is done we can remove its scene graph IPO controller.
 	if (m_done) {
 		ClearControllerList();
+	}
+}
+
+void BL_Action::UpdateIPOs()
+{
+	if (m_requestIpo) {
+        m_obj->GetNode()->UpdateWorldDataThread();
+		m_requestIpo = false;
 	}
 }

--- a/source/gameengine/Ketsji/BL_Action.h
+++ b/source/gameengine/Ketsji/BL_Action.h
@@ -30,15 +30,21 @@
 #include <string>
 #include <vector>
 
+class KX_GameObject;
+class SG_Controller;
+
+struct bAction;
+struct bPose;
+
 class BL_Action
 {
 private:
-	struct bAction* m_action;
-	struct bAction* m_tmpaction;
-	struct bPose* m_blendpose;
-	struct bPose* m_blendinpose;
-	std::vector<class SG_Controller*> m_sg_contr_list;
-	class KX_GameObject* m_obj;
+	bAction* m_action;
+	bAction* m_tmpaction;
+	bPose* m_blendpose;
+	bPose* m_blendinpose;
+	std::vector<SG_Controller *> m_controllers;
+	KX_GameObject* m_obj;
 	std::vector<float>	m_blendshape;
 	std::vector<float>	m_blendinshape;
 
@@ -146,7 +152,6 @@ public:
 		ACT_IPOFLAG_FORCE = 1,
 		ACT_IPOFLAG_LOCAL = 2,
 		ACT_IPOFLAG_ADD = 4,
-		ACT_IPOFLAG_CHILD = 8,
 	};
 };
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -865,26 +865,6 @@ void KX_GameObject::SynchronizeTransformFunc(SG_Node *node, void *gameobj, void 
 	((KX_GameObject *)gameobj)->SynchronizeTransform();
 }
 
-void KX_GameObject::InitIPO(bool ipo_as_force,
-                            bool ipo_add,
-                            bool ipo_local)
-{
-	for (SG_Controller *cont : m_sgNode->GetControllerList()) {
-		cont->SetOption(SG_Controller::SG_CONTR_IPO_RESET, true);
-		cont->SetOption(SG_Controller::SG_CONTR_IPO_IPO_AS_FORCE, ipo_as_force);
-		cont->SetOption(SG_Controller::SG_CONTR_IPO_IPO_ADD, ipo_add);
-		cont->SetOption(SG_Controller::SG_CONTR_IPO_LOCAL, ipo_local);
-	}
-}
-
-void KX_GameObject::UpdateIPO(float curframetime,
-                              bool recurse)
-{
-	// just the 'normal' update procedure.
-	m_sgNode->SetSimulatedTimeThread(curframetime, recurse);
-	m_sgNode->UpdateWorldDataThread();
-}
-
 bool KX_GameObject::GetVisible(void)
 {
 	return m_bVisible;

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -633,25 +633,6 @@ public:
 	static void SynchronizeTransformFunc(SG_Node* node, void* gameobj, void* scene);
 
 	/**
-	 * Function to set IPO option at start of IPO
-	 */ 
-		void
-	InitIPO(
-		bool ipo_as_force,
-		bool ipo_add,
-		bool ipo_local
-	);
-
-	/**
-	 * Odd function to update an ipo. ???
-	 */ 
-		void
-	UpdateIPO(
-		float curframetime,
-		bool recurse
-	);
-
-	/**
 	 * \section Mesh accessor functions.
 	 */
 

--- a/source/gameengine/SceneGraph/SG_Node.h
+++ b/source/gameengine/SceneGraph/SG_Node.h
@@ -42,11 +42,8 @@
 #include <vector>
 #include <memory>
 
-class SG_Controller;
 class SG_Familly;
 class SG_Node;
-
-typedef std::vector<SG_Controller *> SGControllerList;
 
 typedef void * (*SG_ReplicationNewCallback)(SG_Node *sgnode, void *clientobj, void *clientinfo);
 typedef void * (*SG_DestructionNewCallback)(SG_Node *sgnode, void *clientobj, void *clientinfo);
@@ -224,39 +221,7 @@ public:
 
 	void Destruct();
 
-	/**
-	 * Add a pointer to a controller allocated on the heap, to
-	 * this node. This memory for this controller becomes the
-	 * responsibility of this class. It will be deleted when
-	 * this object is deleted.
-	 */
-	void AddController(SG_Controller *cont);
-
-	/**
-	 * Remove a pointer to a controller from this node.
-	 * This does not delete the controller itself! Be careful to
-	 * avoid memory leaks.
-	 */
-	void RemoveController(SG_Controller *cont);
-
-	/**
-	 * Clear the array of pointers to controllers associated with
-	 * this node. This does not delete the controllers themselves!
-	 * This should be used very carefully to avoid memory
-	 * leaks.
-	 */
-	void RemoveAllControllers();
-
 	/// Needed for replication
-
-	/**
-	 * Return a reference to this node's controller list.
-	 * Whilst we don't wish to expose full control of the container
-	 * to the user we do allow them to call non_const methods
-	 * on pointers in the container. C++ topic: how to do this in
-	 * using STL?
-	 */
-	SGControllerList& GetControllerList();
 
 	SG_Callbacks& GetCallBackFunctions();
 
@@ -280,13 +245,6 @@ public:
 	void SetClientObject(void *clientObject);
 	void *GetClientInfo() const;
 	void SetClientInfo(void *clientInfo);
-
-	/**
-	 * Set the current simulation time for this node.
-	 * The implementation of this function runs through
-	 * the nodes list of controllers and calls their SetSimulatedTime methods
-	 */
-	void SetControllerTime(double time);
 
 	void ClearModified();
 	void SetModified();
@@ -359,8 +317,7 @@ protected:
 	void ActivateRecheduleUpdateCallback();
 
 	/**
-	 * Update the world coordinates of this spatial node. This also informs
-	 * any controllers to update this object.
+	 * Update the world coordinates of this spatial node.
 	 */
 	void UpdateSpatialData(const SG_Node *parent, bool& parentUpdated);
 
@@ -372,7 +329,6 @@ private:
 	void *m_clientObject;
 	void *m_clientInfo;
 	SG_Callbacks m_callbacks;
-	SGControllerList m_controllers;
 
 	/**
 	 * The list of children of this node.


### PR DESCRIPTION
Previously SG_Controller were owned and updated by SG_Node. This class
is not the best place for it as SG_Controller are not always modifying spatial,
for example Light or Camera controllers.
The best place is in BL_Action as this class was setting the simulation time
and updating the controllers indirectly.

In the same time the option "child" in action actuator which enabled recursive
time update for controllers is removed. Indeed every call to SetSimulatedTime
was followed by Update for the controllers in BL_Action.