### PR TITLE
UPBGE: Fix python component conversion from async libload.

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.h
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.h
@@ -64,6 +64,8 @@ RAS_Deformer *BL_ConvertDeformer(KX_GameObject *object, KX_Mesh *meshobj);
 void BL_ConvertBlenderObjects(Main *maggie, KX_Scene *kxscene, KX_KetsjiEngine *ketsjiEngine,
 							  RAS_Rasterizer *rendertools, RAS_ICanvas *canvas, BL_SceneConverter& sceneconverter,
                               bool alwaysUseExpandFraming, float camZoom, bool libloading);
+// Non-multithreadable conversion.
+void BL_PostConvertBlenderObjects(KX_Scene *kxscene, const BL_SceneConverter& sceneconverter);
 
 
 SCA_IInputDevice::SCA_EnumInputs BL_ConvertKeyCode(int key_code);

--- a/source/gameengine/Converter/BL_Converter.h
+++ b/source/gameengine/Converter/BL_Converter.h
@@ -106,20 +106,36 @@ private:
 	bool m_alwaysUseExpandFraming;
 	float m_camZoom;
 
+	/** Merge all data contained in the scene converter to the scene slot of
+	 * the destination scene and update the data to use the destination scene.
+	 * \param to The destination scene.
+	 * \param converter The scene converted of the data to merge.
+	 */
+	void MergeSceneData(KX_Scene *to, const BL_SceneConverter& converter);
+
+	/** Complete process of scene merging:
+	 * - post convert
+	 * - merge data
+	 * - merge scene (KX_Scene::MergeScene)
+	 * - finalize data
+	 */
+	void MergeScene(KX_Scene *to, const BL_SceneConverter& converter);
+
 public:
 	BL_Converter(Main *maggie, KX_KetsjiEngine *engine, bool alwaysUseExpandFraming, float camZoom);
 	virtual ~BL_Converter();
 
 	void ConvertScene(BL_SceneConverter& converter, bool libloading);
 
-	/** Generate shaders and mesh attributes depending on.
-	 * This function is separated from ConvertScene to be synchronized when compiling shaders
-	 * and select a scene to generate shaders with. This last point is used for scene libload
-	 * merging.
+	/** Convert all scene data that can't in a separate thread such as python components.
 	 * \param converter The scene convert to finalize.
-	 * \param mergeScene The scene used to generate shaders.
 	 */
-	void FinalizeSceneData(const BL_SceneConverter& converter, KX_Scene *mergeScene);
+	void PostConvertScene(const BL_SceneConverter& converter);
+
+	/** Finalize all data depending on scene context after a potential scene merging,
+	 * such as shader creation depending on lights into scene.
+	 */
+	void FinalizeSceneData(const BL_SceneConverter& converter);
 
 	/** This function removes all entities stored in the converter for that scene
 	 * It should be used instead of direct delete scene
@@ -150,8 +166,6 @@ public:
 	bool FreeBlendFile(const std::string& path);
 
 	KX_Mesh *ConvertMeshSpecial(KX_Scene *kx_scene, Main *maggie, const std::string& name);
-
-	void MergeScene(KX_Scene *to, KX_Scene *from);
 
 	void MergeAsyncLoads();
 	void FinalizeAsyncLoads();

--- a/source/gameengine/Converter/BL_SceneConverter.cpp
+++ b/source/gameengine/Converter/BL_SceneConverter.cpp
@@ -33,6 +33,8 @@
 #include "BL_ConvertObjectInfo.h"
 #include "KX_GameObject.h"
 
+#include "CM_List.h"
+
 BL_SceneConverter::BL_SceneConverter(KX_Scene *scene)
 	:m_scene(scene)
 {
@@ -43,6 +45,7 @@ BL_SceneConverter::BL_SceneConverter(BL_SceneConverter&& other)
 	m_materials(std::move(other.m_materials)),
 	m_meshobjects(std::move(other.m_meshobjects)),
 	m_objectInfos(std::move(other.m_objectInfos)),
+	m_objects(std::move(other.m_objects)),
 	m_blenderToObjectInfos(std::move(other.m_blenderToObjectInfos)),
 	m_map_blender_to_gameobject(std::move(other.m_map_blender_to_gameobject)),
 	m_map_mesh_to_gamemesh(std::move(other.m_map_mesh_to_gamemesh)),
@@ -61,6 +64,7 @@ void BL_SceneConverter::RegisterGameObject(KX_GameObject *gameobject, Object *fo
 {
 	// only maintained while converting, freed during game runtime
 	m_map_blender_to_gameobject[for_blenderobject] = gameobject;
+	m_objects.push_back(gameobject);
 }
 
 /** only need to run this during conversion since
@@ -76,6 +80,8 @@ void BL_SceneConverter::UnregisterGameObject(KX_GameObject *gameobject)
 			m_map_blender_to_gameobject.erase(it);
 		}
 	}
+
+	CM_ListRemoveIfFound(m_objects, gameobject);
 }
 
 KX_GameObject *BL_SceneConverter::FindGameObject(Object *for_blenderobject)
@@ -139,4 +145,9 @@ BL_ConvertObjectInfo *BL_SceneConverter::GetObjectInfo(Object *blenderobj)
 	}
 
 	return it->second;
+}
+
+const std::vector<KX_GameObject *> &BL_SceneConverter::GetObjects() const
+{
+	return m_objects;
 }

--- a/source/gameengine/Converter/BL_SceneConverter.h
+++ b/source/gameengine/Converter/BL_SceneConverter.h
@@ -65,6 +65,8 @@ private:
 	std::vector<KX_BlenderMaterial *> m_materials;
 	std::vector<KX_Mesh *> m_meshobjects;
 	std::vector<BL_ConvertObjectInfo *> m_objectInfos;
+	// List of all object converted, active and inactive.
+	std::vector<KX_GameObject *> m_objects;
 
 	std::map<Object *, BL_ConvertObjectInfo *> m_blenderToObjectInfos;
 	std::map<Object *, KX_GameObject *> m_map_blender_to_gameobject;
@@ -101,6 +103,8 @@ public:
 	SCA_IController *FindGameController(bController *for_controller);
 
 	BL_ConvertObjectInfo *GetObjectInfo(Object *blenderobj);
+
+	const std::vector<KX_GameObject *>& GetObjects() const;
 };
 
 #endif  // __KX_BLENDERSCENECONVERTER_H__

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -41,12 +41,12 @@
 #include "DNA_material_types.h"
 #include "DNA_scene_types.h"
 
-KX_BlenderMaterial::KX_BlenderMaterial(Material *mat, const std::string& name)
+KX_BlenderMaterial::KX_BlenderMaterial(Material *mat, const std::string& name, KX_Scene *scene)
 	:RAS_IPolyMaterial(name),
 	m_material(mat),
 	m_shader(nullptr),
 	m_blenderShader(nullptr),
-	m_scene(nullptr),
+	m_scene(scene),
 	m_userDefBlend(false)
 {
 	// Save material data to restore on exit
@@ -198,6 +198,11 @@ void KX_BlenderMaterial::ReloadMaterial()
 	}
 }
 
+void KX_BlenderMaterial::ReplaceScene(KX_Scene *scene)
+{
+	m_scene = scene;
+}
+
 void KX_BlenderMaterial::InitTextures()
 {
 	// for each unique material...
@@ -211,13 +216,12 @@ void KX_BlenderMaterial::InitTextures()
 	}
 }
 
-void KX_BlenderMaterial::InitScene(KX_Scene *scene)
+void KX_BlenderMaterial::InitShader()
 {
-	m_scene = scene;
+	BLI_assert(!m_blenderShader);
+	BLI_assert(m_scene);
 
-	if (!m_blenderShader) {
-		m_blenderShader = new BL_BlenderShader(m_scene, m_material, this);
-	}
+	m_blenderShader = new BL_BlenderShader(m_scene, m_material, this);
 
 	if (!m_blenderShader->Ok()) {
 		delete m_blenderShader;

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -26,7 +26,7 @@ class KX_BlenderMaterial : public EXP_Value, public RAS_IPolyMaterial
 	Py_Header
 
 public:
-	KX_BlenderMaterial(Material *mat, const std::string& name);
+	KX_BlenderMaterial(Material *mat, const std::string& name, KX_Scene *scene);
 
 	virtual ~KX_BlenderMaterial();
 
@@ -52,11 +52,8 @@ public:
 	virtual SCA_IScene *GetScene() const;
 	virtual void ReloadMaterial();
 
-	/** Set scene owning this material and generate blender shader using
-	 * scene lights.
-	 * \param scene The scene material owner.
-	 */
-	void InitScene(KX_Scene *scene);
+	void ReplaceScene(KX_Scene *scene);
+	void InitShader();
 
 	static void EndFrame(RAS_Rasterizer *rasty);
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -1317,8 +1317,8 @@ void KX_KetsjiEngine::ConvertScene(KX_Scene *scene)
 {
 	BL_SceneConverter sceneConverter(scene);
 	m_converter->ConvertScene(sceneConverter, false);
-	// Finalize material and mesh conversion.
-	m_converter->FinalizeSceneData(sceneConverter, scene);
+	m_converter->PostConvertScene(sceneConverter);
+	m_converter->FinalizeSceneData(sceneConverter);
 }
 
 void KX_KetsjiEngine::AddScheduledScenes()

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
@@ -88,14 +88,14 @@ KX_Scene *KX_LibLoadStatus::GetMergeScene() const
 	return m_mergescene;
 }
 
-const std::vector<Scene *>& KX_LibLoadStatus::GetBlenderScenes() const
+const std::vector<KX_Scene *>& KX_LibLoadStatus::GetScenes() const
 {
-	return m_blenderScenes;
+	return m_scenes;
 }
 
-void KX_LibLoadStatus::SetBlenderScenes(const std::vector<Scene *>& scenes)
+void KX_LibLoadStatus::SetScenes(const std::vector<KX_Scene *>& scenes)
 {
-	m_blenderScenes = scenes;
+	m_scenes = scenes;
 }
 
 const std::vector<BL_SceneConverter>& KX_LibLoadStatus::GetSceneConverters() const

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.h
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.h
@@ -33,7 +33,6 @@
 class BL_Converter;
 class KX_KetsjiEngine;
 class KX_Scene;
-struct Scene;
 
 class KX_LibLoadStatus : public EXP_PyObjectPlus
 {
@@ -42,7 +41,7 @@ private:
 	BL_Converter *m_converter;
 	KX_KetsjiEngine *m_engine;
 	KX_Scene *m_mergescene;
-	std::vector<Scene *> m_blenderScenes;
+	std::vector<KX_Scene *> m_scenes;
 	std::vector<BL_SceneConverter> m_sceneConvertes;
 	std::string m_libname;
 
@@ -70,8 +69,8 @@ public:
 	KX_KetsjiEngine *GetEngine() const;
 	KX_Scene *GetMergeScene() const;
 
-	const std::vector<Scene *>& GetBlenderScenes() const;
-	void SetBlenderScenes(const std::vector<Scene *>& scenes);
+	const std::vector<KX_Scene *>& GetScenes() const;
+	void SetScenes(const std::vector<KX_Scene *>& scenes);
 	const std::vector<BL_SceneConverter>& GetSceneConverters() const;
 	void AddSceneConverter(BL_SceneConverter&& converter);
 

--- a/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
@@ -34,3 +34,9 @@ void KX_PythonComponentManager::UpdateComponents()
 		gameobj->UpdateComponents();
 	}
 }
+
+void KX_PythonComponentManager::Merge(KX_PythonComponentManager& other)
+{
+	m_objects.insert(m_objects.end(), other.m_objects.begin(), other.m_objects.end());
+	other.m_objects.clear();
+}

--- a/source/gameengine/Ketsji/KX_PythonComponentManager.h
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.h
@@ -18,6 +18,8 @@ public:
 	void UnregisterObject(KX_GameObject *gameobj);
 
 	void UpdateComponents();
+
+	void Merge(KX_PythonComponentManager& other);
 };
 
 #endif  // __KX_PYTHON_COMPONENT_H__

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2060,9 +2060,6 @@ void initPlayerPython(int argc, char **argv)
 	PySys_SetObject("argv", py_argv);
 	Py_DECREF(py_argv);
 
-	// Initialize thread support (also acquires lock).
-	PyEval_InitThreads();
-
 	bpy_import_init(PyEval_GetBuiltins());
 
 	/* The modules are imported to call their init functions to ensure the types they own are ready

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -276,6 +276,10 @@ KX_Scene::~KX_Scene()
 		delete m_boundingBoxManager;
 	}
 
+	if (m_worldinfo) {
+		delete m_worldinfo;
+	}
+
 #ifdef WITH_PYTHON
 	if (m_attrDict) {
 		PyDict_Clear(m_attrDict);
@@ -1644,6 +1648,7 @@ bool KX_Scene::MergeScene(KX_Scene *other)
 	m_bucketmanager->Merge(other->GetBucketManager(), this);
 	m_boundingBoxManager->Merge(other->GetBoundingBoxManager());
 	m_rendererManager->Merge(other->GetTextureRendererManager());
+	m_componentManager.Merge(other->GetPythonComponentManager());
 
 	for (KX_GameObject *gameobj : *other->GetObjectList()) {
 		MergeScene_GameObject(gameobj, this, other);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -526,7 +526,6 @@ KX_GameObject *KX_Scene::AddNodeReplicaObject(SG_Node *node, KX_GameObject *game
 			break;
 		}
 	}
-	newobj->AddMeshUser();
 
 	// Logic cannot be replicated, until the whole hierarchy is replicated.
 	m_logicHierarchicalGameObjects.push_back(newobj);

--- a/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
+++ b/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
@@ -32,6 +32,7 @@
 
 class RAS_BucketManager;
 class RAS_MaterialBucket;
+class RAS_DisplayArray;
 class RAS_DisplayArrayBucket;
 class RAS_MeshSlot;
 class RAS_IPolyMaterial;

--- a/source/gameengine/Rasterizer/RAS_AttributeArray.h
+++ b/source/gameengine/Rasterizer/RAS_AttributeArray.h
@@ -31,6 +31,7 @@
 
 #include <vector>
 
+class RAS_DisplayArray;
 class RAS_AttributeArrayStorage;
 class RAS_DisplayArrayStorage;
 

--- a/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
+++ b/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
@@ -53,7 +53,7 @@ RAS_BoundingBox *RAS_BoundingBox::GetReplica()
 
 void RAS_BoundingBox::ProcessReplica()
 {
-	m_users = 1;
+	m_users = 0;
 	m_manager->m_boundingBoxList.push_back(this);
 }
 
@@ -81,6 +81,7 @@ void RAS_BoundingBox::RemoveUser()
 
 void RAS_BoundingBox::SetManager(RAS_BoundingBoxManager *manager)
 {
+	BLI_assert(m_manager);
 	m_manager = manager;
 }
 

--- a/source/gameengine/Rasterizer/RAS_DebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_DebugDraw.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "RAS_DebugDraw.h"
-#include "RAS_OpenGLDebugDraw.h"
+#include "RAS_Rasterizer.h"
 
 RAS_DebugDraw::Shape::Shape(const mt::vec4& color)
 {
@@ -76,7 +76,6 @@ RAS_DebugDraw::Box2d::Box2d(const mt::vec2& pos, const mt::vec2& size, const mt:
 }
 
 RAS_DebugDraw::RAS_DebugDraw()
-	:m_impl(new RAS_OpenGLDebugDraw())
 {
 }
 
@@ -115,7 +114,7 @@ void RAS_DebugDraw::Flush(RAS_Rasterizer *rasty, RAS_ICanvas *canvas)
 		return;
 	}
 
-	m_impl->Flush(rasty, canvas, this);
+	rasty->FlushDebug(canvas, this);
 
 	m_lines.clear();
 	m_aabbs.clear();

--- a/source/gameengine/Rasterizer/RAS_DebugDraw.h
+++ b/source/gameengine/Rasterizer/RAS_DebugDraw.h
@@ -36,11 +36,10 @@
 
 class RAS_Rasterizer;
 class RAS_ICanvas;
-class RAS_OpenGLDebugDraw;
 
 class RAS_DebugDraw
 {
-	friend RAS_OpenGLDebugDraw;
+	friend class RAS_OpenGLDebugDraw;
 
 private:
 	struct Shape
@@ -97,8 +96,6 @@ private:
 	std::vector<Frustum> m_frustums;
 	std::vector<Text2d> m_texts2d;
 	std::vector<Box2d> m_boxes2d;
-
-	std::unique_ptr<RAS_OpenGLDebugDraw> m_impl;
 
 public:
 	RAS_DebugDraw();

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
@@ -31,6 +31,7 @@
 
 #include "RAS_Rasterizer.h"
 #include "RAS_OpenGLRasterizer.h"
+#include "RAS_OpenGLDebugDraw.h"
 #include "RAS_IPolygonMaterial.h"
 #include "RAS_DisplayArrayBucket.h"
 
@@ -216,6 +217,7 @@ RAS_Rasterizer::RAS_Rasterizer()
 	m_overrideShader(RAS_OVERRIDE_SHADER_NONE)
 {
 	m_impl.reset(new RAS_OpenGLRasterizer(this));
+	m_debugDrawImpl.reset(new RAS_OpenGLDebugDraw());
 
 	m_numgllights = m_impl->GetNumLights();
 
@@ -1383,6 +1385,11 @@ void RAS_Rasterizer::GetTransform(const mt::mat4& origmat, int objectdrawmode, f
 			origmat.Pack(mat);
 		}
 	}
+}
+
+void RAS_Rasterizer::FlushDebug(RAS_ICanvas *canvas, RAS_DebugDraw *debugDraw)
+{
+	m_debugDrawImpl->Flush(this, canvas, debugDraw);
 }
 
 void RAS_Rasterizer::DisableForText()

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.h
@@ -47,11 +47,12 @@
 #include <memory>
 
 class RAS_OpenGLRasterizer;
+class RAS_OpenGLDebugDraw;
 class RAS_OpenGLLight;
 class RAS_ICanvas;
 class RAS_OffScreen;
 class RAS_MeshSlot;
-class RAS_DisplayArray;
+class RAS_DebugDraw;
 class RAS_ILightObject;
 class RAS_ISync;
 struct KX_ClientObjectInfo;
@@ -327,6 +328,7 @@ private:
 	OverrideShaderType m_overrideShader;
 
 	std::unique_ptr<RAS_OpenGLRasterizer> m_impl;
+	std::unique_ptr<RAS_OpenGLDebugDraw> m_debugDrawImpl;
 
 	/// Initialize custom shader interface containing uniform location.
 	void InitOverrideShadersInterface();
@@ -664,6 +666,8 @@ public:
 	 * Render Tools
 	 */
 	void GetTransform(const mt::mat4& origmat, int objectdrawmode, float mat[16]);
+
+	void FlushDebug(RAS_ICanvas *canvas, RAS_DebugDraw *debugDraw);
 
 	void DisableForText();
 	/**


### PR DESCRIPTION
Previously the async thread dedicated for the libload was directly calling
python function without ensuring the GIL and this caused issue, no conversion
or memory error.

To fix this issue Py_X_ALLOW_THREADS and Py_X_THREADS macro are used, they
intent on ensuring and locking the python GIL so that any python API calls
are proceeded sequentially.

Fix issue #751.