### PR TITLE
UPBGE: Refactor texture renderers and fix planar and stereo.

### DIFF
--- a/source/blender/gpu/GPU_texture.h
+++ b/source/blender/gpu/GPU_texture.h
@@ -79,6 +79,7 @@ GPUTexture *GPU_texture_create_2D_multisample(
 GPUTexture *GPU_texture_create_depth_multisample(int w, int h, int samples, bool compare, char err_out[256]);
 GPUTexture *GPU_texture_from_blender(
         struct Image *ima, struct ImageUser *iuser, int textarget, bool is_data, double time, int mipmap);
+GPUTexture *GPU_texture_from_bindcode(int textarget, int bindcode);
 GPUTexture *GPU_texture_from_preview(struct PreviewImage *prv, int mipmap);
 GPUTexture *GPU_texture_create_jitter(int w);
 GPUTexture *GPU_texture_global_jitter_64(void);

--- a/source/blender/gpu/intern/gpu_draw.c
+++ b/source/blender/gpu/intern/gpu_draw.c
@@ -824,6 +824,11 @@ void GPU_create_gl_tex(
 			if (cube_map)
 				for (int i = 0; i < 6; i++)
 					glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, informat, w, h, 0, GL_RGBA, type, cube_map[i]);
+			else {
+				for (int i = 0; i < 6; i++) {
+					glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, informat, w, h, 0, GL_RGBA, type, NULL);
+				}
+			}
 
 			glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, gpu_get_mipmap_filter(1));
 

--- a/source/blender/gpu/intern/gpu_texture.c
+++ b/source/blender/gpu/intern/gpu_texture.c
@@ -434,6 +434,40 @@ GPUTexture *GPU_texture_from_blender(Image *ima, ImageUser *iuser, int textarget
 	return tex;
 }
 
+GPUTexture *GPU_texture_from_bindcode(int textarget, int bindcode)
+{
+	GPUTexture *tex = MEM_callocN(sizeof(GPUTexture), "GPUTexture");
+	tex->bindcode = bindcode;
+	tex->number = -1;
+	tex->refcount = 1;
+	tex->target = textarget;
+	tex->target_base = textarget;
+
+	if (!glIsTexture(tex->bindcode)) {
+		GPU_ASSERT_NO_GL_ERRORS("Texture Not Loaded");
+	}
+	else {
+		GLint w, h, border;
+
+		GLenum gettarget;
+
+		if (textarget == GL_TEXTURE_2D)
+			gettarget = GL_TEXTURE_2D;
+		else
+			gettarget = GL_TEXTURE_CUBE_MAP_POSITIVE_X;
+
+		glBindTexture(textarget, tex->bindcode);
+		glGetTexLevelParameteriv(gettarget, 0, GL_TEXTURE_WIDTH, &w);
+		glGetTexLevelParameteriv(gettarget, 0, GL_TEXTURE_HEIGHT, &h);
+		glGetTexLevelParameteriv(gettarget, 0, GL_TEXTURE_BORDER, &border);
+
+		tex->w = w - border;
+		tex->h = h - border;
+	}
+
+	return tex;
+}
+
 GPUTexture *GPU_texture_from_preview(PreviewImage *prv, int mipmap)
 {
 	GPUTexture *tex = prv->gputexture[0];

--- a/source/gameengine/Ketsji/BL_Texture.cpp
+++ b/source/gameengine/Ketsji/BL_Texture.cpp
@@ -38,7 +38,8 @@ BL_Texture::BL_Texture(MTex *mtex)
 	:EXP_Value(),
 	m_isCubeMap(false),
 	m_mtex(mtex),
-	m_gpuTex(nullptr)
+	m_gpuTex(nullptr),
+	m_imaTarget(0)
 {
 	Tex *tex = m_mtex->tex;
 	EnvMap *env = tex->env;
@@ -46,11 +47,13 @@ BL_Texture::BL_Texture(MTex *mtex)
 	               (env->stype == ENV_LOAD ||
 	                (env->stype == ENV_REALT && env->type == ENV_CUBE)));
 
+	m_imaTarget = m_isCubeMap ? TEXTARGET_TEXTURE_CUBE_MAP : TEXTARGET_TEXTURE_2D;
+	m_target = m_isCubeMap ? GetCubeMapTextureType() : GetTexture2DType();
+
 	Image *ima = tex->ima;
 	ImageUser& iuser = tex->iuser;
-	const int gltextarget = m_isCubeMap ? GetCubeMapTextureType() : GetTexture2DType();
 
-	m_gpuTex = (ima ? GPU_texture_from_blender(ima, &iuser, gltextarget, false, 0.0, true) : nullptr);
+	m_gpuTex = (ima ? GPU_texture_from_blender(ima, &iuser, m_target, false, 0.0, true) : nullptr);
 
 	// Initialize saved data.
 	m_name = std::string(m_mtex->tex->id.name + 2);
@@ -101,9 +104,15 @@ BL_Texture::~BL_Texture()
 	copy_v3_v3(m_mtex->size, m_savedData.uvsize);
 
 	if (m_gpuTex) {
-		GPU_texture_set_opengl_bindcode(m_gpuTex, m_savedData.bindcode);
+		SetGPUBindCode(m_savedData.bindcode);
 		GPU_texture_free(m_gpuTex);
 	}
+}
+
+void BL_Texture::SetGPUBindCode(int bindCode)
+{
+	GPU_texture_set_opengl_bindcode(m_gpuTex, bindCode);
+	m_mtex->tex->ima->bindcode[m_imaTarget] = bindCode;
 }
 
 void BL_Texture::CheckValidTexture()
@@ -118,19 +127,16 @@ void BL_Texture::CheckValidTexture()
 	 * The gpu texture in the image can be nullptr or an already different loaded
 	 * gpu texture. In both cases we call GPU_texture_from_blender.
 	 */
-	int target = m_isCubeMap ? TEXTARGET_TEXTURE_CUBE_MAP : TEXTARGET_TEXTURE_2D;
-	if (m_gpuTex != m_mtex->tex->ima->gputexture[target]) {
+	if (m_gpuTex != m_mtex->tex->ima->gputexture[m_imaTarget]) {
 		Tex *tex = m_mtex->tex;
 		Image *ima = tex->ima;
 		ImageUser& iuser = tex->iuser;
 
-		const int gltextarget = m_isCubeMap ? GetCubeMapTextureType() : GetTexture2DType();
-
-		// Restore gpu texture original bind cdoe to make sure we will delete the right opengl texture.
+		// Restore gpu texture original bind code to make sure we will delete the right opengl texture.
 		GPU_texture_set_opengl_bindcode(m_gpuTex, m_savedData.bindcode);
 		GPU_texture_free(m_gpuTex);
 
-		m_gpuTex = (ima ? GPU_texture_from_blender(ima, &iuser, gltextarget, false, 0.0, true) : nullptr);
+		m_gpuTex = (ima ? GPU_texture_from_blender(ima, &iuser, m_target, false, 0.0, true) : nullptr);
 
 		if (m_gpuTex) {
 			int bindCode = GPU_texture_opengl_bindcode(m_gpuTex);
@@ -179,13 +185,17 @@ unsigned int BL_Texture::GetTextureType()
 	return GPU_texture_target(m_gpuTex);
 }
 
+void BL_Texture::UpdateBindCode()
+{
+	/* Since GPUTexture can be shared (as Image is shared along materials)
+	 * between material textures (MTex), we should reapply the bindcode in
+	 * case of VideoTexture owned texture. Without that every material that
+	 * use this GPUTexture will then use the VideoTexture texture, it's not wanted. */
+	SetGPUBindCode(m_bindCode);
+}
+
 void BL_Texture::ActivateTexture(int unit)
 {
-	/* Since GPUTexture can be shared between material textures (MTex),
-	 * we should reapply the bindcode in case of VideoTexture owned texture.
-	 * Without that every material that use this GPUTexture will then use
-	 * the VideoTexture texture, it's not wanted. */
-	GPU_texture_set_opengl_bindcode(m_gpuTex, m_bindCode);
 	GPU_texture_bind(m_gpuTex, unit);
 }
 

--- a/source/gameengine/Ketsji/BL_Texture.h
+++ b/source/gameengine/Ketsji/BL_Texture.h
@@ -40,6 +40,8 @@ private:
 	bool m_isCubeMap;
 	MTex *m_mtex;
 	GPUTexture *m_gpuTex;
+	int m_imaTarget;
+	int m_target;
 
 	struct {
 		unsigned int bindcode;
@@ -62,6 +64,9 @@ private:
 		float uvsize[3];
 	} m_savedData;
 
+	/// Update bind code in GPUTexture and Image data.
+	void SetGPUBindCode(int bindCode);
+
 public:
 	BL_Texture(MTex *mtex);
 	virtual ~BL_Texture();
@@ -81,6 +86,7 @@ public:
 
 	enum {MaxUnits = 8};
 
+	virtual void UpdateBindCode();
 	virtual void CheckValidTexture();
 	virtual void ActivateTexture(int unit);
 	virtual void DisableTexture();

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -125,6 +125,7 @@ set(SRC
 	KX_RadarSensor.cpp
 	KX_RayCast.cpp
 	KX_RaySensor.cpp
+	KX_RenderData.cpp
 	KX_AddObjectActuator.cpp
 	KX_DynamicActuator.cpp
 	KX_EndObjectActuator.cpp
@@ -209,6 +210,7 @@ set(SRC
 	KX_RadarSensor.h
 	KX_RayCast.h
 	KX_RaySensor.h
+	KX_RenderData.h
 	KX_AddObjectActuator.h
 	KX_DynamicActuator.h
 	KX_EndObjectActuator.h

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -31,16 +31,20 @@ public:
 
 	virtual ~KX_BlenderMaterial();
 
-	virtual void Prepare(RAS_Rasterizer *rasty);
+	virtual void Prepare(RAS_Rasterizer *rasty, unsigned short viewportIndex);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);
 	virtual void ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
-	void UpdateTextures();
-	void ApplyTextures();
-	void ActivateShaders(RAS_Rasterizer *rasty);
+	/// Update material textures data and bind code.
+	void UpdateTextures(unsigned short viewportIndex);
+	/// Select bind code in shared texture for next rendering.
+	void SetTexturesBindCode();
+	/// Bind all textures.
+	void BindTextures();
 
+	void ActivateShaders(RAS_Rasterizer *rasty);
 	void ActivateBlenderShaders(RAS_Rasterizer *rasty);
 
 	const RAS_Rasterizer::BlendFunc *GetBlendFunc() const;

--- a/source/gameengine/Ketsji/KX_CubeMap.h
+++ b/source/gameengine/Ketsji/KX_CubeMap.h
@@ -47,17 +47,18 @@ public:
 	/// Face view matrices in 3x3 matrices.
 	static const mt::mat3 faceViewMatrices3x3[NUM_FACES];
 
-	KX_CubeMap(EnvMap *env, KX_GameObject *viewpoint);
+	KX_CubeMap(MTex *mtex, KX_GameObject *viewpoint);
 	virtual ~KX_CubeMap();
 
 	virtual std::string GetName();
 
 	virtual void InvalidateProjectionMatrix();
-	virtual const mt::mat4& GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
-													const RAS_Rect& viewport, const RAS_Rect& area);
+	virtual mt::mat4 GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
+			const RAS_Rect& viewport, const RAS_Rect& area, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye);
 
-	virtual bool SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera);
-	virtual bool SetupCameraFace(KX_Camera *camera, unsigned short index);
+	virtual LayerUsage EnsureLayers(int viewportCount);
+	virtual bool Prepare(KX_Camera *sceneCamera, RAS_Rasterizer::StereoEye eye, KX_Camera *camera);
+	virtual bool PrepareFace(KX_Camera *camera, unsigned short index);
 };
 
 #endif  // __KX_CUBEMAP_H__

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -84,50 +84,6 @@ KX_ExitInfo::KX_ExitInfo()
 {
 }
 
-KX_KetsjiEngine::CameraRenderData::CameraRenderData(KX_Camera *rendercam, KX_Camera *cullingcam, const RAS_Rect& area,
-                                                    const RAS_Rect& viewport, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye)
-	:m_renderCamera(rendercam),
-	m_cullingCamera(cullingcam),
-	m_area(area),
-	m_viewport(viewport),
-	m_stereoMode(stereoMode),
-	m_eye(eye)
-{
-	m_renderCamera->AddRef();
-}
-
-KX_KetsjiEngine::CameraRenderData::CameraRenderData(const CameraRenderData& other)
-	:m_renderCamera(CM_AddRef(other.m_renderCamera)),
-	m_cullingCamera(other.m_cullingCamera),
-	m_area(other.m_area),
-	m_viewport(other.m_viewport),
-	m_stereoMode(other.m_stereoMode),
-	m_eye(other.m_eye)
-{
-}
-
-KX_KetsjiEngine::CameraRenderData::~CameraRenderData()
-{
-	m_renderCamera->Release();
-}
-
-KX_KetsjiEngine::SceneRenderData::SceneRenderData(KX_Scene *scene)
-	:m_scene(scene)
-{
-}
-
-KX_KetsjiEngine::FrameRenderData::FrameRenderData(RAS_OffScreen::Type ofsType)
-	:m_ofsType(ofsType)
-{
-}
-
-KX_KetsjiEngine::RenderData::RenderData(RAS_Rasterizer::StereoMode stereoMode, bool renderPerEye)
-	:m_stereoMode(stereoMode),
-	m_renderPerEye(renderPerEye)
-{
-}
-
-
 const std::string KX_KetsjiEngine::m_profileLabels[tc_numCategories] = {
 	"Physics:", // tc_physics
 	"Logic:", // tc_logic
@@ -516,8 +472,9 @@ void KX_KetsjiEngine::UpdateSuspendedScenes(double framestep)
 	}
 }
 
-KX_KetsjiEngine::CameraRenderData KX_KetsjiEngine::GetCameraRenderData(KX_Scene *scene, KX_Camera *camera, KX_Camera *overrideCullingCam,
-                                                                       const RAS_Rect& displayArea, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye)
+KX_CameraRenderData KX_KetsjiEngine::GetCameraRenderData(KX_Scene *scene, KX_Camera *camera, KX_Camera *overrideCullingCam,
+		const RAS_Rect& displayArea, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye,
+		unsigned short viewportIndex)
 {
 	KX_Camera *rendercam;
 	/* In case of stereo we must copy the camera because it is used twice with different settings
@@ -552,7 +509,7 @@ KX_KetsjiEngine::CameraRenderData KX_KetsjiEngine::GetCameraRenderData(KX_Scene 
 	// Compute the camera matrices: modelview and projection.
 	rendercam->UpdateView(m_rasterizer, scene, stereoMode, eye, viewport, area);
 
-	CameraRenderData cameraData(rendercam, cullingcam, area, viewport, stereoMode, eye);
+	KX_CameraRenderData cameraData(rendercam, cullingcam, area, viewport, stereoMode, eye, viewportIndex);
 
 	if (usestereo) {
 		rendercam->Release();
@@ -561,7 +518,7 @@ KX_KetsjiEngine::CameraRenderData KX_KetsjiEngine::GetCameraRenderData(KX_Scene 
 	return cameraData;
 }
 
-KX_KetsjiEngine::RenderData KX_KetsjiEngine::GetRenderData()
+KX_RenderData KX_KetsjiEngine::GetRenderData()
 {
 	const RAS_Rasterizer::StereoMode stereomode = m_rasterizer->GetStereoMode();
 	const bool usestereo = (stereomode != RAS_Rasterizer::RAS_STEREO_NOSTEREO);
@@ -570,7 +527,7 @@ KX_KetsjiEngine::RenderData KX_KetsjiEngine::GetRenderData()
 	                          stereomode == RAS_Rasterizer::RAS_STEREO_VINTERLACE ||
 	                          stereomode == RAS_Rasterizer::RAS_STEREO_ANAGLYPH;
 
-	RenderData renderData(stereomode, renderpereye);
+	KX_RenderData renderData(stereomode, renderpereye);
 
 	// The number of eyes to manage in case of stereo.
 	const unsigned short numeyes = (usestereo) ? 2 : 1;
@@ -604,9 +561,6 @@ KX_KetsjiEngine::RenderData KX_KetsjiEngine::GetRenderData()
 	}
 
 	for (unsigned short frame = 0; frame < numframes; ++frame) {
-		renderData.m_frameDataList.emplace_back(ofsType[frame]);
-		FrameRenderData& frameData = renderData.m_frameDataList.back();
-
 		// Get the eyes managed per frame.
 		std::vector<RAS_Rasterizer::StereoEye> eyes;
 		// One eye per frame but different.
@@ -621,22 +575,25 @@ KX_KetsjiEngine::RenderData KX_KetsjiEngine::GetRenderData()
 		else {
 			eyes = {RAS_Rasterizer::RAS_STEREO_LEFTEYE};
 		}
+		
+		renderData.m_frameDataList.emplace_back(ofsType[frame], eyes);
+	}
 
-		for (KX_Scene *scene : m_scenes) {
-			frameData.m_sceneDataList.emplace_back(scene);
-			SceneRenderData& sceneFrameData = frameData.m_sceneDataList.back();
+	for (KX_Scene *scene : m_scenes) {
+		renderData.m_sceneDataList.emplace_back(scene);
+		KX_SceneRenderData& sceneFrameData = renderData.m_sceneDataList.back();
 
-			KX_Camera *activecam = scene->GetActiveCamera();
-			KX_Camera *overrideCullingCam = scene->GetOverrideCullingCamera();
-			for (KX_Camera *cam : scene->GetCameraList()) {
-				if (cam != activecam && !cam->UseViewport()) {
-					continue;
-				}
+		KX_Camera *activecam = scene->GetActiveCamera();
+		KX_Camera *overrideCullingCam = scene->GetOverrideCullingCamera();
+		unsigned int viewportIndex = 0;
+		for (KX_Camera *cam : scene->GetCameraList()) {
+			if (cam != activecam && !cam->UseViewport()) {
+				continue;
+			}
 
-				for (RAS_Rasterizer::StereoEye eye : eyes) {
-					sceneFrameData.m_cameraDataList.push_back(GetCameraRenderData(scene, cam, overrideCullingCam, displayAreas[eye],
-					                                                              stereomode, eye));
-				}
+			for (unsigned short eye = 0; eye < numeyes; ++eye) {
+				sceneFrameData.m_cameraDataList[eye].push_back(GetCameraRenderData(scene, cam, overrideCullingCam,
+							displayAreas[eye], stereomode, (RAS_Rasterizer::StereoEye)eye, viewportIndex++));
 			}
 		}
 	}
@@ -650,14 +607,14 @@ void KX_KetsjiEngine::Render()
 
 	BeginFrame();
 
-	for (KX_Scene *scene : m_scenes) {
+	KX_RenderData renderData = GetRenderData();
+
+	for (const KX_SceneRenderData& sceneData : renderData.m_sceneDataList) {
+		KX_Scene *scene = sceneData.m_scene;
 		// shadow buffers
 		RenderShadowBuffers(scene);
-		// Render only independent texture renderers here.
-		scene->RenderTextureRenderers(KX_TextureRendererManager::VIEWPORT_INDEPENDENT, m_rasterizer, nullptr, nullptr, RAS_Rect(), RAS_Rect());
+		scene->RenderTextureRenderers(m_rasterizer, sceneData);
 	}
-
-	RenderData renderData = GetRenderData();
 
 	const int width = m_canvas->GetWidth();
 	const int height = m_canvas->GetHeight();
@@ -674,7 +631,7 @@ void KX_KetsjiEngine::Render()
 	// Used to detect when a camera is the first rendered an then doesn't request a depth clear.
 	unsigned short pass = 0;
 
-	for (FrameRenderData& frameData : renderData.m_frameDataList) {
+	for (KX_FrameRenderData& frameData : renderData.m_frameDataList) {
 		// Current bound off screen.
 		RAS_OffScreen *offScreen = m_canvas->GetOffScreen(frameData.m_ofsType);
 		offScreen->Bind();
@@ -683,8 +640,8 @@ void KX_KetsjiEngine::Render()
 		m_rasterizer->Clear(RAS_Rasterizer::RAS_COLOR_BUFFER_BIT | RAS_Rasterizer::RAS_DEPTH_BUFFER_BIT);
 
 		// for each scene, call the proceed functions
-		for (unsigned short i = 0, size = frameData.m_sceneDataList.size(); i < size; ++i) {
-			const SceneRenderData& sceneFrameData = frameData.m_sceneDataList[i];
+		for (unsigned short i = 0, size = renderData.m_sceneDataList.size(); i < size; ++i) {
+			const KX_SceneRenderData& sceneFrameData = renderData.m_sceneDataList[i];
 			KX_Scene *scene = sceneFrameData.m_scene;
 
 			const bool isfirstscene = (i == 0);
@@ -695,10 +652,13 @@ void KX_KetsjiEngine::Render()
 
 			m_rasterizer->SetAuxilaryClientInfo(scene);
 
-			// Draw the scene once for each camera with an enabled viewport or an active camera.
-			for (const CameraRenderData& cameraFrameData : sceneFrameData.m_cameraDataList) {
-				// do the rendering
-				RenderCamera(scene, cameraFrameData, offScreen, pass++, isfirstscene);
+			// Render the eyes handled by the frame.
+			for (RAS_Rasterizer::StereoEye eye : frameData.m_eyes) {
+				// Draw the scene once for each camera with an enabled viewport or an active camera.
+				for (const KX_CameraRenderData& cameraFrameData : sceneFrameData.m_cameraDataList[eye]) {
+					// do the rendering
+					RenderCamera(scene, cameraFrameData, offScreen, pass++, isfirstscene);
+				}
 			}
 
 			/* Choose final render off screen target. If the current off screen is using multisamples we
@@ -834,7 +794,7 @@ void KX_KetsjiEngine::RenderShadowBuffers(KX_Scene *scene)
 				/* render */
 				m_rasterizer->Clear(RAS_Rasterizer::RAS_DEPTH_BUFFER_BIT | RAS_Rasterizer::RAS_COLOR_BUFFER_BIT);
 				// Send a nullptr off screen because the viewport is binding it's using its own private one.
-				scene->RenderBuckets(objects, RAS_Rasterizer::RAS_SHADOW, camtrans, m_rasterizer, nullptr);
+				scene->RenderBuckets(objects, RAS_Rasterizer::RAS_SHADOW, camtrans, 0, m_rasterizer, nullptr);
 
 				/* unbind framebuffer object, restore drawmode, free camera */
 				raslight->UnbindShadowBuffer();
@@ -845,20 +805,14 @@ void KX_KetsjiEngine::RenderShadowBuffers(KX_Scene *scene)
 }
 
 // update graphics
-void KX_KetsjiEngine::RenderCamera(KX_Scene *scene, const CameraRenderData& cameraFrameData, RAS_OffScreen *offScreen,
+void KX_KetsjiEngine::RenderCamera(KX_Scene *scene, const KX_CameraRenderData& cameraFrameData, RAS_OffScreen *offScreen,
                                    unsigned short pass, bool isFirstScene)
 {
 	KX_Camera *rendercam = cameraFrameData.m_renderCamera;
 	KX_Camera *cullingcam = cameraFrameData.m_cullingCamera;
-	const RAS_Rect &area = cameraFrameData.m_area;
 	const RAS_Rect &viewport = cameraFrameData.m_viewport;
 
 	KX_SetActiveScene(scene);
-
-	/* Render texture probes depending of the the current viewport and area, these texture probes are commonly the planar map
-	 * which need to be recomputed by each view in case of multi-viewport or stereo.
-	 */
-	scene->RenderTextureRenderers(KX_TextureRendererManager::VIEWPORT_DEPENDENT, m_rasterizer, offScreen, rendercam, viewport, area);
 
 	// set the viewport for this frame and scene
 	const int left = viewport.GetLeft();
@@ -915,7 +869,8 @@ void KX_KetsjiEngine::RenderCamera(KX_Scene *scene, const CameraRenderData& came
 	scene->RunDrawingCallbacks(KX_Scene::PRE_DRAW, rendercam);
 #endif
 
-	scene->RenderBuckets(objects, m_rasterizer->GetDrawingMode(), rendercam->GetWorldToCamera(), m_rasterizer, offScreen);
+	scene->RenderBuckets(objects, m_rasterizer->GetDrawingMode(), rendercam->GetWorldToCamera(),
+			cameraFrameData.m_index, m_rasterizer, offScreen);
 
 	if (scene->GetPhysicsEnvironment()) {
 		scene->GetPhysicsEnvironment()->DebugDrawWorld();
@@ -1117,7 +1072,7 @@ void KX_KetsjiEngine::RenderDebugProperties()
 	m_debugDraw.Flush(m_rasterizer, m_canvas);
 }
 
-void KX_KetsjiEngine::DrawDebugCameraFrustum(KX_Scene *scene, const CameraRenderData& cameraFrameData)
+void KX_KetsjiEngine::DrawDebugCameraFrustum(KX_Scene *scene, const KX_CameraRenderData& cameraFrameData)
 {
 	if (m_showCameraFrustum == KX_DebugOption::DISABLE) {
 		return;

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -35,6 +35,7 @@
 
 #include <string>
 #include "KX_TimeCategoryLogger.h"
+#include "KX_RenderData.h"
 #include "EXP_Python.h"
 #include "KX_WorldInfo.h"
 #include "RAS_CameraData.h"
@@ -118,48 +119,6 @@ public:
 	};
 
 private:
-	struct CameraRenderData
-	{
-		CameraRenderData(KX_Camera *rendercam, KX_Camera *cullingcam, const RAS_Rect& area, const RAS_Rect& viewport,
-				RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye);
-		CameraRenderData(const CameraRenderData& other);
-		~CameraRenderData();
-
-		/// Rendered camera, could be a temporary camera in case of stereo.
-		KX_Camera *m_renderCamera;
-		KX_Camera *m_cullingCamera;
-		RAS_Rect m_area;
-		RAS_Rect m_viewport;
-		RAS_Rasterizer::StereoMode m_stereoMode;
-		RAS_Rasterizer::StereoEye m_eye;
-	};
-
-	struct SceneRenderData
-	{
-		SceneRenderData(KX_Scene *scene);
-
-		KX_Scene *m_scene;
-		std::vector<CameraRenderData> m_cameraDataList;
-	};
-
-	/// Data used to render a frame.
-	struct FrameRenderData
-	{
-		FrameRenderData(RAS_OffScreen::Type ofsType);
-
-		RAS_OffScreen::Type m_ofsType;
-		std::vector<SceneRenderData> m_sceneDataList;
-	};
-
-	struct RenderData
-	{
-		RenderData(RAS_Rasterizer::StereoMode stereoMode, bool renderPerEye);
-
-		RAS_Rasterizer::StereoMode m_stereoMode;
-		bool m_renderPerEye;
-		std::vector<FrameRenderData> m_frameDataList;
-	};
-
 	struct FrameTimes
 	{
 		// Number of frames to proceed.
@@ -292,16 +251,17 @@ private:
 	/// Update and return the projection matrix of a camera depending on the viewport.
 	mt::mat4 GetCameraProjectionMatrix(KX_Scene *scene, KX_Camera *cam, RAS_Rasterizer::StereoMode stereoMode,
 			RAS_Rasterizer::StereoEye eye, const RAS_Rect& viewport, const RAS_Rect& area) const;
-	CameraRenderData GetCameraRenderData(KX_Scene *scene, KX_Camera *camera, KX_Camera *overrideCullingCam, const RAS_Rect& displayArea,
-			RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye);
+	KX_CameraRenderData GetCameraRenderData(KX_Scene *scene, KX_Camera *camera, KX_Camera *overrideCullingCam,
+			const RAS_Rect& displayArea, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye,
+			unsigned short viewportIndex);
 	/// Compute frame render data per eyes (in case of stereo), scenes and camera.
-	RenderData GetRenderData();
+	KX_RenderData GetRenderData();
 
-	void RenderCamera(KX_Scene *scene, const CameraRenderData& cameraFrameData, RAS_OffScreen *offScreen, unsigned short pass, bool isFirstScene);
+	void RenderCamera(KX_Scene *scene, const KX_CameraRenderData& cameraFrameData, RAS_OffScreen *offScreen, unsigned short pass, bool isFirstScene);
 	RAS_OffScreen *PostRenderScene(KX_Scene *scene, RAS_OffScreen *inputofs, RAS_OffScreen *targetofs);
 	void RenderDebugProperties();
 	/// Debug draw cameras frustum of a scene.
-	void DrawDebugCameraFrustum(KX_Scene *scene, const CameraRenderData& cameraFrameData);
+	void DrawDebugCameraFrustum(KX_Scene *scene, const KX_CameraRenderData& cameraFrameData);
 	/// Debug draw lights shadow frustum of a scene.
 	void DrawDebugShadowFrustum(KX_Scene *scene);
 

--- a/source/gameengine/Ketsji/KX_PlanarMap.cpp
+++ b/source/gameengine/Ketsji/KX_PlanarMap.cpp
@@ -31,13 +31,11 @@
 #include "RAS_Rasterizer.h"
 #include "RAS_Texture.h"
 
-KX_PlanarMap::KX_PlanarMap(EnvMap *env, KX_GameObject *viewpoint)
-	:KX_TextureRenderer(env, viewpoint),
+KX_PlanarMap::KX_PlanarMap(MTex *mtex, KX_GameObject *viewpoint)
+	:KX_TextureRenderer(mtex, viewpoint, LAYER_UNIQUE),
 	m_normal(mt::axisZ3)
 {
-	m_faces.emplace_back(RAS_Texture::GetTexture2DType());
-
-	switch (env->mode) {
+	switch (m_mtex->tex->env->mode) {
 		case ENVMAP_REFLECTION:
 		{
 			m_type = REFLECTION;
@@ -74,21 +72,16 @@ void KX_PlanarMap::ComputeClipPlane(const mt::vec3& mirrorObjWorldPos, const mt:
 
 void KX_PlanarMap::InvalidateProjectionMatrix()
 {
-	m_projections.clear();
 }
 
-const mt::mat4& KX_PlanarMap::GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
-                                                  const RAS_Rect& viewport, const RAS_Rect& area)
+mt::mat4 KX_PlanarMap::GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
+	const RAS_Rect& viewport, const RAS_Rect& area, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye)
 {
-	std::unordered_map<KX_Camera *, mt::mat4>::const_iterator projectionit = m_projections.find(sceneCamera);
-	if (projectionit != m_projections.end()) {
-		return projectionit->second;
-	}
-
-	mt::mat4& projection = m_projections[sceneCamera];
+	mt::mat4 projection;
 
 	RAS_FrameFrustum frustum;
 	const bool orthographic = !sceneCamera->GetCameraData()->m_perspective;
+	const float focallength = sceneCamera->GetFocalLength();
 
 	if (orthographic) {
 		RAS_FramingManager::ComputeOrtho(
@@ -132,33 +125,44 @@ const mt::mat4& KX_PlanarMap::GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scen
 			frustum.x1, frustum.x2, frustum.y1, frustum.y2, frustum.camnear, frustum.camfar);
 	}
 	else {
-		projection = rasty->GetFrustumMatrix(frustum.x1, frustum.x2, frustum.y1, frustum.y2, frustum.camnear, frustum.camfar);
+		projection = rasty->GetFrustumMatrix(stereoMode, eye, focallength,
+				frustum.x1, frustum.x2, frustum.y1, frustum.y2, frustum.camnear, frustum.camfar);
 	}
 
 	return projection;
 }
 
-void KX_PlanarMap::BeginRenderFace(RAS_Rasterizer *rasty)
+void KX_PlanarMap::BeginRender(RAS_Rasterizer* rasty, unsigned short layer)
 {
-	KX_TextureRenderer::BeginRenderFace(rasty);
+	RAS_TextureRenderer::BeginRender(rasty, layer);
 
-	if (m_type == REFLECTION) {
-		rasty->SetInvertFrontFace(true);
-		rasty->EnableClipPlane(0, m_clipPlane);
-	}
-	else {
-		rasty->EnableClipPlane(0, -m_clipPlane);
-	}
+	rasty->SetInvertFrontFace((m_type == REFLECTION));
 }
 
-void KX_PlanarMap::EndRenderFace(RAS_Rasterizer *rasty)
+void KX_PlanarMap::EndRender(RAS_Rasterizer* rasty, unsigned short layer)
 {
-	if (m_type == REFLECTION) {
-		rasty->SetInvertFrontFace(false);
-	}
-	rasty->DisableClipPlane(0);
+	RAS_TextureRenderer::EndRender(rasty, layer);
 
-	KX_TextureRenderer::EndRenderFace(rasty);
+	rasty->SetInvertFrontFace(false);
+	rasty->DisableClipPlane(0);
+}
+
+void KX_PlanarMap::BeginRenderFace(RAS_Rasterizer* rasty, unsigned short layer, unsigned short face)
+{
+	RAS_TextureRenderer::BeginRenderFace(rasty, layer, face);
+
+	switch (m_type) {
+		case REFLECTION:
+		{
+			rasty->EnableClipPlane(0, m_clipPlane);
+			break;
+		}
+		case REFRACTION:
+		{
+			rasty->EnableClipPlane(0, -m_clipPlane);
+			break;
+		}
+	}
 }
 
 const mt::vec3& KX_PlanarMap::GetNormal() const
@@ -171,15 +175,30 @@ void KX_PlanarMap::SetNormal(const mt::vec3& normal)
 	m_normal = normal.Normalized();
 }
 
-bool KX_PlanarMap::SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera)
+RAS_TextureRenderer::LayerUsage KX_PlanarMap::EnsureLayers(int viewportCount)
 {
-	KX_GameObject *mirror = GetViewpointObject();
+	// Create as much layers as viewports in the scene, cause the rendering depends on the camera transform.
+	const unsigned short size = m_layers.size();
+	if (size < viewportCount) {
+		m_layers.resize(viewportCount);
+		for (unsigned short i = size; i < viewportCount; ++i) {
+			m_layers[i] = Layer({RAS_Texture::GetTexture2DType()}, RAS_Texture::GetTexture2DType(), 
+					m_mtex->tex->ima, m_useMipmap, m_useLinear);
+		}
+	}
 
+	return m_layerUsage;
+}
+
+bool KX_PlanarMap::Prepare(KX_Camera *sceneCamera, RAS_Rasterizer::StereoEye eye, KX_Camera *camera)
+{
 	// Compute camera position and orientation.
-	const mt::mat3& mirrorObjWorldOri = mirror->NodeGetWorldOrientation();
-	const mt::vec3& mirrorObjWorldPos = mirror->NodeGetWorldPosition();
+	const mt::mat3& mirrorObjWorldOri = m_viewpointObject->NodeGetWorldOrientation();
+	const mt::vec3& mirrorObjWorldPos = m_viewpointObject->NodeGetWorldPosition();
 
-	mt::vec3 cameraWorldPos = sceneCamera->NodeGetWorldPosition();
+	// Use the position and orientation from the view matrix to take care of stereo.
+	const mt::mat4& viewMat = sceneCamera->GetModelviewMatrix(eye).Inverse();
+	mt::vec3 cameraWorldPos = viewMat.TranslationVector3D();
 
 	// Update clip plane to possible new normal or viewpoint object.
 	ComputeClipPlane(mirrorObjWorldPos, mirrorObjWorldOri);
@@ -195,7 +214,7 @@ bool KX_PlanarMap::SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera)
 	}
 
 	const mt::mat3 mirrorObjWorldOriInverse = mirrorObjWorldOri.Inverse();
-	mt::mat3 cameraWorldOri = sceneCamera->NodeGetWorldOrientation();
+	mt::mat3 cameraWorldOri = mt::mat3::ToRotationMatrix(viewMat);
 
 	static const mt::mat3 unmir(1.0f, 0.0f, 0.0f,
 	                            0.0f, 1.0f, 0.0f,
@@ -217,7 +236,7 @@ bool KX_PlanarMap::SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera)
 	return true;
 }
 
-bool KX_PlanarMap::SetupCameraFace(KX_Camera *camera, unsigned short index)
+bool KX_PlanarMap::PrepareFace(KX_Camera *camera, unsigned short index)
 {
 	return true;
 }

--- a/source/gameengine/Ketsji/KX_PlanarMap.h
+++ b/source/gameengine/Ketsji/KX_PlanarMap.h
@@ -29,8 +29,6 @@
 
 #include "KX_TextureRenderer.h"
 
-#include <unordered_map>
-
 class KX_PlanarMap : public KX_TextureRenderer, public mt::SimdClassAllocator
 {
 	Py_Header
@@ -41,15 +39,13 @@ private:
 	/// Clip plane equation values.
 	mt::vec4 m_clipPlane;
 
-	std::unordered_map<KX_Camera *, mt::mat4> m_projections;
-
 	enum Type {
 		REFLECTION,
 		REFRACTION
 	} m_type;
 
 public:
-	KX_PlanarMap(EnvMap *env, KX_GameObject *viewpoint);
+	KX_PlanarMap(MTex *mtex, KX_GameObject *viewpoint);
 	virtual ~KX_PlanarMap();
 
 	virtual std::string GetName();
@@ -57,17 +53,19 @@ public:
 	void ComputeClipPlane(const mt::vec3& mirrorObjWorldPos, const mt::mat3& mirrorObjWorldOri);
 
 	virtual void InvalidateProjectionMatrix();
-	virtual const mt::mat4& GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
-													const RAS_Rect& viewport, const RAS_Rect& area);
-
-	virtual void BeginRenderFace(RAS_Rasterizer *rasty) override;
-	virtual void EndRenderFace(RAS_Rasterizer *rasty) override;
+	virtual mt::mat4 GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
+			const RAS_Rect& viewport, const RAS_Rect& area, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye);
 
 	const mt::vec3& GetNormal() const;
 	void SetNormal(const mt::vec3& normal);
 
-	virtual bool SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera);
-	virtual bool SetupCameraFace(KX_Camera *camera, unsigned short index);
+	virtual void BeginRender(RAS_Rasterizer *rasty, unsigned short layer);
+	virtual void EndRender(RAS_Rasterizer *rasty, unsigned short layer);
+	virtual void BeginRenderFace(RAS_Rasterizer *rasty, unsigned short layer, unsigned short face);
+
+	virtual LayerUsage EnsureLayers(int viewportCount);
+	virtual bool Prepare(KX_Camera *sceneCamera, RAS_Rasterizer::StereoEye eye, KX_Camera *camera);
+	virtual bool PrepareFace(KX_Camera *camera, unsigned short index);
 
 #ifdef WITH_PYTHON
 	static PyObject *pyattr_get_normal(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -1189,7 +1189,12 @@ static PyObject *gPySetAnisotropicFiltering(PyObject *, PyObject *args)
 		return nullptr;
 	}
 
-	KX_GetActiveEngine()->GetRasterizer()->SetAnisotropicFiltering(level);
+	KX_KetsjiEngine *engine = KX_GetActiveEngine();
+	engine->GetRasterizer()->SetAnisotropicFiltering(level);
+
+	for (KX_Scene *scene : engine->CurrentScenes()) {
+		scene->GetTextureRendererManager()->ReloadTextures();
+	}
 
 	Py_RETURN_NONE;
 }
@@ -1283,7 +1288,13 @@ static PyObject *gPySetMipmapping(PyObject *, PyObject *args)
 		return nullptr;
 	}
 
-	KX_GetActiveEngine()->GetRasterizer()->SetMipmapping((RAS_Rasterizer::MipmapOption)val);
+	KX_KetsjiEngine *engine = KX_GetActiveEngine();
+	engine->GetRasterizer()->SetMipmapping((RAS_Rasterizer::MipmapOption)val);
+
+	for (KX_Scene *scene : engine->CurrentScenes()) {
+		scene->GetTextureRendererManager()->ReloadTextures();
+	}
+
 	Py_RETURN_NONE;
 }
 

--- a/source/gameengine/Ketsji/KX_RenderData.cpp
+++ b/source/gameengine/Ketsji/KX_RenderData.cpp
@@ -35,7 +35,7 @@ KX_SceneRenderData::KX_SceneRenderData(KX_Scene *scene)
 {
 }
 
-KX_FrameRenderData::KX_FrameRenderData(RAS_Rasterizer::OffScreenType ofsType, const std::vector<RAS_Rasterizer::StereoEye>& eyes)
+KX_FrameRenderData::KX_FrameRenderData(RAS_OffScreen::Type ofsType, const std::vector<RAS_Rasterizer::StereoEye>& eyes)
 	:m_ofsType(ofsType),
 	m_eyes(eyes)
 {

--- a/source/gameengine/Ketsji/KX_RenderData.h
+++ b/source/gameengine/Ketsji/KX_RenderData.h
@@ -2,6 +2,7 @@
 #define __KX_RENDER_DATA_H__
 
 #include "RAS_Rasterizer.h"
+#include "RAS_OffScreen.h"
 
 class KX_Scene;
 class KX_Camera;
@@ -41,9 +42,9 @@ struct KX_SceneRenderData
 /// Data used to render a frame.
 struct KX_FrameRenderData
 {
-	KX_FrameRenderData(RAS_Rasterizer::OffScreenType ofsType, const std::vector<RAS_Rasterizer::StereoEye>& eyes);
+	KX_FrameRenderData(RAS_OffScreen::Type ofsType, const std::vector<RAS_Rasterizer::StereoEye>& eyes);
 	
-	RAS_Rasterizer::OffScreenType m_ofsType;
+	RAS_OffScreen::Type m_ofsType;
 	std::vector<RAS_Rasterizer::StereoEye> m_eyes;
 };
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1407,8 +1407,8 @@ void KX_Scene::UpdateParents()
 	}
 }
 
-void KX_Scene::RenderBuckets(const std::vector<KX_GameObject *>& objects, RAS_Rasterizer::DrawType drawingMode, const mt::mat3x4& cameratransform,
-                             RAS_Rasterizer *rasty, RAS_OffScreen *offScreen)
+void KX_Scene::RenderBuckets(const std::vector<KX_GameObject *>& objects, RAS_Rasterizer::DrawType drawingMode,
+		const mt::mat3x4& cameratransform, unsigned short viewportIndex, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen)
 {
 	for (KX_GameObject *gameobj : objects) {
 		/* This function update all mesh slot info (e.g culling, color, matrix) from the game object.
@@ -1416,14 +1416,13 @@ void KX_Scene::RenderBuckets(const std::vector<KX_GameObject *>& objects, RAS_Ra
 		gameobj->UpdateBuckets();
 	}
 
-	m_bucketmanager->Renderbuckets(drawingMode, cameratransform, rasty, offScreen);
+	m_bucketmanager->Renderbuckets(drawingMode, cameratransform, viewportIndex, rasty, offScreen);
 	KX_BlenderMaterial::EndFrame(rasty);
 }
 
-void KX_Scene::RenderTextureRenderers(KX_TextureRendererManager::RendererCategory category, RAS_Rasterizer *rasty,
-                                      RAS_OffScreen *offScreen, KX_Camera *camera, const RAS_Rect& viewport, const RAS_Rect& area)
+void KX_Scene::RenderTextureRenderers(RAS_Rasterizer *rasty, const KX_SceneRenderData& sceneData)
 {
-	m_rendererManager->Render(category, rasty, offScreen, camera, viewport, area);
+	m_rendererManager->Render(rasty, sceneData);
 }
 
 void KX_Scene::UpdateObjectLods(KX_Camera *cam, const std::vector<KX_GameObject *>& objects)

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -276,9 +276,9 @@ public:
 	KX_TextureRendererManager *GetTextureRendererManager() const;
 	RAS_BoundingBoxManager *GetBoundingBoxManager() const;
 	void RenderBuckets(const std::vector<KX_GameObject *>& objects, RAS_Rasterizer::DrawType drawingMode,
-	                   const mt::mat3x4& cameratransform, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen);
-	void RenderTextureRenderers(KX_TextureRendererManager::RendererCategory category, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen,
-	                            KX_Camera *sceneCamera, const RAS_Rect& viewport, const RAS_Rect& area);
+			const mt::mat3x4& cameratransform, unsigned short viewportIndex,
+			RAS_Rasterizer *rasty, RAS_OffScreen *offScreen);
+	void RenderTextureRenderers(RAS_Rasterizer *rasty, const KX_SceneRenderData& sceneData);
 
 	/// Update all transforms according to the scenegraph.
 	static bool KX_ScenegraphUpdateFunc(SG_Node *node, void *gameobj, void *scene);

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -39,7 +39,7 @@ KX_TextMaterial::~KX_TextMaterial()
 {
 }
 
-void KX_TextMaterial::Prepare(RAS_Rasterizer *rasty)
+void KX_TextMaterial::Prepare(RAS_Rasterizer *rasty, unsigned short viewportIndex)
 {
 }
 

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -36,7 +36,7 @@ public:
 	KX_TextMaterial();
 	virtual ~KX_TextMaterial();
 
-	virtual void Prepare(RAS_Rasterizer *rasty);
+	virtual void Prepare(RAS_Rasterizer *rasty, unsigned short viewportIndex);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);

--- a/source/gameengine/Ketsji/KX_TextureRenderer.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRenderer.cpp
@@ -28,18 +28,23 @@
 #include "KX_GameObject.h"
 #include "KX_Globals.h"
 
+#include "GPU_draw.h"
+
 #include "DNA_texture_types.h"
 
-KX_TextureRenderer::KX_TextureRenderer(EnvMap *env, KX_GameObject *viewpoint)
-	:m_clipStart(env->clipsta),
-	m_clipEnd(env->clipend),
+KX_TextureRenderer::KX_TextureRenderer(MTex *mtex, KX_GameObject *viewpoint, LayerUsage layerUsage)
+	:RAS_TextureRenderer((mtex->tex->env->filtering == ENVMAP_MIPMAP_MIPMAP),
+			(mtex->tex->env->filtering == ENVMAP_MIPMAP_LINEAR), layerUsage),
+	m_mtex(mtex),
+	m_clipStart(mtex->tex->env->clipsta),
+	m_clipEnd(mtex->tex->env->clipend),
 	m_viewpointObject(viewpoint),
 	m_enabled(true),
-	m_ignoreLayers(env->notlay),
-	m_lodDistanceFactor(env->lodfactor),
+	m_ignoreLayers(mtex->tex->env->notlay),
+	m_lodDistanceFactor(mtex->tex->env->lodfactor),
+	m_autoUpdate(mtex->tex->env->flag & ENVMAP_AUTO_UPDATE),
 	m_forceUpdate(true)
 {
-	m_autoUpdate = (env->flag & ENVMAP_AUTO_UPDATE) != 0;
 }
 
 KX_TextureRenderer::~KX_TextureRenderer()
@@ -49,6 +54,11 @@ KX_TextureRenderer::~KX_TextureRenderer()
 std::string KX_TextureRenderer::GetName()
 {
 	return "KX_TextureRenderer";
+}
+
+MTex *KX_TextureRenderer::GetMTex() const
+{
+	return m_mtex;
 }
 
 KX_GameObject *KX_TextureRenderer::GetViewpointObject() const

--- a/source/gameengine/Ketsji/KX_TextureRenderer.h
+++ b/source/gameengine/Ketsji/KX_TextureRenderer.h
@@ -35,19 +35,20 @@ class KX_Camera;
 class KX_Scene;
 class RAS_Rect;
 
-struct EnvMap;
+struct MTex;
 
 class KX_TextureRenderer : public EXP_Value, public RAS_TextureRenderer
 {
 	Py_Header
 
 protected:
+	MTex *m_mtex;
+
 	/// View clip start.
 	float m_clipStart;
 	/// View clip end.
 	float m_clipEnd;
 
-private:
 	/// The object used to render from its position.
 	KX_GameObject *m_viewpointObject;
 
@@ -55,7 +56,6 @@ private:
 	bool m_enabled;
 	/// Layers to ignore during render.
 	int m_ignoreLayers;
-
 
 	/// Distance factor for level of detail.
 	float m_lodDistanceFactor;
@@ -68,10 +68,12 @@ private:
 	bool m_forceUpdate;
 
 public:
-	KX_TextureRenderer(EnvMap *env, KX_GameObject *viewpoint);
+	KX_TextureRenderer(MTex *mtex, KX_GameObject *viewpoint, LayerUsage layerUsage);
 	virtual ~KX_TextureRenderer();
 
 	virtual std::string GetName();
+
+	MTex *GetMTex() const;
 
 	KX_GameObject *GetViewpointObject() const;
 	void SetViewpointObject(KX_GameObject *gameobj);
@@ -81,8 +83,8 @@ public:
 	float GetLodDistanceFactor() const;
 	void SetLodDistanceFactor(float lodfactor);
 
-	virtual const mt::mat4& GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
-													const RAS_Rect& viewport, const RAS_Rect& area) = 0;
+	virtual mt::mat4 GetProjectionMatrix(RAS_Rasterizer *rasty, KX_Scene *scene, KX_Camera *sceneCamera,
+			const RAS_Rect& viewport, const RAS_Rect& area, RAS_Rasterizer::StereoMode stereoMode, RAS_Rasterizer::StereoEye eye) = 0;
 
 	bool GetEnabled() const;
 	int GetIgnoreLayers() const;
@@ -96,9 +98,9 @@ public:
 	bool NeedUpdate();
 
 	/// Setup camera position and orientation shared by all the faces, returns true when the render will be made.
-	virtual bool SetupCamera(KX_Camera *sceneCamera, KX_Camera *camera) = 0;
+	virtual bool Prepare(KX_Camera *sceneCamera, RAS_Rasterizer::StereoEye eye, KX_Camera *camera) = 0;
 	/// Setup camera position and orientation unique per faces, returns true when the render will be made.
-	virtual bool SetupCameraFace(KX_Camera *camera, unsigned short index) = 0;
+	virtual bool PrepareFace(KX_Camera *camera, unsigned short index) = 0;
 
 #ifdef WITH_PYTHON
 	EXP_PYMETHOD_DOC_NOARGS(KX_TextureRenderer, update);

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -49,10 +49,8 @@ KX_TextureRendererManager::KX_TextureRendererManager(KX_Scene *scene)
 
 KX_TextureRendererManager::~KX_TextureRendererManager()
 {
-	for (unsigned short i = 0; i < CATEGORY_MAX; ++i) {
-		for (KX_TextureRenderer *renderer : m_renderers[i]) {
-			delete renderer;
-		}
+	for (KX_TextureRenderer *renderer : m_renderers) {
+		delete renderer;
 	}
 
 	m_camera->Release();
@@ -60,68 +58,64 @@ KX_TextureRendererManager::~KX_TextureRendererManager()
 
 void KX_TextureRendererManager::InvalidateViewpoint(KX_GameObject *gameobj)
 {
-	for (unsigned short i = 0; i < CATEGORY_MAX; ++i) {
-		for (KX_TextureRenderer *renderer : m_renderers[i]) {
-			if (renderer->GetViewpointObject() == gameobj) {
-				renderer->SetViewpointObject(nullptr);
-			}
+	for (KX_TextureRenderer *renderer : m_renderers) {
+		if (renderer->GetViewpointObject() == gameobj) {
+			renderer->SetViewpointObject(nullptr);
 		}
+	}
+}
+
+void KX_TextureRendererManager::ReloadTextures()
+{
+	for (KX_TextureRenderer *renderer : m_renderers) {
+		renderer->ReloadTexture();
 	}
 }
 
 void KX_TextureRendererManager::AddRenderer(RendererType type, RAS_Texture *texture, KX_GameObject *viewpoint)
 {
-	/* Don't Add renderer several times for the same texture. If the texture is shared by several objects,
-	 * we just add a "textureUser" to signal that the renderer texture will be shared by several objects.
-	 */
-	for (unsigned short i = 0; i < CATEGORY_MAX; ++i) {
-		for (KX_TextureRenderer *renderer : m_renderers[i]) {
-			if (renderer->EqualTextureUser(texture)) {
-				renderer->AddTextureUser(texture);
-
-				KX_GameObject *origviewpoint = renderer->GetViewpointObject();
-				if (viewpoint != origviewpoint) {
-					CM_Warning("texture renderer (" << texture->GetName() << ") uses different viewpoint objects (" <<
-					           (origviewpoint ? origviewpoint->GetName() : "<None>") << " and " << viewpoint->GetName() << ").");
-				}
-				return;
+	// Find a shared renderer (using the same material texture) or create a new one.
+	for (KX_TextureRenderer *renderer : m_renderers) {
+		if (texture->GetMTex() == renderer->GetMTex()) {
+			texture->SetRenderer(renderer);
+			KX_GameObject *origviewpoint = renderer->GetViewpointObject();
+			if (viewpoint != origviewpoint) {
+				CM_Warning("texture renderer (" << texture->GetName() << ") uses different viewpoint objects (" <<
+				           (origviewpoint ? origviewpoint->GetName() : "<None>") << " and " << viewpoint->GetName() << ").");
 			}
+			return;
 		}
 	}
 
-	EnvMap *env = texture->GetTex()->env;
+	MTex *mtex = texture->GetMTex();
 	KX_TextureRenderer *renderer;
 	switch (type) {
 		case CUBE:
 		{
-			renderer = new KX_CubeMap(env, viewpoint);
-			m_renderers[VIEWPORT_INDEPENDENT].push_back(renderer);
+			renderer = new KX_CubeMap(mtex, viewpoint);
 			break;
 		}
 		case PLANAR:
 		{
-			renderer = new KX_PlanarMap(env, viewpoint);
-			m_renderers[VIEWPORT_DEPENDENT].push_back(renderer);
+			renderer = new KX_PlanarMap(mtex, viewpoint);
 			break;
 		}
 	}
 
-	renderer->AddTextureUser(texture);
+	texture->SetRenderer(renderer);
+	m_renderers.push_back(renderer);
 }
 
-bool KX_TextureRendererManager::RenderRenderer(RAS_Rasterizer *rasty, KX_TextureRenderer *renderer,
-                                               KX_Camera *sceneCamera, const RAS_Rect& viewport, const RAS_Rect& area)
+void KX_TextureRendererManager::RenderRenderer(RAS_Rasterizer *rasty, KX_TextureRenderer *renderer,
+		const std::vector<const KX_CameraRenderData *>& cameraDatas)
 {
 	KX_GameObject *viewpoint = renderer->GetViewpointObject();
 	// Doesn't need (or can) update.
 	if (!renderer->NeedUpdate() || !renderer->GetEnabled() || !viewpoint) {
-		return false;
+		return;
 	}
 
-	// Set camera setting shared by all the renderer's faces.
-	if (!renderer->SetupCamera(sceneCamera, m_camera)) {
-		return false;
-	}
+	const int visibleLayers = ~renderer->GetIgnoreLayers();
 
 	const bool visible = viewpoint->GetVisible();
 	/* We hide the viewpoint object in the case backface culling is disabled -> we can't see through
@@ -132,90 +126,108 @@ bool KX_TextureRendererManager::RenderRenderer(RAS_Rasterizer *rasty, KX_Texture
 	// Set camera lod distance factor from renderer value.
 	m_camera->SetLodDistanceFactor(renderer->GetLodDistanceFactor());
 
-	/* When we update clipstart or clipend values,
-	 * or if the projection matrix is not computed yet,
-	 * we have to compute projection matrix.
-	 */
-	const mt::mat4& projmat = renderer->GetProjectionMatrix(rasty, m_scene, sceneCamera, viewport, area);
-	m_camera->SetProjectionMatrix(projmat, RAS_Rasterizer::RAS_STEREO_LEFTEYE);
-	rasty->SetProjectionMatrix(projmat);
+	// Ensure the number of layers for all viewports or use a unique layer.
+	const unsigned short numViewport = cameraDatas.size();
+	RAS_TextureRenderer::LayerUsage usage = renderer->EnsureLayers(numViewport);
+	const unsigned short numlay = (usage == RAS_TextureRenderer::LAYER_SHARED) ? 1 : numViewport;
 
-	// Begin rendering stuff
-	renderer->BeginRender(rasty);
+	for (unsigned short layer = 0; layer < numlay; ++layer) {
+		/* Two cases are possible :
+		 * - Only one layer is present for any number of viewports,
+		 *   in this case the renderer must not care about the viewport (e.g cube map).
+		 * - Multiple layers are present, one per viewport, in this case
+		 *   the renderer could care of the viewport and the index of the layer
+		 *   match the index of the viewport in the scene.
+		 */
 
-	for (unsigned short i = 0; i < renderer->GetNumFaces(); ++i) {
-		// Set camera settings unique per faces.
-		if (!renderer->SetupCameraFace(m_camera, i)) {
+		const KX_CameraRenderData *cameraData = cameraDatas[layer];
+		KX_Camera *sceneCamera = cameraData->m_renderCamera;
+		RAS_Rasterizer::StereoEye eye = cameraData->m_eye;
+
+		// Set camera setting shared by all the renderer's faces.
+		if (!renderer->Prepare(sceneCamera, eye, m_camera)) {
 			continue;
 		}
 
-		m_camera->NodeUpdate();
+		/* When we update clipstart or clipend values,
+		* or if the projection matrix is not computed yet,
+		* we have to compute projection matrix.
+		*/
+		const mt::mat4 projmat = renderer->GetProjectionMatrix(rasty, m_scene, sceneCamera,
+				cameraData->m_viewport, cameraData->m_area, cameraData->m_stereoMode, eye);
+		m_camera->SetProjectionMatrix(projmat, eye);
+		rasty->SetProjectionMatrix(projmat);
 
-		renderer->BindFace(i);
+		// Begin rendering stuff
+		renderer->BeginRender(rasty, layer);
 
-		const mt::mat3x4 camtrans(m_camera->GetWorldToCamera());
-		const mt::mat4 viewmat = mt::mat4::FromAffineTransform(camtrans);
+		for (unsigned short face = 0, numface = renderer->GetNumFaces(layer); face < numface; ++face) {
+			// Set camera settings unique per faces.
+			if (!renderer->PrepareFace(m_camera, face)) {
+				continue;
+			}
 
-		rasty->SetViewMatrix(viewmat);
-		m_camera->SetModelviewMatrix(viewmat, RAS_Rasterizer::RAS_STEREO_LEFTEYE);
+			m_camera->NodeUpdate();
 
-		const std::vector<KX_GameObject *> objects = m_scene->CalculateVisibleMeshes(m_camera, RAS_Rasterizer::RAS_STEREO_LEFTEYE, ~renderer->GetIgnoreLayers());
+			const mt::mat3x4 camtrans(m_camera->GetWorldToCamera());
+			const mt::mat4 viewmat = mt::mat4::FromAffineTransform(camtrans);
+			rasty->SetViewMatrix(viewmat);
+			m_camera->SetModelviewMatrix(viewmat, eye);
 
-		/* Updating the lod per face is normally not expensive because a cube map normally show every objects
-		 * but here we update only visible object of a face including the clip end and start.
-		 */
-		m_scene->UpdateObjectLods(m_camera, objects);
+			renderer->BeginRenderFace(rasty, layer, face);
 
-		/* Update animations to use the culling of each faces, BL_ActionManager avoid redundants
-		 * updates internally. */
-		KX_GetActiveEngine()->UpdateAnimations(m_scene);
+			const std::vector<KX_GameObject *> objects = m_scene->CalculateVisibleMeshes(m_camera, eye, visibleLayers);
 
-		renderer->BeginRenderFace(rasty);
+			/* Updating the lod per face is normally not expensive because a cube map normally show every objects
+			* but here we update only visible object of a face including the clip end and start.
+			*/
+			m_scene->UpdateObjectLods(m_camera, objects);
 
-		// Now the objects are culled and we can render the scene.
-		m_scene->GetWorldInfo()->RenderBackground(rasty);
-		// Send a nullptr off screen because we use a set of FBO with shared textures, not an off screen.
-		m_scene->RenderBuckets(objects, RAS_Rasterizer::RAS_RENDERER, camtrans, rasty, nullptr);
+			/* Update animations to use the culling of each faces, BL_ActionManager avoid redundants
+			* updates internally. */
+			KX_GetActiveEngine()->UpdateAnimations(m_scene);
 
-		renderer->EndRenderFace(rasty);
+			// Now the objects are culled and we can render the scene.
+			m_scene->GetWorldInfo()->RenderBackground(rasty);
+
+			m_scene->RenderBuckets(objects, RAS_Rasterizer::RAS_RENDERER, camtrans, layer, rasty, nullptr);
+		}
+
+		renderer->EndRender(rasty, layer);
 	}
 
 	viewpoint->SetVisible(visible, false);
-
-	renderer->EndRender(rasty);
-
-	return true;
 }
 
-void KX_TextureRendererManager::Render(RendererCategory category, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen,
-                                       KX_Camera *sceneCamera, const RAS_Rect& viewport, const RAS_Rect& area)
+void KX_TextureRendererManager::Render(RAS_Rasterizer *rasty, const KX_SceneRenderData& sceneData)
 {
-	const std::vector<KX_TextureRenderer *>& renderers = m_renderers[category];
-	if (renderers.empty() || rasty->GetDrawingMode() != RAS_Rasterizer::RAS_TEXTURED) {
+	if (m_renderers.empty() || rasty->GetDrawingMode() != RAS_Rasterizer::RAS_TEXTURED) {
 		return;
+	}
+
+	// Get the number of viewports.
+	const unsigned short viewportCount = sceneData.m_cameraDataList[RAS_Rasterizer::RAS_STEREO_LEFTEYE].size() +
+	sceneData.m_cameraDataList[RAS_Rasterizer::RAS_STEREO_RIGHTEYE].size();
+	// Construct a list of all the camera data by the viewport index order.
+	std::vector<const KX_CameraRenderData *> cameraDatas(viewportCount);
+	for (unsigned short eye = RAS_Rasterizer::RAS_STEREO_LEFTEYE; eye < RAS_Rasterizer::RAS_STEREO_MAXEYE; ++eye) {
+		for (const KX_CameraRenderData& cameraData : sceneData.m_cameraDataList[eye]) {
+			cameraDatas[cameraData.m_index] = &cameraData;
+		}
 	}
 
 	// Disable scissor to not bother with scissor box.
 	rasty->Disable(RAS_Rasterizer::RAS_SCISSOR_TEST);
 
-	// Check if at least one renderer was rendered.
-	bool rendered = false;
-	for (KX_TextureRenderer *renderer : renderers) {
-		rendered |= RenderRenderer(rasty, renderer, sceneCamera, viewport, area);
+	for (KX_TextureRenderer *renderer : m_renderers) {
+		RenderRenderer(rasty, renderer, cameraDatas);
 	}
 
 	rasty->Enable(RAS_Rasterizer::RAS_SCISSOR_TEST);
-
-	if (offScreen && rendered) {
-		// Restore the off screen bound before rendering the texture renderers.
-		offScreen->Bind();
-	}
 }
 
 void KX_TextureRendererManager::Merge(KX_TextureRendererManager *other)
 {
-	for (unsigned short i = 0; i < CATEGORY_MAX; ++i) {
-		m_renderers[i].insert(m_renderers[i].end(), other->m_renderers[i].begin(), other->m_renderers[i].end());
-		other->m_renderers[i].clear();
-	}
+	m_renderers.insert(m_renderers.end(), other->m_renderers.begin(), other->m_renderers.end());
+	other->m_renderers.clear();
 }

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.h
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.h
@@ -27,38 +27,26 @@
 #ifndef __KX_TEXTURE_RENDERER_MANAGER_H__
 #define __KX_TEXTURE_RENDERER_MANAGER_H__
 
-#include <vector>
+#include "KX_RenderData.h"
 
 class KX_GameObject;
-class KX_Camera;
-class KX_Scene;
 class KX_TextureRenderer;
 
-class RAS_Rasterizer;
-class RAS_OffScreen;
 class RAS_Texture;
-class RAS_Rect;
 
 class KX_TextureRendererManager
 {
-public:
-	enum RendererCategory {
-		VIEWPORT_DEPENDENT = 0,
-		VIEWPORT_INDEPENDENT,
-		CATEGORY_MAX
-	};
-
 private:
-	/// All existing renderers of this scene by categories.
-	std::vector<KX_TextureRenderer *> m_renderers[CATEGORY_MAX];
+	/// All existing renderers of this scene.
+	std::vector<KX_TextureRenderer *> m_renderers;
 	/// The camera used for renderers render, it's own by the renderer manager.
 	KX_Camera *m_camera;
 	/// The scene we are rendering for.
 	KX_Scene *m_scene;
 
 	/// Render a texture renderer, return true if the render was proceeded.
-	bool RenderRenderer(RAS_Rasterizer *rasty, KX_TextureRenderer *renderer,
-						KX_Camera *sceneCamera, const RAS_Rect& viewport, const RAS_Rect& area);
+	void RenderRenderer(RAS_Rasterizer *rasty, KX_TextureRenderer *renderer,
+			const std::vector<const KX_CameraRenderData *>& cameraDatas);
 
 public:
 	enum RendererType {
@@ -72,21 +60,16 @@ public:
 	/// Invalidate renderers using the given game object as viewpoint object.
 	void InvalidateViewpoint(KX_GameObject *gameobj);
 
+	/// Reload all the texture when a global texture setting changed.
+	void ReloadTextures();
+
 	/** Add and create a renderer if none existing renderer was using the same
 	* texture containing in the material texture passed.
 	*/
 	void AddRenderer(RendererType type, RAS_Texture *texture, KX_GameObject *viewpoint);
 
-	/** Execute all the texture renderer.
-	 * \param category The category of renderers to render.
-	 * \param offScreen The off screen bound before rendering the texture renderers.
-	 * \param sceneCamera The scene camera currently rendering the scene, used only in case of
-	 * VIEWPORT_DEPENDENT category.
-	 * \param viewport The viewport render area.
-	 * \param area The windows render area.
-	 */
-	void Render(RendererCategory category, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen,
-				KX_Camera *sceneCamera, const RAS_Rect& viewport, const RAS_Rect& area);
+	/// Execute all texture renderers.
+	void Render(RAS_Rasterizer *rasty, const KX_SceneRenderData& sceneData);
 
 	/// Merge the content of an other renderer manager, used during lib loading.
 	void Merge(KX_TextureRendererManager *other);

--- a/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
+++ b/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
@@ -56,6 +56,7 @@ struct RAS_ManagerNodeData
 	RAS_Rasterizer::DrawType m_drawingMode;
 	bool m_sort;
 	bool m_shaderOverride;
+	unsigned short m_viewportIndex;
 };
 
 struct RAS_MaterialNodeData

--- a/source/gameengine/Rasterizer/RAS_BucketManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.cpp
@@ -92,7 +92,8 @@ RAS_BucketManager::~RAS_BucketManager()
 	}
 }
 
-void RAS_BucketManager::PrepareBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
+void RAS_BucketManager::PrepareBuckets(RAS_Rasterizer *rasty, unsigned short viewportIndex,
+		RAS_BucketManager::BucketType bucketType)
 {
 	if (m_nodeData.m_shaderOverride) {
 		return;
@@ -100,13 +101,13 @@ void RAS_BucketManager::PrepareBuckets(RAS_Rasterizer *rasty, RAS_BucketManager:
 
 	for (RAS_MaterialBucket *bucket : m_buckets[bucketType]) {
 		RAS_IMaterial *mat = bucket->GetMaterial();
-		mat->Prepare(rasty);
+		mat->Prepare(rasty, viewportIndex);
 	}
 }
 
 void RAS_BucketManager::RenderSortedBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
 {
-	PrepareBuckets(rasty, bucketType);
+	PrepareBuckets(rasty, m_nodeData.m_viewportIndex, bucketType);
 
 	BucketList& solidBuckets = m_buckets[bucketType];
 	RAS_UpwardTreeLeafs leafs;
@@ -143,7 +144,7 @@ void RAS_BucketManager::RenderSortedBuckets(RAS_Rasterizer *rasty, RAS_BucketMan
 
 void RAS_BucketManager::RenderBasicBuckets(RAS_Rasterizer *rasty, RAS_BucketManager::BucketType bucketType)
 {
-	PrepareBuckets(rasty, bucketType);
+	PrepareBuckets(rasty, m_nodeData.m_viewportIndex, bucketType);
 
 	RAS_UpwardTreeLeafs leafs;
 	for (RAS_MaterialBucket *bucket : m_buckets[bucketType]) {
@@ -156,12 +157,13 @@ void RAS_BucketManager::RenderBasicBuckets(RAS_Rasterizer *rasty, RAS_BucketMana
 	}
 }
 
-void RAS_BucketManager::Renderbuckets(RAS_Rasterizer::DrawType drawingMode, const mt::mat3x4& cameratrans, RAS_Rasterizer *rasty,
-                                      RAS_OffScreen *offScreen)
+void RAS_BucketManager::Renderbuckets(RAS_Rasterizer::DrawType drawingMode, const mt::mat3x4& cameratrans, 
+		unsigned short viewportIndex, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen)
 {
 	m_nodeData.m_rasty = rasty;
 	m_nodeData.m_trans = cameratrans;
 	m_nodeData.m_drawingMode = drawingMode;
+	m_nodeData.m_viewportIndex = viewportIndex;
 
 	switch (drawingMode) {
 		case RAS_Rasterizer::RAS_SHADOW:

--- a/source/gameengine/Rasterizer/RAS_BucketManager.h
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.h
@@ -104,8 +104,8 @@ public:
 	RAS_BucketManager(RAS_IMaterial *textMaterial);
 	virtual ~RAS_BucketManager();
 
-	void Renderbuckets(RAS_Rasterizer::DrawType drawingMode, const mt::mat3x4& cameratrans, RAS_Rasterizer *rasty,
-			RAS_OffScreen *offScreen);
+	void Renderbuckets(RAS_Rasterizer::DrawType drawingMode, const mt::mat3x4& cameratrans, 
+			unsigned short viewportIndex, RAS_Rasterizer *rasty, RAS_OffScreen *offScreen);
 
 	RAS_MaterialBucket *FindBucket(RAS_IMaterial *material, bool &bucketCreated);
 	RAS_DisplayArrayBucket *GetTextDisplayArrayBucket() const;
@@ -119,7 +119,7 @@ public:
 	void Merge(RAS_BucketManager *other, SCA_IScene *scene);
 
 private:
-	void PrepareBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
+	void PrepareBuckets(RAS_Rasterizer *rasty, unsigned short viewportIndex, BucketType bucketType);
 	void RenderBasicBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
 	void RenderSortedBuckets(RAS_Rasterizer *rasty, BucketType bucketType);
 };

--- a/source/gameengine/Rasterizer/RAS_IMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IMaterial.h
@@ -105,7 +105,7 @@ public:
 	virtual ~RAS_IMaterial();
 
 	/// Prepare the material data for rendering.
-	virtual void Prepare(RAS_Rasterizer *rasty) = 0;
+	virtual void Prepare(RAS_Rasterizer *rasty, unsigned short viewportIndex) = 0;
 	virtual void Activate(RAS_Rasterizer *rasty) = 0;
 	virtual void Desactivate(RAS_Rasterizer *rasty) = 0;
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer) = 0;

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
@@ -417,7 +417,7 @@ RAS_Rect RAS_Rasterizer::GetRenderArea(RAS_ICanvas *canvas, StereoMode stereoMod
 				}
 				default:
 				{
-					break;
+					BLI_assert(false);
 				}
 			}
 			break;
@@ -446,7 +446,7 @@ RAS_Rect RAS_Rasterizer::GetRenderArea(RAS_ICanvas *canvas, StereoMode stereoMod
 				}
 				default:
 				{
-					break;
+					BLI_assert(false);
 				}
 			}
 			break;
@@ -474,7 +474,7 @@ RAS_Rect RAS_Rasterizer::GetRenderArea(RAS_ICanvas *canvas, StereoMode stereoMod
 				}
 				default:
 				{
-					break;
+					BLI_assert(false);
 				}
 			}
 			break;
@@ -617,7 +617,7 @@ mt::mat4 RAS_Rasterizer::GetFrustumMatrix(StereoMode stereoMode, StereoEye eye, 
 			}
 			default:
 			{
-				break;
+				BLI_assert(false);
 			}
 		}
 		// leave bottom and top untouched
@@ -682,7 +682,7 @@ mt::mat4 RAS_Rasterizer::GetViewMatrix(StereoMode stereoMode, StereoEye eye, con
 			}
 			default:
 			{
-				break;
+				BLI_assert(false);
 			}
 		}
 

--- a/source/gameengine/Rasterizer/RAS_Texture.cpp
+++ b/source/gameengine/Rasterizer/RAS_Texture.cpp
@@ -36,10 +36,6 @@ RAS_Texture::RAS_Texture()
 
 RAS_Texture::~RAS_Texture()
 {
-	// If the texture is free before the renderer (e.g lib free) then unregsiter ourself.
-	if (m_renderer) {
-		m_renderer->RemoveTextureUser(this);
-	}
 }
 
 std::string& RAS_Texture::GetName()
@@ -79,6 +75,13 @@ const std::array<int, 6>& RAS_Texture::GetCubeMapTargets()
 									  }};
 
 	return targets;
+}
+
+void RAS_Texture::ApplyRenderer(unsigned short viewportIndex)
+{
+	if (m_renderer) {
+		m_bindCode = m_renderer->GetBindCode(viewportIndex);
+	}
 }
 
 void RAS_Texture::DesactiveTextures()

--- a/source/gameengine/Rasterizer/RAS_Texture.h
+++ b/source/gameengine/Rasterizer/RAS_Texture.h
@@ -70,6 +70,11 @@ public:
 
 	enum {MaxUnits = 8};
 
+	/** Copy renderer (if available) texture bind code to current texture for next binding.
+	 * \param viewportIndex The index of the renderer layer to use for bind code.
+	 */
+	void ApplyRenderer(unsigned short viewportIndex);
+	virtual void UpdateBindCode() = 0;
 	virtual void CheckValidTexture() = 0;
 	virtual void ActivateTexture(int unit) = 0;
 	virtual void DisableTexture() = 0;

--- a/source/gameengine/Rasterizer/RAS_TextureRenderer.h
+++ b/source/gameengine/Rasterizer/RAS_TextureRenderer.h
@@ -27,20 +27,26 @@
 #ifndef __RAS_TEXTURE_RENDERER_H__
 #define __RAS_TEXTURE_RENDERER_H__
 
+#include "RAS_Rasterizer.h"
 #include <vector>
-
-class RAS_Texture;
-class RAS_Rasterizer;
 
 struct GPUFrameBuffer;
 struct GPURenderBuffer;
 struct GPUTexture;
+struct Image;
 
 /** \brief This class is used to render something into a material texture (RAS_Texture).
  * The render is made by faces added in the sub classes of RAS_TextureRenderer.
  */
 class RAS_TextureRenderer
 {
+public:
+	enum LayerUsage
+	{
+		LAYER_SHARED = 0,
+		LAYER_UNIQUE = 1
+	};
+
 protected:
 	class Face
 	{
@@ -55,46 +61,79 @@ protected:
 		~Face();
 
 		/// Bind the face frame buffer object.
-		void Bind();
+		void Bind() const;
 		/// Recreate and attach frame buffer object and render buffer to the texture.
 		void AttachTexture(GPUTexture *tex);
 		/// Free and detach frame buffer object and render buffer to the texture.
 		void DetachTexture(GPUTexture *tex);
 	};
 
-	/// All the material texture users.
-	std::vector<RAS_Texture *> m_textureUsers;
+	/** \brief Layer are used to make the texture rendering unique per viewport
+	 * in case of rendering depending on the camera view.
+	 * They use their own created texture attached to the faces FBO.
+	 */
+	class Layer
+	{
+	private:
+		std::vector<Face> m_faces;
+		GPUTexture *m_gpuTex;
+		unsigned int m_bindCode;
 
-	std::vector<Face> m_faces;
+	public:
+		Layer() = default;
+		Layer(const std::vector<int>& attachmentTargets, int textureTarget, Image *ima,
+				bool mipmap, bool linear);
+		~Layer();
 
-private:
-	/// Planar texture to attach to frame buffer objects.
-	GPUTexture *m_gpuTex;
-	/** Obtain the latest planar texture, if it's not the same as before,
-	* then detach the previous planar texture and attach the new one.
-	*/
-	void GetValidTexture();
+		Layer(const Layer& other) = delete;
+		Layer(Layer&& other);
 
-	/// Use mipmapping?
+		Layer& operator=(const Layer& other) = delete;
+		Layer& operator=(Layer&& other);
+
+		unsigned short GetNumFaces() const;
+		unsigned int GetBindCode() const;
+
+		void BindFace(unsigned short index) const;
+		void Bind() const;
+		void Unbind(bool mipmap) const;
+	};
+
+	/// Use mipmapping ?
 	bool m_useMipmap;
+	/// Use linear filtering ?
+	bool m_useLinear;
+	/// Share one layer for all the viewports ?
+	LayerUsage m_layerUsage;
+	/// Layers used for each viewport, only one if m_shareLayer is true.
+	std::vector<Layer> m_layers;
 
 public:
-	RAS_TextureRenderer();
+	/**
+	 * \param mipmap Use texture mipmapping.
+	 * \param linear Use linear texture filtering.
+	 * \param layerUsage Use only one shared layer for all the viewports or unique.
+	 */
+	RAS_TextureRenderer(bool mipmap, bool linear, LayerUsage layerUsage);
 	virtual ~RAS_TextureRenderer();
 
-	unsigned short GetNumFaces() const;
+	unsigned short GetNumFaces(unsigned short layer) const;
+	/// Get a layer texture bind code.
+	unsigned int GetBindCode(unsigned short index);
 
-	/// Return true if the material texture use the same data than one of the texture user.
-	bool EqualTextureUser(RAS_Texture *texture) const;
-	void AddTextureUser(RAS_Texture *texture);
-	void RemoveTextureUser(RAS_Texture *texture);
+	/// Setup rasterizer for rendering.
+	virtual void BeginRender(RAS_Rasterizer *rasty, unsigned short layer);
+	/// Undo the rasterizer setup.
+	virtual void EndRender(RAS_Rasterizer *rasty, unsigned short layer);
+	/// Setup rasterizer for a face render.
+	virtual void BeginRenderFace(RAS_Rasterizer *rasty, unsigned short layer, unsigned short face);
 
-	virtual void BeginRender(RAS_Rasterizer *rasty);
-	virtual void EndRender(RAS_Rasterizer *rasty);
-	virtual void BeginRenderFace(RAS_Rasterizer *rasty);
-	virtual void EndRenderFace(RAS_Rasterizer *rasty);
+	/** Ensure to have the all layers for the number of viewport, returns the
+	 * usage of the layers, shared (only one) or unique (as much as viewport).
+	 */
+	virtual LayerUsage EnsureLayers(int viewportCount) = 0;
 
-	void BindFace(unsigned short index);
+	void ReloadTexture();
 };
 
 #endif  // __RAS_TEXTURE_RENDERER_H__

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -394,7 +394,7 @@ bool ImageRender::Render()
 
 	m_engine->UpdateAnimations(m_scene);
 
-	m_scene->RenderBuckets(objects, RAS_Rasterizer::RAS_TEXTURED, camtrans, m_rasterizer, m_offScreen.get());
+	m_scene->RenderBuckets(objects, RAS_Rasterizer::RAS_TEXTURED, camtrans, 0, m_rasterizer, m_offScreen.get());
 
 	m_canvas->EndFrame();
 


### PR DESCRIPTION
One common issue of the texture renderer is the management of multiple
viewports (as for stereo). For renderer as cube map it doesn't matter
because none data from the viewport (view, projection) is used for the
cube faces, but planar does. Planar renderer use the camera of the
current viewport to figure out a mirror view matrix and use a projection
matrix near to the one of the viewport.

In case of stereo a planar renderer must be rendered twice for the both
stereo viewports. Previously it was achieved by separating the planar
in dependant renderer category and render this category in each viewport
render (RenderCamera function), but it implies to interrupt the render
of the viewport by unbinding its off screen.
Also in futur it would be interesting to create all the render data
and execute all the renders after without determining for who the
rasterizer is rendering.

At first point, the planars will all be rendered before the viewport
and use unique textures that will be selected in the viewport rendering.
Each of these textures are stored by layers (RAS_TextureRenderer::Layer)
which contain the render faces (Face class). Two situations are
possible:
- the renderer shares its layers along viewport, only one layer is
  available.
- the renderer use a unique layer per viewport.

The function RAS_TextureRenderer::EnsureLayers constructs the layers
if needed and return the usage of the layers : shared or unique.

When a layer is created, its constructor create a new GPUTexture
using the bind code from GPU_create_gl_tex and passing it to
GPU_texture_from_bindcode. Finally the texture is attached to the
frame buffers of the faces.

The renderer manager proceed the rendering per renderer, then per layer,
then per face. The render data changed to support this system.
First of all the camera data are now stored in the scene render data
and not per frame data. Also they are organized per eyes and frame
data use a list of eyes to specify which cameras could be rendered
for a frame. Each camera render data stores an unique index, this
index is used as renderer layer index.
When rendering, the camera data index is passed to RAS_BucketManager::Renderbuckets
which is used in fonction PrepareBuckets and KX_BlenderMaterial::Prepare
calling for each texture ApplyRenderer. This last function, in case
of renderer, get the bind code of the renderer depending on the
viewport index and copy this bind code for the next texture binding.

Finally the texture users are not needed anymore in RAS_TextureRenderer
as the renderer now create themselves the textures and changing the
mipmapping or the anisotropic filtering explicitly call the recreation
of the textures now.

Examples files :
[ge_map.zip](https://github.com/UPBGE/blender/files/2194921/ge_map.zip)
