### PR TITLE
UPBGE: Implement dynamic object ligthing layer.

### DIFF
--- a/source/blender/editors/space_view3d/view3d_draw.c
+++ b/source/blender/editors/space_view3d/view3d_draw.c
@@ -3107,7 +3107,7 @@ static void view3d_main_region_clear(Scene *scene, View3D *v3d, ARegion *ar)
 		GPUMaterial *gpumat = GPU_material_world(scene, scene->world);
 
 		/* calculate full shader for background */
-		GPU_material_bind(gpumat, 1, 1, 1.0, true, rv3d->viewmat, rv3d->viewinv, rv3d->viewcamtexcofac, (v3d->scenelock != 0));
+		GPU_material_bind(gpumat, 1, 1.0, true, rv3d->viewmat, rv3d->viewinv, rv3d->viewcamtexcofac, (v3d->scenelock != 0));
 
 		bool material_not_bound = !GPU_material_bound(gpumat);
 

--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -76,6 +76,8 @@ typedef enum GPUType {
 	GPU_MAT3 = 9,
 	GPU_MAT4 = 16,
 
+	GPU_INT = 17,
+
 	GPU_TEX2D = 1002,
 	GPU_SHADOW2D = 1003,
 	GPU_TEXCUBE = 1004,
@@ -105,7 +107,8 @@ typedef enum GPUBuiltin {
 	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 19),
 	GPU_INSTANCING_POSITION_ATTRIB = (1 << 20),
 	GPU_TIME                       = (1 << 21),
-	GPU_OBJECT_INFO                = (1 << 22)
+	GPU_OBJECT_INFO                = (1 << 22),
+	GPU_OBJECT_LAY                 = (1 << 23)
 } GPUBuiltin;
 
 typedef enum GPUOpenGLBuiltin {
@@ -172,14 +175,15 @@ typedef enum GPUDynamicType {
 	GPU_DYNAMIC_LAMP_DYNENERGY       = 5  | GPU_DYNAMIC_GROUP_LAMP,
 	GPU_DYNAMIC_LAMP_DYNCOL          = 6  | GPU_DYNAMIC_GROUP_LAMP,
 	GPU_DYNAMIC_LAMP_DYNSPOTSCALE    = 7  | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_DISTANCE        = 8  | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_ATT1            = 9  | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_ATT2            = 10 | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_SPOTSIZE        = 11 | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_SPOTBLEND       = 12 | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_COEFFCONST      = 13 | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_COEFFLIN        = 14 | GPU_DYNAMIC_GROUP_LAMP,
-	GPU_DYNAMIC_LAMP_COEFFQUAD       = 15 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_DYNVISI         = 8 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_DISTANCE        = 9  | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_ATT1            = 10  | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_ATT2            = 11 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_SPOTSIZE        = 12 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_SPOTBLEND       = 13 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_COEFFCONST      = 14 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_COEFFLIN        = 15 | GPU_DYNAMIC_GROUP_LAMP,
+	GPU_DYNAMIC_LAMP_COEFFQUAD       = 16 | GPU_DYNAMIC_GROUP_LAMP,
 
 	GPU_DYNAMIC_SAMPLER_2DBUFFER     = 1  | GPU_DYNAMIC_GROUP_SAMPLER,
 	GPU_DYNAMIC_SAMPLER_2DIMAGE      = 2  | GPU_DYNAMIC_GROUP_SAMPLER,
@@ -234,7 +238,7 @@ typedef enum GPUDynamicType {
 
 GPUNodeLink *GPU_attribute(CustomDataType type, const char *name);
 GPUNodeLink *GPU_uniform(float *num);
-GPUNodeLink *GPU_dynamic_uniform(float *num, GPUDynamicType dynamictype, void *data);
+GPUNodeLink *GPU_dynamic_uniform(void *num, GPUDynamicType dynamictype, void *data);
 GPUNodeLink *GPU_select_uniform(float *num, GPUDynamicType dynamictype, void *data, struct Material *material);
 GPUNodeLink *GPU_image(struct Image *ima, struct ImageUser *iuser, bool is_data);
 GPUNodeLink *GPU_cube_map(struct Image *ima, struct ImageUser *iuser, bool is_data);
@@ -264,12 +268,13 @@ void GPU_material_free(struct ListBase *gpumaterial);
 void GPU_materials_free(void);
 
 bool GPU_lamp_visible(GPULamp *lamp, struct SceneRenderLayer *srl, struct Material *ma);
+void GPU_material_update_lamps(GPUMaterial *material, float viewmat[4][4], float viewinv[4][4]);
 void GPU_material_bind(
-        GPUMaterial *material, int oblay, int viewlay, double time, int mipmap,
+        GPUMaterial *material, int viewlay, double time, int mipmap,
         float viewmat[4][4], float viewinv[4][4], float cameraborder[4], bool scenelock);
 void GPU_material_bind_uniforms(
         GPUMaterial *material, float obmat[4][4], float viewmat[4][4], const float obcol[4],
-        float autobumpscale, GPUParticleInfo *pi, float object_info[3]);
+		int oblay, float autobumpscale, GPUParticleInfo *pi, float object_info[3]);
 void GPU_material_unbind(GPUMaterial *material);
 bool GPU_material_bound(GPUMaterial *material);
 struct Scene *GPU_material_scene(GPUMaterial *material);

--- a/source/blender/gpu/intern/gpu_draw.c
+++ b/source/blender/gpu/intern/gpu_draw.c
@@ -1869,12 +1869,13 @@ int GPU_object_material_bind(int nr, void *attribs)
 				GPU_get_object_info(object_info, mat);
 			}
 
+			GPU_material_update_lamps(gpumat, GMS.gviewmat, GMS.gviewinv);
 			GPU_material_bind(
-			        gpumat, GMS.gob->lay, GMS.glay, 1.0, !(GMS.gob->mode & OB_MODE_TEXTURE_PAINT),
+			        gpumat, GMS.glay, 1.0, !(GMS.gob->mode & OB_MODE_TEXTURE_PAINT),
 			        GMS.gviewmat, GMS.gviewinv, GMS.gviewcamtexcofac, GMS.gscenelock);
 
 			auto_bump_scale = GMS.gob->derivedFinal != NULL ? GMS.gob->derivedFinal->auto_bump_scale : 1.0f;
-			GPU_material_bind_uniforms(gpumat, GMS.gob->obmat, GMS.gviewmat, GMS.gob->col, auto_bump_scale, &partile_info, object_info);
+			GPU_material_bind_uniforms(gpumat, GMS.gob->obmat, GMS.gviewmat, GMS.gob->col, GMS.gob->lay, auto_bump_scale, &partile_info, object_info);
 			GMS.gboundmat = mat;
 
 			/* for glsl use alpha blend mode, unless it's set to solid and

--- a/source/blender/gpu/shaders/gpu_shader_material.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_material.glsl
@@ -2070,6 +2070,13 @@ void shade_diffuse_oren_nayer(float nl, vec3 n, vec3 l, vec3 v, float rough, out
 	}
 }
 
+void lamp_visible(int lay, int oblay, vec3 col, float energy, out vec3 outcol, out float outenergy)
+{
+	int mask = min((lay & oblay), 1);
+	outcol = col * mask;
+	outenergy = energy * mask;
+}
+
 void shade_diffuse_toon(vec3 n, vec3 l, vec3 v, float size, float tsmooth, out float is)
 {
 	float rslt = dot(n, l);

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -423,7 +423,7 @@ static void BL_GetUvRgba(const RAS_Mesh::LayersInfo& layersInfo, std::vector<MLo
 	}
 }
 
-static RAS_MaterialBucket *BL_ConvertMaterial(Material *ma, int lightlayer, KX_Scene *scene, BL_SceneConverter& converter)
+static RAS_MaterialBucket *BL_ConvertMaterial(Material *ma, KX_Scene *scene, BL_SceneConverter& converter)
 {
 	KX_BlenderMaterial *mat = converter.FindMaterial(ma);
 
@@ -434,7 +434,7 @@ static RAS_MaterialBucket *BL_ConvertMaterial(Material *ma, int lightlayer, KX_S
 			name = "MA";
 		}
 
-		mat = new KX_BlenderMaterial(ma, name, lightlayer);
+		mat = new KX_BlenderMaterial(ma, name);
 
 		// this is needed to free up memory afterwards.
 		converter.RegisterMaterial(mat, ma);
@@ -452,7 +452,6 @@ static RAS_MaterialBucket *BL_ConvertMaterial(Material *ma, int lightlayer, KX_S
 KX_Mesh *BL_ConvertMesh(Mesh *me, Object *blenderobj, KX_Scene *scene, BL_SceneConverter& converter)
 {
 	KX_Mesh *meshobj;
-	const int lightlayer = blenderobj ? blenderobj->lay : (1 << 20) - 1; // all layers if no object.
 
 	// Without checking names, we get some reuse we don't want that can cause
 	// problems with material LoDs.
@@ -512,7 +511,7 @@ KX_Mesh *BL_ConvertMesh(Mesh *me, Object *blenderobj, KX_Scene *scene, BL_SceneC
 			ma = &defmaterial;
 		}
 
-		RAS_MaterialBucket *bucket = BL_ConvertMaterial(ma, lightlayer, scene, converter);
+		RAS_MaterialBucket *bucket = BL_ConvertMaterial(ma, scene, converter);
 		RAS_MeshMaterial *meshmat = meshobj->AddMaterial(bucket, i, vertformat);
 		RAS_IPolyMaterial *mat = meshmat->GetBucket()->GetPolyMaterial();
 

--- a/source/gameengine/Ketsji/BL_BlenderShader.h
+++ b/source/gameengine/Ketsji/BL_BlenderShader.h
@@ -56,13 +56,12 @@ class BL_BlenderShader
 private:
 	Scene *m_blenderScene;
 	Material *m_mat;
-	int m_lightLayer;
 	int m_alphaBlend;
 	GPUMaterial *m_gpuMat;
 	CM_UpdateServer<RAS_IPolyMaterial> *m_materialUpdateServer;
 
 public:
-	BL_BlenderShader(KX_Scene *scene, Material *ma, int lightlayer, CM_UpdateServer<RAS_IPolyMaterial> *materialUpdateServer);
+	BL_BlenderShader(KX_Scene *scene, Material *ma, CM_UpdateServer<RAS_IPolyMaterial> *materialUpdateServer);
 	virtual ~BL_BlenderShader();
 
 	bool Ok() const;
@@ -76,6 +75,7 @@ public:
 	 */
 	const RAS_AttributeArray::AttribList GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const;
 
+	void UpdateLights(RAS_Rasterizer *rasty);
 	void Update(RAS_MeshSlot *ms, RAS_Rasterizer *rasty);
 
 	/// Return true if the shader uses a special vertex shader for geometry instancing.

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -26,15 +26,18 @@ class KX_BlenderMaterial : public EXP_Value, public RAS_IPolyMaterial
 	Py_Header
 
 public:
-	KX_BlenderMaterial(Material *mat, const std::string& name, int lightlayer);
+	KX_BlenderMaterial(Material *mat, const std::string& name);
 
 	virtual ~KX_BlenderMaterial();
 
+	virtual void Prepare(RAS_Rasterizer *rasty);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
+	void UpdateTextures();
+	void ApplyTextures();
 	void ActivateShaders(RAS_Rasterizer *rasty);
 
 	void ActivateBlenderShaders(RAS_Rasterizer *rasty);
@@ -110,7 +113,6 @@ private:
 	KX_Scene *m_scene;
 	bool m_userDefBlend;
 	RAS_Rasterizer::BlendFunc m_blendFunc[2];
-	int m_lightLayer;
 
 	struct {
 		float r, g, b, a;

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -141,9 +141,12 @@ void KX_FontObject::AddMeshUser()
 
 void KX_FontObject::UpdateBuckets()
 {
+	RAS_TextUser *textUser = static_cast<RAS_TextUser *>(m_meshUser);
+
 	// Update datas and add mesh slot to be rendered only if the object is not culled.
 	if (m_sgNode->IsDirty(SG_Node::DIRTY_RENDER)) {
 		NodeGetWorldTransform().PackFromAffineTransform(m_meshUser->GetMatrix());
+		textUser->SetFrontFace(!IsNegativeScaling());
 		m_sgNode->ClearDirty(SG_Node::DIRTY_RENDER);
 	}
 
@@ -167,10 +170,8 @@ void KX_FontObject::UpdateBuckets()
 	// Orient the spacing vector
 	mt::vec3 spacing = NodeGetWorldOrientation() * mt::vec3(0.0f, m_fsize * m_line_spacing, 0.0f) * NodeGetWorldScaling()[1];
 
-	RAS_TextUser *textUser = (RAS_TextUser *)m_meshUser;
-
+	textUser->SetLayer(m_layer);
 	textUser->SetColor(mt::vec4(color));
-	textUser->SetFrontFace(!IsNegativeScaling());
 	textUser->SetFontId(m_fontid);
 	textUser->SetSize(size);
 	textUser->SetDpi(m_dpi);

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -708,11 +708,12 @@ void KX_GameObject::UpdateBuckets()
 	// Update datas and add mesh slot to be rendered only if the object is not culled.
 	if (m_sgNode->IsDirty(SG_Node::DIRTY_RENDER)) {
 		NodeGetWorldTransform().PackFromAffineTransform(m_meshUser->GetMatrix());
+		m_meshUser->SetFrontFace(!IsNegativeScaling());
 		m_sgNode->ClearDirty(SG_Node::DIRTY_RENDER);
 	}
 
+	m_meshUser->SetLayer(m_layer);
 	m_meshUser->SetColor(m_objectColor);
-	m_meshUser->SetFrontFace(!IsNegativeScaling());
 	m_meshUser->ActivateMeshSlots();
 }
 

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -39,6 +39,10 @@ KX_TextMaterial::~KX_TextMaterial()
 {
 }
 
+void KX_TextMaterial::Prepare(RAS_Rasterizer *rasty)
+{
+}
+
 void KX_TextMaterial::Activate(RAS_Rasterizer *rasty)
 {
 }

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -36,6 +36,7 @@ public:
 	KX_TextMaterial();
 	virtual ~KX_TextMaterial();
 
+	virtual void Prepare(RAS_Rasterizer *rasty);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -212,7 +212,7 @@ void KX_WorldInfo::RenderBackground(RAS_Rasterizer *rasty)
 			GPUMaterial *gpumat = GPU_material_world(m_scene, m_scene->world);
 
 			static float texcofac[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
-			GPU_material_bind(gpumat, 0xFFFFFFFF, m_scene->lay, 1.0f, false, rasty->GetViewMatrix().Data(),
+			GPU_material_bind(gpumat, m_scene->lay, 1.0f, false, rasty->GetViewMatrix().Data(),
 			                  rasty->GetViewInvMatrix().Data(), texcofac, false);
 
 			rasty->Disable(RAS_Rasterizer::RAS_CULL_FACE);

--- a/source/gameengine/Rasterizer/RAS_BucketManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.cpp
@@ -96,8 +96,22 @@ RAS_BucketManager::~RAS_BucketManager()
 	}
 }
 
+void RAS_BucketManager::PrepareBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
+{
+	if (m_nodeData.m_shaderOverride) {
+		return;
+	}
+
+	for (RAS_MaterialBucket *bucket : m_buckets[bucketType]) {
+		RAS_IPolyMaterial *mat = bucket->GetPolyMaterial();
+		mat->Prepare(rasty);
+	}
+}
+
 void RAS_BucketManager::RenderSortedBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
 {
+	PrepareBuckets(rasty, bucketType);
+
 	BucketList& solidBuckets = m_buckets[bucketType];
 	RAS_UpwardTreeLeafs leafs;
 	for (RAS_MaterialBucket *bucket : solidBuckets) {
@@ -133,6 +147,8 @@ void RAS_BucketManager::RenderSortedBuckets(RAS_Rasterizer *rasty, RAS_BucketMan
 
 void RAS_BucketManager::RenderBasicBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
 {
+	PrepareBuckets(rasty, bucketType);
+
 	RAS_UpwardTreeLeafs leafs;
 	for (RAS_MaterialBucket *bucket : m_buckets[bucketType]) {
 		bucket->GenerateTree(m_downwardNode, m_upwardNode, leafs, m_nodeData.m_drawingMode, false);

--- a/source/gameengine/Rasterizer/RAS_BucketManager.h
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.h
@@ -119,6 +119,7 @@ public:
 	void MergeBucketManager(RAS_BucketManager *other, SCA_IScene *scene);
 
 private:
+	void PrepareBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
 	void RenderBasicBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
 	void RenderSortedBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
 };

--- a/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IPolygonMaterial.h
@@ -102,6 +102,8 @@ public:
 
 	virtual ~RAS_IPolyMaterial();
 
+	/// Prepare the material data for rendering.
+	virtual void Prepare(RAS_Rasterizer *rasty) = 0;
 	virtual void Activate(RAS_Rasterizer *rasty) = 0;
 	virtual void Desactivate(RAS_Rasterizer *rasty) = 0;
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride) = 0;

--- a/source/gameengine/Rasterizer/RAS_MeshUser.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.cpp
@@ -33,7 +33,8 @@
 #include "RAS_Deformer.h"
 
 RAS_MeshUser::RAS_MeshUser(void *clientobj, RAS_BoundingBox *boundingBox, RAS_Deformer *deformer)
-	:m_frontFace(true),
+	:m_layer((1 << 20) - 1),
+	m_frontFace(true),
 	m_color(mt::zero4),
 	m_boundingBox(boundingBox),
 	m_clientObject(clientobj),
@@ -59,6 +60,11 @@ RAS_MeshUser::~RAS_MeshUser()
 void RAS_MeshUser::NewMeshSlot(RAS_DisplayArrayBucket *arrayBucket)
 {
 	m_meshSlots.emplace_back(this, arrayBucket);
+}
+
+unsigned int RAS_MeshUser::GetLayer() const
+{
+	return m_layer;
 }
 
 bool RAS_MeshUser::GetFrontFace() const
@@ -99,6 +105,11 @@ RAS_BatchGroup *RAS_MeshUser::GetBatchGroup() const
 RAS_Deformer *RAS_MeshUser::GetDeformer()
 {
 	return m_deformer.get();
+}
+
+void RAS_MeshUser::SetLayer(unsigned int layer)
+{
+	m_layer = layer;
 }
 
 void RAS_MeshUser::SetFrontFace(bool frontFace)

--- a/source/gameengine/Rasterizer/RAS_MeshUser.h
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.h
@@ -40,6 +40,8 @@ class RAS_Deformer;
 class RAS_MeshUser : public mt::SimdClassAllocator
 {
 private:
+	/// Lamp layer.
+	unsigned int m_layer;
 	/// OpenGL face wise.
 	bool m_frontFace;
 	/// Object color.
@@ -62,6 +64,7 @@ public:
 	virtual ~RAS_MeshUser();
 
 	void NewMeshSlot(RAS_DisplayArrayBucket *arrayBucket);
+	unsigned int GetLayer() const;
 	bool GetFrontFace() const;
 	const mt::vec4& GetColor() const;
 	float *GetMatrix();
@@ -71,6 +74,7 @@ public:
 	RAS_BatchGroup *GetBatchGroup() const;
 	RAS_Deformer *GetDeformer();
 
+	void SetLayer(unsigned int layer);
 	void SetFrontFace(bool frontFace);
 	void SetColor(const mt::vec4& color);
 	void SetBatchGroup(RAS_BatchGroup *batchGroup);

--- a/source/gameengine/Rasterizer/RAS_TextureRenderer.cpp
+++ b/source/gameengine/Rasterizer/RAS_TextureRenderer.cpp
@@ -38,6 +38,8 @@
 
 #include "DNA_texture_types.h"
 
+#include "CM_Message.h"
+
 RAS_TextureRenderer::Face::Face(int target)
 	:m_fbo(nullptr),
 	m_rb(nullptr),
@@ -134,7 +136,17 @@ void RAS_TextureRenderer::GetValidTexture()
 		GPU_texture_free(m_gpuTex);
 	}
 
+	Image *ima = texture->GetImage();
+	unsigned int bindCode;
+	GPU_create_gl_tex(&bindCode, nullptr, nullptr, 1024, 1024, RAS_Texture::GetTexture2DType(), false, false, ima);
+	CM_Debug("bind code : " << bindCode);
 	m_gpuTex = gputex;
+	GPU_texture_set_opengl_bindcode(m_gpuTex, bindCode);
+
+	for (RAS_Texture *user : m_textureUsers) {
+		user->SetBindCode(bindCode);
+	}
+// 	ima->bindcode[TEXTARGET_TEXTURE_2D] = bindCode;
 
 	// Increment reference to make sure the gpu texture will not be freed by someone else.
 	GPU_texture_ref(m_gpuTex);


### PR DESCRIPTION
Previously the ligthing of the objects based on a layer was fixed
at the conversion time by the construction of BL_BlenderShader
with the member m_lightLayer. Also because of the blender
material managment the object layer was used only when binding
the material and not when binding object dependent uniforms.

The situation is changed firstly because the usage of one
layer for all the object using the same material is totally wrong.
Secondly the layers were not dynamic per object.

To solve this situation the fastest way is to expose a layer into
the shader, the function lamp_visible is designed for. It receives
the lamp layer, object layer, lamp color and lamp energy and
updates out color and energy if the lamp layer mask the object
layer, to avoid branching the test computes a value of 0 or 1
and multiply the color and energy by it.

The object layer is defined as a material builtin uniform and
each GPULamp holds a dynlayer used as a dynamic uniform.
At each call to GPU_material_bind_uniforms the object layer
is updated. Concerning the lamps the dynlayer value is updated
in a preparing stage before rendering any material, this stage
intents to update the textures and the lamps. The main caller
is RAS_BucketManager::PrepareBuckets calling for each material
the Prepare function redirected to BL_BlenderShader::UpdateLights.
This last function is calling GPU_material_update_lamps which
over all lamps update the "dyn" value for color and matrices.

Inside GPU_material_bind the lamp layer is computed. As it is
not the only way to decide of the visibility of a lamp, if the
lamp is hidden or the layer is set to 0, else if the lamp is not
using a "layer only" option then all layers are enabled, else if
the layer is not in the scene layer the layer is set to 0
else to the actual lamp object layer.

As GPU_material_bind_uniforms now use the object layer,
RAS_MeshUser store the layer of the object to allow BL_BlenderShader
to get this value and send it to the GPU_ function.
In the same time the calls to SetFrontFace are reduced to
only updating when the object node transform changed.

No performance win neither loss were noticed.

Test file, the two cube are from different layer and the lamp is switching of layer:
[ge_lamp_layer.zip](https://github.com/UPBGE/blender/files/2171721/ge_lamp_layer.zip)
