### PR TITLE
UPBGE: Avoid calling glGetUniformLocation while setting a uniform through BL_Shader.

### DIFF
--- a/source/blender/gpu/GPU_shader.h
+++ b/source/blender/gpu/GPU_shader.h
@@ -73,6 +73,16 @@ void GPU_shader_unbind(void);
 
 int GPU_shader_program(GPUShader *shader);
 
+typedef struct GPUUniformInfo
+{
+	unsigned int location;
+	unsigned int size;
+	unsigned int type;
+	char name[255];
+} GPUUniformInfo;
+
+int GPU_shader_get_uniform_infos(GPUShader *shader, GPUUniformInfo **infos);
+
 void *GPU_shader_get_interface(GPUShader *shader);
 void GPU_shader_set_interface(GPUShader *shader, void *interface);
 int GPU_shader_get_uniform(GPUShader *shader, const char *name);

--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -598,6 +598,27 @@ void GPU_shader_free(GPUShader *shader)
 	MEM_freeN(shader);
 }
 
+int GPU_shader_get_uniform_infos(GPUShader *shader, GPUUniformInfo **infos)
+{
+	int count;
+	glGetProgramiv(shader->program, GL_ACTIVE_UNIFORMS, &count);
+
+	if (count == 0) {
+		*infos = NULL;
+		return 0;
+	}
+
+	*infos = MEM_callocN(sizeof(GPUUniformInfo) * count, "GPUUniformInfo");
+
+	for (unsigned int i = 0; i < count; ++i) {
+		GPUUniformInfo *info = &((*infos)[i]);
+		glGetActiveUniform(shader->program, i, 255, NULL, (int *)&info->size, &info->type, info->name);
+		info->location = GPU_shader_get_uniform(shader, info->name);
+	}
+
+	return count;
+}
+
 int GPU_shader_get_uniform(GPUShader *shader, const char *name)
 {
 	return glGetUniformLocation(shader->program, name);

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #define SORT_UNIFORMS 1
 
@@ -107,6 +108,16 @@ public:
 	};
 
 protected:
+	struct UniformInfo
+	{
+		unsigned int location;
+		unsigned short size;
+		unsigned int type;
+	};
+
+	/// Information (location, type, size) on existing uniforms.
+	std::unordered_map<std::string, UniformInfo> m_uniformInfos;
+
 	typedef std::vector<RAS_Uniform *> RAS_UniformVec;
 	typedef std::vector<RAS_DefUniform *> RAS_UniformVecDef;
 
@@ -129,6 +140,7 @@ protected:
 	// Compiles and links the shader
 	virtual bool LinkProgram();
 	void ValidateProgram();
+	void ExtractUniformInfos();
 
 	// search by location
 	RAS_Uniform *FindUniform(const int location);
@@ -139,6 +151,7 @@ protected:
 public:
 	RAS_Shader();
 	virtual ~RAS_Shader();
+
 
 	bool GetError();
 	bool Ok() const;


### PR DESCRIPTION
All the setUniform functions in BL_Shader are using name to identify the uniform,
these functions call RAS_Shader::GetUniformLocation.

This last function was naively calling indirectly glGetUniformLocation, but even
simple OpenGL calls cost more than caching.
Fortunatly OpenGL allows to enumerate all active uniforms thanks to glGetActiveUniform,
this function is used in GPUShader side inside function GPU_shader_get_uniform_infos
constructing a list of GPUUniformInfo storing the uniform location, size, type and
name.

These uniform info are used in RAS_Shader::ExtractUniformInfos which insert the
info in a map associating to the name the location, size and type> This map is then
used into GetUniformLocation.

Tested with a 4 uniforms shader and 1000 updates :
Previous : 3.26ms
Current : 2.88ms

Test file :
[ge_uniforms.zip](https://github.com/UPBGE/blender/files/2167666/ge_uniforms.zip)
