### PR TITLE
UPBGE: Fix navmesh rebuild after mesh replacement.

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1815,9 +1815,6 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
 			KX_NavMeshObject *navmesh = static_cast<KX_NavMeshObject *>(gameobj);
 			navmesh->SetVisible(false, true);
 			navmesh->BuildNavMesh();
-			if (obssimulation) {
-				obssimulation->AddObstaclesForNavMesh(navmesh);
-			}
 		}
 	}
 	for (KX_GameObject *gameobj : inactivelist) {

--- a/source/gameengine/Ketsji/KX_NavMeshObject.h
+++ b/source/gameengine/Ketsji/KX_NavMeshObject.h
@@ -38,6 +38,16 @@ class KX_NavMeshObject : public KX_GameObject
 protected:
 	dtStatNavMesh *m_navMesh;
 
+	bool BuildFromDerivedMesh(float *&vertices, int& nverts,
+	                        unsigned short * &polys, int& npolys, unsigned short *&dmeshes,
+	                        float *&dvertices, int &ndvertsuniq, unsigned short * &dtris,
+	                        int& ndtris, int &vertsPerPoly);
+
+	bool BuildFromMesh(float *&vertices, int& nverts,
+	                        unsigned short * &polys, int& npolys, unsigned short *&dmeshes,
+	                        float *&dvertices, int &ndvertsuniq, unsigned short * &dtris,
+	                        int& ndtris, int &vertsPerPoly);
+
 	bool BuildVertIndArrays(float *&vertices, int& nverts,
 	                        unsigned short * &polys, int& npolys, unsigned short *&dmeshes,
 	                        float *&dvertices, int &ndvertsuniq, unsigned short * &dtris,


### PR DESCRIPTION
Previously the navmesh rebuilding was failing because of two issues,
first the mesh used as source was always the one from the blender object
secondly the navmesh itself wasn't updated in the obstacle simulation.

To solve this first issue the function BuildVertIndArrays is calling
two sub functions, BuildFromDerivedMesh for creating from a derived
mesh and benefit from CD_RECAST layer, if this function fails to get
the recast layer BuildFromMesh is called and generate information from
a RAS_Mesh without detailed meshes.
In this last function the indices computation is solved by the requirement
of Detour library to use 6 indices per polygon, the unused indices are
discarded by value 0xFFFF.

The second issue is solved by calling AddObstaclesForNavMesh only from
KX_NavMeshObject::BuildNavMesh, this call is preceded by a call to
DestroyObstacleForObj intenting to remove the previous obstacle
associated to this navmesh.

Fix issue #633.

Example file : 
[ge_navmesh.zip](https://github.com/UPBGE/blender/files/2262978/ge_navmesh.zip)

Press `Space` to replace the mesh and rebuild.
