### PR TITLE
UPBGE: Add `onRemove` callbacks

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -82,9 +82,9 @@ base class --- :class:`EXP_PyObjectPlus`
       The current active camera.
 
       :type: :class:`KX_Camera`
-      
+
       .. note::
-         
+
          This can be set directly from python to avoid using the :class:`KX_SceneActuator`.
 
    .. attribute:: overrideCullingCamera
@@ -137,8 +137,20 @@ base class --- :class:`EXP_PyObjectPlus`
 
    .. attribute:: pre_draw_setup
 
-      A list of callables to be run before the drawing setup (i.e., before the model view and projection matrices are computed). 
+      A list of callables to be run before the drawing setup (i.e., before the model view and projection matrices are computed).
       The callbacks can take as argument the rendered camera, the camera could be temporary in case of stereo rendering.
+
+      :type: list
+
+   .. attribute:: onRemove
+
+      A list of callables to run when the scene is destroyed.
+
+         .. code-block:: python
+
+            @scene.onRemove.append
+            def callback(scene):
+                  print('exiting %s...' % scene.name)
 
       :type: list
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -1054,7 +1054,7 @@ void KX_KetsjiEngine::StopEngine()
 
 		while (m_scenes->GetCount() > 0) {
 			KX_Scene *scene = m_scenes->GetFront();
-			m_converter->RemoveScene(scene);
+			DestructScene(scene);
 			// WARNING: here the scene is a dangling pointer.
 			m_scenes->Remove(0);
 		}
@@ -1296,7 +1296,7 @@ void KX_KetsjiEngine::RemoveScheduledScenes()
 
 			KX_Scene *scene = FindScene(scenename);
 			if (scene) {
-				m_converter->RemoveScene(scene);
+				DestructScene(scene);
 				m_scenes->RemoveValue(scene);
 			}
 		}
@@ -1408,7 +1408,8 @@ void KX_KetsjiEngine::ReplaceScheduledScenes()
 					// avoid crash if the new scene doesn't exist, just do nothing
 					Scene *blScene = m_converter->GetBlenderSceneForName(newscenename);
 					if (blScene) {
-						m_converter->RemoveScene(scene);
+						DestructScene(scene);
+						m_scenes->RemoveValue(scene);
 
 						KX_Scene *tmpscene = CreateScene(blScene);
 						ConvertScene(tmpscene);
@@ -1441,6 +1442,12 @@ void KX_KetsjiEngine::ResumeScene(const std::string& scenename)
 	if (scene) {
 		scene->Resume();
 	}
+}
+
+void KX_KetsjiEngine::DestructScene(KX_Scene *scene)
+{
+	scene->RunOnRemoveCallbacks();
+	m_converter->RemoveScene(scene);
 }
 
 double KX_KetsjiEngine::GetTicRate()

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -362,6 +362,7 @@ public:
 	EXP_ListValue<KX_Scene> *CurrentScenes();
 	KX_Scene *FindScene(const std::string& scenename);
 	void AddScene(KX_Scene *scene);
+	void DestructScene(KX_Scene *scene);
 	void ConvertAndAddScene(const std::string& scenename, bool overlay);
 
 	void RemoveScene(const std::string& scenename);
@@ -441,7 +442,7 @@ public:
 	double GetAverageFrameRate();
 
 	/**
-	 * Gets the time scale multiplier 
+	 * Gets the time scale multiplier
 	 */
 	double GetTimeScale() const;
 

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -108,6 +108,7 @@ private:
 
 #ifdef WITH_PYTHON
 	PyObject *m_attrDict;
+	PyObject *m_removeCallbacks;
 	PyObject *m_drawCallbacks[MAX_DRAW_CALLBACK];
 #endif
 
@@ -455,6 +456,8 @@ public:
 	static int pyattr_set_overrideCullingCamera(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject *pyattr_get_drawing_callback(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_drawing_callback(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef, PyObject *value);
+	static PyObject *pyattr_get_remove_callback(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_remove_callback(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 	static PyObject *pyattr_get_gravity(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
 	static int pyattr_set_gravity(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
@@ -464,6 +467,9 @@ public:
 
 	/// Run the registered python drawing functions.
 	void RunDrawingCallbacks(DrawingCallbackType callbackType, KX_Camera *camera);
+
+	// Run the registered python callbacks when the scene is removed.
+	void RunOnRemoveCallbacks();
 #endif
 };
 


### PR DESCRIPTION
Register functions into a callback list on scenes.

```py
def example(controller):
	scene = controller.owner.scene

	@scene.onRemove.append
	def callback(scene):
		print('exiting %s...' % scene.name)
```

---

Before this there was no event to listen for the engine shutdown. I would use the `weakref` module and monitor the `bge.logic` object destruction to trigger code.

This commit adds a list of callbacks on scenes to listen for engine shutdown.