### PR TITLE
UPBGE: Implement BVH generation from KX_Mesh.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Mesh.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Mesh.rst
@@ -154,3 +154,10 @@ base class --- :class:`EXP_Value`
 
       :return: a duplicated mesh of the current used.
       :rtype: :class:`KX_Mesh`.
+
+   .. method:: constructBvh()
+
+      Return a BVH tree based on mesh geometry. Indices of tree elements match polygons indices.
+
+      :return: A BVH tree based on mesh geometry.
+      :rtype: :class:`mathutils.bvhtree.BVHTree`

--- a/source/blender/python/mathutils/mathutils_bvhtree.c
+++ b/source/blender/python/mathutils/mathutils_bvhtree.c
@@ -117,7 +117,7 @@ typedef struct {
 /** \name Utility helper functions
  * \{ */
 
-static PyObject *bvhtree_CreatePyObject(
+PyObject *bvhtree_CreatePyObject(
         BVHTree *tree, float epsilon,
 
         float (*coords)[3], unsigned int coords_len,

--- a/source/blender/python/mathutils/mathutils_bvhtree.h
+++ b/source/blender/python/mathutils/mathutils_bvhtree.h
@@ -26,11 +26,22 @@
 #ifndef __MATHUTILS_BVHTREE_H__
 #define __MATHUTILS_BVHTREE_H__
 
+typedef struct BVHTree BVHTree;
+
 PyMODINIT_FUNC PyInit_mathutils_bvhtree(void);
 
 extern PyTypeObject PyBVHTree_Type;
 
 #define PyBVHTree_Check(v)  PyObject_TypeCheck((v), &PyBVHTree_Type)
 #define PyBVHTree_CheckExact(v)  (Py_TYPE(v) == &PyBVHTree_Type)
+
+PyObject *bvhtree_CreatePyObject(
+	BVHTree *tree, float epsilon,
+	
+	float (*coords)[3], unsigned int coords_len,
+	unsigned int (*tris)[3], unsigned int tris_len,
+
+	/* optional arrays */
+	int *orig_index, float (*orig_normal)[3]);
 
 #endif /* __MATHUTILS_BVHTREE_H__ */

--- a/source/gameengine/Ketsji/KX_Mesh.h
+++ b/source/gameengine/Ketsji/KX_Mesh.h
@@ -76,6 +76,7 @@ public:
 	EXP_PYMETHOD(KX_Mesh, TransformUV);
 	EXP_PYMETHOD(KX_Mesh, ReplaceMaterial);
 	EXP_PYMETHOD_NOARGS(KX_Mesh, Copy);
+	EXP_PYMETHOD(KX_Mesh, ConstructBvh);
 
 	static PyObject *pyattr_get_materials(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
 	static PyObject *pyattr_get_numMaterials(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);


### PR DESCRIPTION
The python function KX_Mesh.constructBvh now returns a new BVH Tree
based on the mesh geometry where every indices elements of the tree
correspond to the polygons indices.

Test file:
[ge_bvhtree.zip](https://github.com/UPBGE/blender/files/2173760/ge_bvhtree.zip)
