### PR TITLE
UPBGE: Restore object info node.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_material.py
+++ b/release/scripts/startup/bl_ui/properties_material.py
@@ -822,6 +822,7 @@ class MATERIAL_PT_game_options(MaterialButtonsPanel, Panel):
         col.prop(mat, "use_vertex_color_light")
         col.prop(mat, "use_object_color")
         col.prop(mat, "use_instancing")
+        col.prop(mat, "pass_index")
 
 class MATERIAL_PT_shadow(MaterialButtonsPanel, Panel):
     bl_label = "Shadow"

--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -107,13 +107,15 @@ typedef enum GPUBuiltin {
 	GPU_INSTANCING_INVERSE_MATRIX  = (1 << 16),
 	GPU_INSTANCING_COLOR           = (1 << 17),
 	GPU_INSTANCING_LAYER           = (1 << 18),
-	GPU_INSTANCING_COLOR_ATTRIB    = (1 << 19),
-	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 20),
-	GPU_INSTANCING_POSITION_ATTRIB = (1 << 21),
-	GPU_INSTANCING_LAYER_ATTRIB    = (1 << 22),
-	GPU_TIME                       = (1 << 23),
-	GPU_OBJECT_INFO                = (1 << 24),
-	GPU_OBJECT_LAY                 = (1 << 25)
+	GPU_INSTANCING_INFO            = (1 << 19),
+	GPU_INSTANCING_COLOR_ATTRIB    = (1 << 20),
+	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 21),
+	GPU_INSTANCING_POSITION_ATTRIB = (1 << 22),
+	GPU_INSTANCING_LAYER_ATTRIB    = (1 << 23),
+	GPU_INSTANCING_INFO_ATTRIB     = (1 << 24),
+	GPU_TIME                       = (1 << 25),
+	GPU_OBJECT_INFO                = (1 << 26),
+	GPU_OBJECT_LAY                 = (1 << 27)
 } GPUBuiltin;
 
 typedef enum GPUOpenGLBuiltin {
@@ -271,6 +273,9 @@ void GPU_material_enable_alpha(GPUMaterial *material);
 GPUBuiltin GPU_get_material_builtins(GPUMaterial *material);
 GPUBlendMode GPU_material_alpha_blend(GPUMaterial *material, const float obcol[4]);
 
+/// Possibly translate builtin to instancing builtin if instancing enabled and return node.
+GPUNodeLink *GPU_material_builtin(GPUMaterial *mat, GPUBuiltin builtin);
+
 /* High level functions to create and use GPU materials */
 GPUMaterial *GPU_material_world(struct Scene *scene, struct World *wo, GPUMaterialFlag flags);
 
@@ -417,7 +422,7 @@ void GPU_material_update_fvar_offset(GPUMaterial *gpu_material,
 
 /* Instancing material */
 bool GPU_material_use_instancing(GPUMaterial *material);
-void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, void *layeroffset);
+void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, void *layeroffset, void *infooffset);
 
 #ifdef __cplusplus
 }

--- a/source/blender/gpu/intern/gpu_codegen.c
+++ b/source/blender/gpu/intern/gpu_codegen.c
@@ -423,6 +423,8 @@ const char *GPU_builtin_name(GPUBuiltin builtin)
 		return "varinstcolor";
 	else if (builtin == GPU_INSTANCING_LAYER)
 		return "varinstlayer";
+	else if (builtin == GPU_INSTANCING_INFO)
+		return "varinstinfo";
 	else if (builtin == GPU_INSTANCING_COLOR_ATTRIB)
 		return "ininstcolor";
 	else if (builtin == GPU_INSTANCING_MATRIX_ATTRIB)
@@ -431,6 +433,8 @@ const char *GPU_builtin_name(GPUBuiltin builtin)
 		return "ininstposition";
 	else if (builtin == GPU_INSTANCING_LAYER_ATTRIB)
 		return "ininstlayer";
+	else if (builtin == GPU_INSTANCING_INFO_ATTRIB)
+		return "ininstinfo";
 	else if (builtin == GPU_TIME)
 		return "unftime";
 	else if (builtin == GPU_OBJECT_INFO)

--- a/source/blender/gpu/shaders/gpu_shader_vertex.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_vertex.glsl
@@ -12,11 +12,13 @@ in mat3 ininstmatrix;
 in vec3 ininstposition;
 in vec4 ininstcolor;
 in int ininstlayer;
+in vec3 ininstinfo;
 
 out vec4 varinstcolor;
 out mat4 varinstmat;
 out mat4 varinstinvmat;
 flat out int varinstlayer;
+out vec3 varinstinfo;
 
 uniform mat4 unfviewmat;
 #endif
@@ -117,6 +119,7 @@ void main()
 #endif
 	varinstcolor = ininstcolor;
 	varinstlayer = ininstlayer;
+	varinstinfo = ininstinfo;
 
 	position *= instmat;
 	normal *= ininstmatrix;

--- a/source/blender/nodes/shader/nodes/node_shader_ambient_occlusion.c
+++ b/source/blender/nodes/shader/nodes/node_shader_ambient_occlusion.c
@@ -44,7 +44,7 @@ static bNodeSocketTemplate sh_node_ambient_occlusion_out[] = {
 
 static int node_shader_gpu_ambient_occlusion(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	return GPU_stack_link(mat, "node_ambient_occlusion", in, out, GPU_builtin(GPU_VIEW_NORMAL));
+	return GPU_stack_link(mat, "node_ambient_occlusion", in, out, GPU_material_builtin(mat, GPU_VIEW_NORMAL));
 }
 
 static void node_shader_init_ambient_occlusion(bNodeTree *UNUSED(ntree), bNode *node)

--- a/source/blender/nodes/shader/nodes/node_shader_background.c
+++ b/source/blender/nodes/shader/nodes/node_shader_background.c
@@ -42,7 +42,7 @@ static bNodeSocketTemplate sh_node_background_out[] = {
 
 static int node_shader_gpu_background(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	return GPU_stack_link(mat, "node_background", in, out, GPU_builtin(GPU_VIEW_NORMAL));
+	return GPU_stack_link(mat, "node_background", in, out, GPU_material_builtin(mat, GPU_VIEW_NORMAL));
 }
 
 /* node type definition */

--- a/source/blender/nodes/shader/nodes/node_shader_bevel.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bevel.c
@@ -48,7 +48,7 @@ static void node_shader_init_bevel(bNodeTree *UNUSED(ntree), bNode *node)
 static int gpu_shader_bevel(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[1].link) {
-		GPU_link(mat, "direction_transform_m4v3", GPU_builtin(GPU_VIEW_NORMAL), GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &in[1].link);
+		GPU_link(mat, "direction_transform_m4v3", GPU_material_builtin(mat, GPU_VIEW_NORMAL), GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &in[1].link);
 	}
 
 	return GPU_stack_link(mat, "node_bevel", in, out);

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_anisotropic.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_anisotropic.c
@@ -52,9 +52,9 @@ static void node_shader_init_anisotropic(bNodeTree *UNUSED(ntree), bNode *node)
 static int node_shader_gpu_bsdf_anisotropic(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[4].link)
-		in[4].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[4].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[4].link, GPU_builtin(GPU_VIEW_MATRIX), &in[4].link);
+		GPU_link(mat, "direction_transform_m4v3", in[4].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[4].link);
 
 	return GPU_stack_link(mat, "node_bsdf_anisotropic", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_diffuse.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_diffuse.c
@@ -44,9 +44,9 @@ static bNodeSocketTemplate sh_node_bsdf_diffuse_out[] = {
 static int node_shader_gpu_bsdf_diffuse(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[2].link)
-		in[2].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[2].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_builtin(GPU_VIEW_MATRIX), &in[2].link);
+		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[2].link);
 
 	return GPU_stack_link(mat, "node_bsdf_diffuse", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_glass.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_glass.c
@@ -50,9 +50,9 @@ static void node_shader_init_glass(bNodeTree *UNUSED(ntree), bNode *node)
 static int node_shader_gpu_bsdf_glass(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[3].link)
-		in[3].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[3].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_builtin(GPU_VIEW_MATRIX), &in[3].link);
+		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[3].link);
 
 	return GPU_stack_link(mat, "node_bsdf_glass", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_glossy.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_glossy.c
@@ -49,9 +49,9 @@ static void node_shader_init_glossy(bNodeTree *UNUSED(ntree), bNode *node)
 static int node_shader_gpu_bsdf_glossy(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[2].link)
-		in[2].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[2].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_builtin(GPU_VIEW_MATRIX), &in[2].link);
+		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[2].link);
 
 	return GPU_stack_link(mat, "node_bsdf_glossy", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_principled.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_principled.c
@@ -68,17 +68,17 @@ static int node_shader_gpu_bsdf_principled(GPUMaterial *mat, bNode *UNUSED(node)
 {
 	// normal
 	if (!in[17].link)
-		in[17].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[17].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[17].link, GPU_builtin(GPU_VIEW_MATRIX), &in[17].link);
+		GPU_link(mat, "direction_transform_m4v3", in[17].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[17].link);
 
 	// clearcoat normal
 	if (!in[18].link)
-		in[18].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[18].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[18].link, GPU_builtin(GPU_VIEW_MATRIX), &in[18].link);
+		GPU_link(mat, "direction_transform_m4v3", in[18].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[18].link);
 
-	return GPU_stack_link(mat, "node_bsdf_principled", in, out, GPU_builtin(GPU_VIEW_POSITION));
+	return GPU_stack_link(mat, "node_bsdf_principled", in, out, GPU_material_builtin(mat, GPU_VIEW_POSITION));
 }
 
 static void node_shader_update_principled(bNodeTree *UNUSED(ntree), bNode *node)

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_refraction.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_refraction.c
@@ -50,9 +50,9 @@ static void node_shader_init_refraction(bNodeTree *UNUSED(ntree), bNode *node)
 static int node_shader_gpu_bsdf_refraction(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[3].link)
-		in[3].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[3].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_builtin(GPU_VIEW_MATRIX), &in[3].link);
+		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[3].link);
 
 	return GPU_stack_link(mat, "node_bsdf_refraction", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_toon.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_toon.c
@@ -45,9 +45,9 @@ static bNodeSocketTemplate sh_node_bsdf_toon_out[] = {
 static int node_shader_gpu_bsdf_toon(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[3].link)
-		in[3].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[3].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_builtin(GPU_VIEW_MATRIX), &in[3].link);
+		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[3].link);
 
 	return GPU_stack_link(mat, "node_bsdf_toon", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_translucent.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_translucent.c
@@ -43,9 +43,9 @@ static bNodeSocketTemplate sh_node_bsdf_translucent_out[] = {
 static int node_shader_gpu_bsdf_translucent(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[1].link)
-		in[1].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[1].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_builtin(GPU_VIEW_MATRIX), &in[1].link);
+		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[1].link);
 
 	return GPU_stack_link(mat, "node_bsdf_translucent", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bsdf_velvet.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bsdf_velvet.c
@@ -44,9 +44,9 @@ static bNodeSocketTemplate sh_node_bsdf_velvet_out[] = {
 static int node_shader_gpu_bsdf_velvet(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[2].link)
-		in[2].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[2].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_builtin(GPU_VIEW_MATRIX), &in[2].link);
+		GPU_link(mat, "direction_transform_m4v3", in[2].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[2].link);
 
 	return GPU_stack_link(mat, "node_bsdf_velvet", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_bump.c
+++ b/source/blender/nodes/shader/nodes/node_shader_bump.c
@@ -48,18 +48,18 @@ static bNodeSocketTemplate sh_node_bump_out[] = {
 static int gpu_shader_bump(GPUMaterial *mat, bNode *node, bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[3].link)
-		in[3].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[3].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_builtin(GPU_VIEW_MATRIX), &in[3].link);
+		GPU_link(mat, "direction_transform_m4v3", in[3].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[3].link);
 	float invert = node->custom1;
-	GPU_stack_link(mat, "node_bump", in, out, GPU_builtin(GPU_VIEW_POSITION), GPU_uniform(&invert));
+	GPU_stack_link(mat, "node_bump", in, out, GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_uniform(&invert));
 	/* Other nodes are applying view matrix if the input Normal has a link.
 	 * We don't want normal to have view matrix applied twice, so we cancel it here.
 	 *
 	 * TODO(sergey): This is an extra multiplication which cancels each other,
 	 * better avoid this but that requires bigger refactor.
 	 */
-	return GPU_link(mat, "direction_transform_m4v3", out[0].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &out[0].link);
+	return GPU_link(mat, "direction_transform_m4v3", out[0].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &out[0].link);
 }
 
 /* node type definition */

--- a/source/blender/nodes/shader/nodes/node_shader_camera.c
+++ b/source/blender/nodes/shader/nodes/node_shader_camera.c
@@ -56,7 +56,7 @@ static int gpu_shader_camera(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecDat
 {
 	GPUNodeLink *viewvec;
 
-	viewvec = GPU_builtin(GPU_VIEW_POSITION);
+	viewvec = GPU_material_builtin(mat, GPU_VIEW_POSITION);
 
 	/* Blender has negative Z, Cycles positive Z convention */
 	if (GPU_material_use_new_shading_nodes(mat))

--- a/source/blender/nodes/shader/nodes/node_shader_displacement.c
+++ b/source/blender/nodes/shader/nodes/node_shader_displacement.c
@@ -57,14 +57,14 @@ static void node_shader_init_displacement(bNodeTree *UNUSED(ntree), bNode *node)
 static int gpu_shader_displacement(GPUMaterial *mat, bNode *node, bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[3].link) {
-		GPU_link(mat, "direction_transform_m4v3", GPU_builtin(GPU_VIEW_NORMAL), GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &in[3].link);
+		GPU_link(mat, "direction_transform_m4v3", GPU_material_builtin(mat, GPU_VIEW_NORMAL), GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &in[3].link);
 	}
 
 	if (node->custom1 == SHD_SPACE_OBJECT) {
-		return GPU_stack_link(mat, "node_displacement_object", in, out, GPU_builtin(GPU_OBJECT_MATRIX));
+		return GPU_stack_link(mat, "node_displacement_object", in, out, GPU_material_builtin(mat, GPU_OBJECT_MATRIX));
 	}
 	else {
-		return GPU_stack_link(mat, "node_displacement_world", in, out, GPU_builtin(GPU_OBJECT_MATRIX));
+		return GPU_stack_link(mat, "node_displacement_world", in, out, GPU_material_builtin(mat, GPU_OBJECT_MATRIX));
 	}
 }
 

--- a/source/blender/nodes/shader/nodes/node_shader_emission.c
+++ b/source/blender/nodes/shader/nodes/node_shader_emission.c
@@ -42,7 +42,7 @@ static bNodeSocketTemplate sh_node_emission_out[] = {
 
 static int node_shader_gpu_emission(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	return GPU_stack_link(mat, "node_emission", in, out, GPU_builtin(GPU_VIEW_NORMAL));
+	return GPU_stack_link(mat, "node_emission", in, out, GPU_material_builtin(mat, GPU_VIEW_NORMAL));
 }
 
 /* node type definition */

--- a/source/blender/nodes/shader/nodes/node_shader_fresnel.c
+++ b/source/blender/nodes/shader/nodes/node_shader_fresnel.c
@@ -42,13 +42,13 @@ static bNodeSocketTemplate sh_node_fresnel_out[] = {
 static int node_shader_gpu_fresnel(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[1].link) {
-		in[1].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[1].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	}
 	else if (GPU_material_use_world_space_shading(mat)) {
-		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_builtin(GPU_VIEW_MATRIX), &in[1].link);
+		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[1].link);
 	}
 
-	return GPU_stack_link(mat, "node_fresnel", in, out, GPU_builtin(GPU_VIEW_POSITION));
+	return GPU_stack_link(mat, "node_fresnel", in, out, GPU_material_builtin(mat, GPU_VIEW_POSITION));
 }
 
 static void node_shader_exec_fresnel(void *data, int UNUSED(thread), bNode *node, bNodeExecData *UNUSED(execdata), bNodeStack **in, bNodeStack **out)

--- a/source/blender/nodes/shader/nodes/node_shader_geom.c
+++ b/source/blender/nodes/shader/nodes/node_shader_geom.c
@@ -137,11 +137,11 @@ static int gpu_shader_geom(GPUMaterial *mat, bNode *node, bNodeExecData *UNUSED(
 	GPUNodeLink *mcol = GPU_attribute(CD_MCOL, ngeo->colname);
 
 	bool ret = GPU_stack_link(mat, "geom", in, out,
-	                      GPU_builtin(GPU_VIEW_POSITION), GPU_builtin(GPU_VIEW_NORMAL),
-	                      GPU_builtin(GPU_INVERSE_VIEW_MATRIX), orco, mtface, mcol);
+	                      GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+	                      GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), orco, mtface, mcol);
 	if (GPU_material_use_world_space_shading(mat)) {
 		GPU_link(mat, "vec_math_negate", out[5].link, &out[5].link);
-		ret &= GPU_link(mat, "direction_transform_m4v3", out[5].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &out[5].link);
+		ret &= GPU_link(mat, "direction_transform_m4v3", out[5].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &out[5].link);
 	}
 	return ret;
 }

--- a/source/blender/nodes/shader/nodes/node_shader_geometry.c
+++ b/source/blender/nodes/shader/nodes/node_shader_geometry.c
@@ -44,8 +44,8 @@ static bNodeSocketTemplate sh_node_geometry_out[] = {
 static int node_shader_gpu_geometry(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	return GPU_stack_link(mat, "node_geometry", in, out,
-	                      GPU_builtin(GPU_VIEW_POSITION), GPU_builtin(GPU_VIEW_NORMAL),
-	                      GPU_builtin(GPU_INVERSE_VIEW_MATRIX));
+	                      GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+	                      GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX));
 }
 
 /* node type definition */

--- a/source/blender/nodes/shader/nodes/node_shader_lamp.c
+++ b/source/blender/nodes/shader/nodes/node_shader_lamp.c
@@ -70,7 +70,7 @@ static int gpu_shader_lamp(GPUMaterial *mat, bNode *node, bNodeExecData *UNUSED(
 
 		bool ret = GPU_stack_link(mat, "lamp", in, out, col, energy, lv, dist, shadow, visifac);
 		if (GPU_material_use_world_space_shading(mat))
-			ret &= GPU_link(mat, "direction_transform_m4v3", out[1].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &out[1].link);
+			ret &= GPU_link(mat, "direction_transform_m4v3", out[1].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &out[1].link);
 		return ret;
 	}
 

--- a/source/blender/nodes/shader/nodes/node_shader_layer_weight.c
+++ b/source/blender/nodes/shader/nodes/node_shader_layer_weight.c
@@ -44,12 +44,12 @@ static bNodeSocketTemplate sh_node_layer_weight_out[] = {
 static int node_shader_gpu_layer_weight(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[1].link)
-		in[1].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[1].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else if (GPU_material_use_world_space_shading(mat)) {
-		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_builtin(GPU_VIEW_MATRIX), &in[1].link);
+		GPU_link(mat, "direction_transform_m4v3", in[1].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[1].link);
 	}
 
-	return GPU_stack_link(mat, "node_layer_weight", in, out, GPU_builtin(GPU_VIEW_POSITION));
+	return GPU_stack_link(mat, "node_layer_weight", in, out, GPU_material_builtin(mat, GPU_VIEW_POSITION));
 }
 
 static void node_shader_exec_layer_weight(void *data, int UNUSED(thread), bNode *node, bNodeExecData *UNUSED(execdata), bNodeStack **in, bNodeStack **out)

--- a/source/blender/nodes/shader/nodes/node_shader_material.c
+++ b/source/blender/nodes/shader/nodes/node_shader_material.c
@@ -280,7 +280,7 @@ static int gpu_shader_material(GPUMaterial *mat, bNode *node, bNodeExecData *UNU
 			shi.vn = gpu_get_input_link(mat, &in[MAT_IN_NORMAL]);
 			if (GPU_material_use_world_space_shading(mat)) {
 				GPU_link(mat, "vec_math_negate", shi.vn, &shi.vn);
-				GPU_link(mat, "direction_transform_m4v3", shi.vn, GPU_builtin(GPU_VIEW_MATRIX), &shi.vn);
+				GPU_link(mat, "direction_transform_m4v3", shi.vn, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &shi.vn);
 			}
 			GPU_link(mat, "vec_math_normalize", shi.vn, &shi.vn, &tmp);
 		}
@@ -328,7 +328,7 @@ static int gpu_shader_material(GPUMaterial *mat, bNode *node, bNodeExecData *UNU
 		out[MAT_OUT_NORMAL].link = shi.vn;
 		if (GPU_material_use_world_space_shading(mat)) {
 			GPU_link(mat, "vec_math_negate", out[MAT_OUT_NORMAL].link, &out[MAT_OUT_NORMAL].link);
-			GPU_link(mat, "direction_transform_m4v3", out[MAT_OUT_NORMAL].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &out[MAT_OUT_NORMAL].link);
+			GPU_link(mat, "direction_transform_m4v3", out[MAT_OUT_NORMAL].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &out[MAT_OUT_NORMAL].link);
 		}
 
 		if (node->type == SH_NODE_MATERIAL_EXT) {

--- a/source/blender/nodes/shader/nodes/node_shader_normal_map.c
+++ b/source/blender/nodes/shader/nodes/node_shader_normal_map.c
@@ -142,7 +142,7 @@ static int gpu_shader_normal_map(GPUMaterial *mat, bNode *node, bNodeExecData *U
 	else
 		realnorm = GPU_uniform(in[1].vec);
 
-	negnorm = GPU_builtin(GPU_VIEW_NORMAL);
+	negnorm = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	GPU_link(mat, "math_max", strength, GPU_uniform(d), &strength);
 
 	if (GPU_material_use_world_space_shading(mat)) {
@@ -156,20 +156,20 @@ static int gpu_shader_normal_map(GPUMaterial *mat, bNode *node, bNodeExecData *U
 			case SHD_SPACE_TANGENT:
 				GPU_link(mat, "color_to_normal_new_shading", realnorm, &realnorm);
 				GPU_link(mat, "node_normal_map", GPU_attribute(CD_TANGENT, nm->uv_map), negnorm, realnorm, &realnorm);
-				GPU_link(mat, "vec_math_mix", strength, realnorm, GPU_builtin(GPU_VIEW_NORMAL), &out[0].link);
+				GPU_link(mat, "vec_math_mix", strength, realnorm, GPU_material_builtin(mat, GPU_VIEW_NORMAL), &out[0].link);
 				/* for uniform scale this is sufficient to match Cycles */
-				GPU_link(mat, "direction_transform_m4v3", out[0].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &out[0].link);
+				GPU_link(mat, "direction_transform_m4v3", out[0].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &out[0].link);
 				GPU_link(mat, "vect_normalize", out[0].link, &out[0].link);
 				return true;
 			case SHD_SPACE_OBJECT:
 			case SHD_SPACE_BLENDER_OBJECT:
-				GPU_link(mat, "direction_transform_m4v3", negnorm, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &negnorm);
+				GPU_link(mat, "direction_transform_m4v3", negnorm, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &negnorm);
 				GPU_link(mat, color_to_normal_fnc_name, realnorm, &realnorm);
-				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_builtin(GPU_OBJECT_MATRIX), &realnorm);
+				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_material_builtin(mat, GPU_OBJECT_MATRIX), &realnorm);
 				break;
 			case SHD_SPACE_WORLD:
 			case SHD_SPACE_BLENDER_WORLD:
-				GPU_link(mat, "direction_transform_m4v3", negnorm, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &negnorm);
+				GPU_link(mat, "direction_transform_m4v3", negnorm, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &negnorm);
 				GPU_link(mat, color_to_normal_fnc_name, realnorm, &realnorm);
 				break;
 		}
@@ -189,11 +189,11 @@ static int gpu_shader_normal_map(GPUMaterial *mat, bNode *node, bNodeExecData *U
 				break;
 			case SHD_SPACE_OBJECT:
 			case SHD_SPACE_BLENDER_OBJECT:
-				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_builtin(GPU_LOC_TO_VIEW_MATRIX),  &realnorm);
+				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_material_builtin(mat, GPU_LOC_TO_VIEW_MATRIX),  &realnorm);
 				break;
 			case SHD_SPACE_WORLD:
 			case SHD_SPACE_BLENDER_WORLD:
-				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_builtin(GPU_VIEW_MATRIX),  &realnorm);
+				GPU_link(mat, "direction_transform_m4v3", realnorm, GPU_material_builtin(mat, GPU_VIEW_MATRIX),  &realnorm);
 				break;
 		}
 	}

--- a/source/blender/nodes/shader/nodes/node_shader_object.c
+++ b/source/blender/nodes/shader/nodes/node_shader_object.c
@@ -40,7 +40,7 @@ static bNodeSocketTemplate sh_node_object_out[] = {
 
 static int gpu_shader_object(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	GPUNodeLink *obcolor = GPU_builtin(GPU_material_use_instancing(mat) ? GPU_INSTANCING_COLOR : GPU_OBCOLOR);
+	GPUNodeLink *obcolor = GPU_material_builtin(mat, GPU_OBCOLOR);
 
 	return GPU_stack_link(mat, "set_rgba", in, out, obcolor);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_object_info.c
+++ b/source/blender/nodes/shader/nodes/node_shader_object_info.c
@@ -39,7 +39,7 @@ static bNodeSocketTemplate sh_node_object_info_out[] = {
 
 static int node_shader_gpu_object_info(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	return GPU_stack_link(mat, "node_object_info", in, out, GPU_builtin(GPU_OBJECT_MATRIX), GPU_builtin(GPU_OBJECT_INFO));
+	return GPU_stack_link(mat, "node_object_info", in, out, GPU_material_builtin(mat, GPU_OBJECT_MATRIX), GPU_material_builtin(mat, GPU_OBJECT_INFO));
 }
 
 static void node_shader_exec_object_info(void *data, int UNUSED(thread), bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), bNodeStack **UNUSED(in), bNodeStack **out)

--- a/source/blender/nodes/shader/nodes/node_shader_parallax.c
+++ b/source/blender/nodes/shader/nodes/node_shader_parallax.c
@@ -57,12 +57,12 @@ static int gpu_shader_parallax(GPUMaterial *mat, bNode *node, bNodeExecData *UNU
 			}
 		}
 
-		GPU_link(mat, "texco_norm", GPU_builtin(GPU_VIEW_NORMAL), &norm);
+		GPU_link(mat, "texco_norm", GPU_material_builtin(mat, GPU_VIEW_NORMAL), &norm);
 		GPU_link(mat, "mtex_2d_mapping", in[0].link, &texco);
 
 		float comp = (float) node->custom1;
 		float discard = (float) node->custom2;
-		GPU_link(mat, "mtex_parallax", texco, GPU_builtin(GPU_VIEW_POSITION), GPU_attribute(CD_TANGENT, ""), norm, texlink,
+		GPU_link(mat, "mtex_parallax", texco, GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_attribute(CD_TANGENT, ""), norm, texlink,
 			in[1].link, in[2].link, GPU_uniform(one), GPU_uniform(&discard), GPU_uniform(&comp), &outuv);
 
 		GPU_link(mat, "parallax_uv_attribute", outuv, &out[0].link);

--- a/source/blender/nodes/shader/nodes/node_shader_particle_info.c
+++ b/source/blender/nodes/shader/nodes/node_shader_particle_info.c
@@ -53,10 +53,10 @@ static int gpu_shader_particle_info(GPUMaterial *mat, bNode *UNUSED(node), bNode
 {
 
 	return GPU_stack_link(mat, "particle_info", in, out,
-	                      GPU_builtin(GPU_PARTICLE_SCALAR_PROPS),
-	                      GPU_builtin(GPU_PARTICLE_LOCATION),
-	                      GPU_builtin(GPU_PARTICLE_VELOCITY),
-	                      GPU_builtin(GPU_PARTICLE_ANG_VELOCITY));
+	                      GPU_material_builtin(mat, GPU_PARTICLE_SCALAR_PROPS),
+	                      GPU_material_builtin(mat, GPU_PARTICLE_LOCATION),
+	                      GPU_material_builtin(mat, GPU_PARTICLE_VELOCITY),
+	                      GPU_material_builtin(mat, GPU_PARTICLE_ANG_VELOCITY));
 }
 
 /* node type definition */

--- a/source/blender/nodes/shader/nodes/node_shader_subsurface_scattering.c
+++ b/source/blender/nodes/shader/nodes/node_shader_subsurface_scattering.c
@@ -52,9 +52,9 @@ static void node_shader_init_subsurface_scattering(bNodeTree *UNUSED(ntree), bNo
 static int node_shader_gpu_subsurface_scattering(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
 	if (!in[5].link)
-		in[5].link = GPU_builtin(GPU_VIEW_NORMAL);
+		in[5].link = GPU_material_builtin(mat, GPU_VIEW_NORMAL);
 	else
-		GPU_link(mat, "direction_transform_m4v3", in[5].link, GPU_builtin(GPU_VIEW_MATRIX), &in[5].link);
+		GPU_link(mat, "direction_transform_m4v3", in[5].link, GPU_material_builtin(mat, GPU_VIEW_MATRIX), &in[5].link);
 
 	return GPU_stack_link(mat, "node_subsurface_scattering", in, out);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_tex_coord.c
+++ b/source/blender/nodes/shader/nodes/node_shader_tex_coord.c
@@ -50,15 +50,15 @@ static int node_shader_gpu_tex_coord(GPUMaterial *mat, bNode *UNUSED(node), bNod
 
 	if (type == GPU_MATERIAL_TYPE_MESH) {
 		return GPU_stack_link(mat, "node_tex_coord", in, out,
-		                      GPU_builtin(GPU_VIEW_POSITION), GPU_builtin(GPU_VIEW_NORMAL),
-		                      GPU_builtin(GPU_INVERSE_VIEW_MATRIX), GPU_builtin(GPU_INVERSE_OBJECT_MATRIX),
-		                      GPU_builtin(GPU_CAMERA_TEXCO_FACTORS), orco, mtface);
+		                      GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+		                      GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), GPU_material_builtin(mat, GPU_INVERSE_OBJECT_MATRIX),
+		                      GPU_material_builtin(mat, GPU_CAMERA_TEXCO_FACTORS), orco, mtface);
 	}
 	else {
 		return GPU_stack_link(mat, "node_tex_coord_background", in, out,
-		                      GPU_builtin(GPU_VIEW_POSITION), GPU_builtin(GPU_VIEW_NORMAL),
-		                      GPU_builtin(GPU_INVERSE_VIEW_MATRIX), GPU_builtin(GPU_INVERSE_OBJECT_MATRIX),
-		                      GPU_builtin(GPU_CAMERA_TEXCO_FACTORS), orco, mtface);
+		                      GPU_material_builtin(mat, GPU_VIEW_POSITION), GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+		                      GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), GPU_material_builtin(mat, GPU_INVERSE_OBJECT_MATRIX),
+		                      GPU_material_builtin(mat, GPU_CAMERA_TEXCO_FACTORS), orco, mtface);
 	}
 }
 

--- a/source/blender/nodes/shader/nodes/node_shader_tex_environment.c
+++ b/source/blender/nodes/shader/nodes/node_shader_tex_environment.c
@@ -68,9 +68,9 @@ static int node_shader_gpu_tex_environment(GPUMaterial *mat, bNode *node, bNodeE
 		GPUMatType type = GPU_Material_get_type(mat);
 
 		if (type == GPU_MATERIAL_TYPE_MESH)
-			in[0].link = GPU_builtin(GPU_VIEW_POSITION);
+			in[0].link = GPU_material_builtin(mat, GPU_VIEW_POSITION);
 		else
-			GPU_link(mat, "background_transform_to_world", GPU_builtin(GPU_VIEW_POSITION), &in[0].link);
+			GPU_link(mat, "background_transform_to_world", GPU_material_builtin(mat, GPU_VIEW_POSITION), &in[0].link);
 	}
 
 	node_shader_gpu_tex_mapping(mat, node, in, out);

--- a/source/blender/nodes/shader/nodes/node_shader_tex_image.c
+++ b/source/blender/nodes/shader/nodes/node_shader_tex_image.c
@@ -78,11 +78,11 @@ static int node_shader_gpu_tex_image(GPUMaterial *mat, bNode *node, bNodeExecDat
 			GPU_stack_link(mat, "node_tex_image", in, out, GPU_image(ima, iuser, isdata));
 			break;
 		case SHD_PROJ_BOX:
-			GPU_link(mat, "direction_transform_m4v3", GPU_builtin(GPU_VIEW_NORMAL),
-			                                          GPU_builtin(GPU_INVERSE_VIEW_MATRIX),
+			GPU_link(mat, "direction_transform_m4v3", GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+			                                          GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX),
 			                                          &norm);
 			GPU_link(mat, "direction_transform_m4v3", norm,
-			                                          GPU_builtin(GPU_INVERSE_OBJECT_MATRIX),
+			                                          GPU_material_builtin(mat, GPU_INVERSE_OBJECT_MATRIX),
 			                                          &norm);
 			GPU_link(mat, "node_tex_image_box", in[0].link,
 			                                    norm,

--- a/source/blender/nodes/shader/nodes/node_shader_texture.c
+++ b/source/blender/nodes/shader/nodes/node_shader_texture.c
@@ -136,7 +136,7 @@ static int gpu_shader_texture(GPUMaterial *mat, bNode *node, bNodeExecData *UNUS
 				in[1].link = GPU_uniform(&in[1].vec[0]);
 			}
 			if (!GPU_material_use_world_space_shading(mat))
-				GPU_link(mat, "direction_transform_m4v3", in[0].link, GPU_builtin(GPU_INVERSE_VIEW_MATRIX), &in[0].link);
+				GPU_link(mat, "direction_transform_m4v3", in[0].link, GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX), &in[0].link);
 			GPU_link(mat, "mtex_cube_map_refl_from_refldir",
 				GPU_cube_map(tex->ima, &tex->iuser, false), in[0].link, in[1].link, &out[0].link, &out[1].link);
 			GPU_link(mat, "color_to_normal", out[1].link, &out[2].link);

--- a/source/blender/nodes/shader/nodes/node_shader_time.c
+++ b/source/blender/nodes/shader/nodes/node_shader_time.c
@@ -35,7 +35,7 @@ static bNodeSocketTemplate sh_node_time_out[] = {
 
 static int gpu_shader_time(GPUMaterial *mat, bNode *UNUSED(node), bNodeExecData *UNUSED(execdata), GPUNodeStack *in, GPUNodeStack *out)
 {
-	GPUNodeLink *time = GPU_builtin(GPU_TIME);
+	GPUNodeLink *time = GPU_material_builtin(mat, GPU_TIME);
 
 	return GPU_stack_link(mat, "set_value", in, out, time);
 }

--- a/source/blender/nodes/shader/nodes/node_shader_vectTransform.c
+++ b/source/blender/nodes/shader/nodes/node_shader_vectTransform.c
@@ -116,7 +116,7 @@ static void node_shader_exec_vect_transform(void *data, int UNUSED(thread), bNod
 	}
 }
 
-static GPUNodeLink *get_gpulink_matrix_from_to(short from, short to)
+static GPUNodeLink *get_gpulink_matrix_from_to(GPUMaterial *mat, short from, short to)
 {
 	switch (from) {
 		case SHD_VECT_TRANSFORM_SPACE_OBJECT:
@@ -124,9 +124,9 @@ static GPUNodeLink *get_gpulink_matrix_from_to(short from, short to)
 				case SHD_VECT_TRANSFORM_SPACE_OBJECT:
 					return NULL;
 				case SHD_VECT_TRANSFORM_SPACE_WORLD:
-					return GPU_builtin(GPU_OBJECT_MATRIX);
+					return GPU_material_builtin(mat, GPU_OBJECT_MATRIX);
 				case SHD_VECT_TRANSFORM_SPACE_CAMERA:
-					return GPU_builtin(GPU_LOC_TO_VIEW_MATRIX);
+					return GPU_material_builtin(mat, GPU_LOC_TO_VIEW_MATRIX);
 			}
 			break;
 		case SHD_VECT_TRANSFORM_SPACE_WORLD:
@@ -134,9 +134,9 @@ static GPUNodeLink *get_gpulink_matrix_from_to(short from, short to)
 				case SHD_VECT_TRANSFORM_SPACE_WORLD:
 					return NULL;
 				case SHD_VECT_TRANSFORM_SPACE_CAMERA:
-					return GPU_builtin(GPU_VIEW_MATRIX);
+					return GPU_material_builtin(mat, GPU_VIEW_MATRIX);
 				case SHD_VECT_TRANSFORM_SPACE_OBJECT:
-					return GPU_builtin(GPU_INVERSE_OBJECT_MATRIX);
+					return GPU_material_builtin(mat, GPU_INVERSE_OBJECT_MATRIX);
 			}
 			break;
 		case SHD_VECT_TRANSFORM_SPACE_CAMERA:
@@ -144,9 +144,9 @@ static GPUNodeLink *get_gpulink_matrix_from_to(short from, short to)
 				case SHD_VECT_TRANSFORM_SPACE_CAMERA:
 					return NULL;
 				case SHD_VECT_TRANSFORM_SPACE_WORLD:
-					return GPU_builtin(GPU_INVERSE_VIEW_MATRIX);
+					return GPU_material_builtin(mat, GPU_INVERSE_VIEW_MATRIX);
 				case SHD_VECT_TRANSFORM_SPACE_OBJECT:
-					return GPU_builtin(GPU_INVERSE_LOC_TO_VIEW_MATRIX);
+					return GPU_material_builtin(mat, GPU_INVERSE_LOC_TO_VIEW_MATRIX);
 			}
 			break;
 	}
@@ -170,7 +170,7 @@ static int gpu_shader_vect_transform(GPUMaterial *mat, bNode *node, bNodeExecDat
 	else
 		inputlink = GPU_uniform(in[0].vec);
 
-	fromto = get_gpulink_matrix_from_to(nodeprop->convert_from, nodeprop->convert_to);
+	fromto = get_gpulink_matrix_from_to(mat, nodeprop->convert_from, nodeprop->convert_to);
 
 	func_name = (nodeprop->type == SHD_VECT_TRANSFORM_TYPE_POINT) ? ptransform : vtransform;
 	if (fromto) {

--- a/source/blender/nodes/shader/nodes/node_shader_vector_displacement.c
+++ b/source/blender/nodes/shader/nodes/node_shader_vector_displacement.c
@@ -54,12 +54,12 @@ static int gpu_shader_vector_displacement(GPUMaterial *mat, bNode *node, bNodeEx
 		                      in,
 		                      out,
 		                      GPU_attribute(CD_TANGENT, ""),
-		                      GPU_builtin(GPU_VIEW_NORMAL),
-		                      GPU_builtin(GPU_OBJECT_MATRIX),
-		                      GPU_builtin(GPU_VIEW_MATRIX));
+		                      GPU_material_builtin(mat, GPU_VIEW_NORMAL),
+		                      GPU_material_builtin(mat, GPU_OBJECT_MATRIX),
+		                      GPU_material_builtin(mat, GPU_VIEW_MATRIX));
 	}
 	else if (node->custom1 == SHD_SPACE_OBJECT) {
-		return GPU_stack_link(mat, "node_vector_displacement_object", in, out, GPU_builtin(GPU_OBJECT_MATRIX));
+		return GPU_stack_link(mat, "node_vector_displacement_object", in, out, GPU_material_builtin(mat, GPU_OBJECT_MATRIX));
 	}
 	else {
 		return GPU_stack_link(mat, "node_vector_displacement_world", in, out);

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1058,6 +1058,7 @@ static KX_GameObject *BL_GameObjectFromBlenderObject(Object *ob, KX_Scene *kxsce
 	}
 	if (gameobj) {
 		gameobj->SetLayer(ob->lay);
+		gameobj->SetPassIndex(ob->index);
 		BL_ConvertObjectInfo *info = converter.GetObjectInfo(ob);
 		gameobj->SetConvertObjectInfo(info);
 		gameobj->SetObjectColor(mt::vec4(ob->col));

--- a/source/gameengine/Ketsji/BL_BlenderShader.h
+++ b/source/gameengine/Ketsji/BL_BlenderShader.h
@@ -78,7 +78,7 @@ public:
 	RAS_InstancingBuffer::Attrib GetInstancingAttribs() const;
 
 	void UpdateLights(RAS_Rasterizer *rasty);
-	void Update(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty);
+	void Update(RAS_MeshUser *meshUser, short matPassIndex, RAS_Rasterizer *rasty);
 
 	/// Return true if the shader uses a special vertex shader for geometry instancing.
 	bool UseInstancing() const;

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -115,6 +115,8 @@ KX_BlenderMaterial::KX_BlenderMaterial(Material *mat, const std::string& name, K
 	m_flag |= ((mat->mode2 & MA_CASTSHADOW) != 0) ? RAS_CASTSHADOW : 0;
 	m_flag |= ((mat->mode & MA_ONLYCAST) != 0) ? RAS_ONLYSHADOW : 0;
 
+	m_passIndex = mat->index;
+
 	m_blendFunc[0] = RAS_Rasterizer::RAS_ZERO;
 	m_blendFunc[1] = RAS_Rasterizer::RAS_ZERO;
 }
@@ -372,7 +374,7 @@ void KX_BlenderMaterial::ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer
 		rasty->ProcessLighting(UsesLighting(), camtrans);
 	}
 	else if (m_blenderShader) {
-		m_blenderShader->Update(meshUser, rasty);
+		m_blenderShader->Update(meshUser, m_passIndex, rasty);
 
 		/* we do blend modes here, because they can change per object
 		 * with the same material due to obcolor/obalpha */
@@ -590,6 +592,7 @@ PyAttributeDef KX_BlenderMaterial::Attributes[] = {
 	EXP_PYATTRIBUTE_RW_FUNCTION("emit", KX_BlenderMaterial, pyattr_get_emit, pyattr_set_emit),
 	EXP_PYATTRIBUTE_RW_FUNCTION("ambient", KX_BlenderMaterial, pyattr_get_ambient, pyattr_set_ambient),
 	EXP_PYATTRIBUTE_RW_FUNCTION("specularAlpha", KX_BlenderMaterial, pyattr_get_specular_alpha, pyattr_set_specular_alpha),
+	EXP_PYATTRIBUTE_SHORT_RW("passIndex", 0, SHRT_MAX, false, KX_BlenderMaterial, m_passIndex),
 
 	EXP_PYATTRIBUTE_NULL //Sentinel
 };

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -110,6 +110,7 @@ KX_GameObject::KX_GameObject(void *sgReplicationInfo,
                              SG_Callbacks callbacks)
 	:m_clientInfo(this, KX_ClientObjectInfo::ACTOR),
 	m_layer(0),
+	m_passIndex(0),
 	m_lodManager(nullptr),
 	m_currentLodLevel(0),
 	m_meshUser(nullptr),
@@ -140,6 +141,7 @@ KX_GameObject::KX_GameObject(const KX_GameObject& other)
 	m_clientInfo(this, other.m_clientInfo.m_type),
 	m_name(other.m_name),
 	m_layer(other.m_layer),
+	m_passIndex(other.m_passIndex),
 	m_meshes(other.m_meshes),
 	m_lodManager(other.m_lodManager),
 	m_currentLodLevel(0),
@@ -734,6 +736,7 @@ void KX_GameObject::UpdateBuckets()
 		m_sgNode->ClearDirty(SG_Node::DIRTY_RENDER);
 	}
 
+	m_meshUser->SetPassIndex(m_passIndex);
 	m_meshUser->SetLayer(m_layer);
 	m_meshUser->SetColor(m_objectColor);
 	m_meshUser->ActivateMeshSlots();
@@ -1004,6 +1007,16 @@ void KX_GameObject::SetLayer(int l)
 int KX_GameObject::GetLayer(void)
 {
 	return m_layer;
+}
+
+void KX_GameObject::SetPassIndex(short index)
+{
+	m_passIndex = index;
+}
+
+short KX_GameObject::GetPassIndex() const
+{
+	return m_passIndex;
 }
 
 void KX_GameObject::AddLinearVelocity(const mt::vec3& lin_vel, bool local)
@@ -1997,6 +2010,7 @@ PyAttributeDef KX_GameObject::Attributes[] = {
 	EXP_PYATTRIBUTE_RW_FUNCTION("angularVelocityMin", KX_GameObject, pyattr_get_ang_vel_min, pyattr_set_ang_vel_min),
 	EXP_PYATTRIBUTE_RW_FUNCTION("angularVelocityMax", KX_GameObject, pyattr_get_ang_vel_max, pyattr_set_ang_vel_max),
 	EXP_PYATTRIBUTE_RW_FUNCTION("layer", KX_GameObject, pyattr_get_layer, pyattr_set_layer),
+	EXP_PYATTRIBUTE_SHORT_RW("passIndex", 0, SHRT_MAX, false, KX_GameObject, m_passIndex),
 	EXP_PYATTRIBUTE_RW_FUNCTION("visible",  KX_GameObject, pyattr_get_visible,  pyattr_set_visible),
 	EXP_PYATTRIBUTE_RO_FUNCTION("culled", KX_GameObject, pyattr_get_culled),
 	EXP_PYATTRIBUTE_RO_FUNCTION("cullingBox",   KX_GameObject, pyattr_get_cullingBox),

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -106,6 +106,7 @@ protected:
 	KX_ClientObjectInfo m_clientInfo;
 	std::string							m_name;
 	int									m_layer;
+	short m_passIndex;
 	std::vector<KX_Mesh *>		m_meshes;
 	KX_LodManager						*m_lodManager;
 	short								m_currentLodLevel;
@@ -749,6 +750,9 @@ public:
 	GetLayer(
 		void
 	);
+
+	void SetPassIndex(short index);
+	short GetPassIndex() const;
 
 	/// Allow auto updating bounding volume box.
 	inline void SetAutoUpdateBounds(bool autoUpdate)

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -256,6 +256,8 @@ void RAS_DisplayArrayBucket::RunInstancingNode(const RAS_DisplayArrayNodeTuple& 
 	RAS_IMaterial *material = materialData->m_material;
 	RAS_InstancingBuffer *buffer = m_nodeData.m_instancingBuffer;
 
+	const short matPasIndex = material->GetPassIndex();
+
 	// Bind the instancing buffer to work on it.
 	buffer->Realloc(nummeshslots);
 
@@ -279,11 +281,11 @@ void RAS_DisplayArrayBucket::RunInstancingNode(const RAS_DisplayArrayNodeTuple& 
 		}
 
 		// Fill the buffer with the sorted mesh slots.
-		buffer->Update(rasty, materialData->m_drawingMode, meshSlots);
+		buffer->Update(rasty, materialData->m_drawingMode, matPasIndex, meshSlots);
 	}
 	else {
 		// Fill the buffer with the original mesh slots.
-		buffer->Update(rasty, materialData->m_drawingMode, m_activeMeshSlots);
+		buffer->Update(rasty, materialData->m_drawingMode, matPasIndex, m_activeMeshSlots);
 	}
 
 	RAS_AttributeArrayStorage *attribStorage = m_nodeData.m_attribStorage;

--- a/source/gameengine/Rasterizer/RAS_IMaterial.cpp
+++ b/source/gameengine/Rasterizer/RAS_IMaterial.cpp
@@ -38,7 +38,8 @@ RAS_IMaterial::RAS_IMaterial(const std::string& name)
 	m_alphablend(0),
 	m_zoffset(0.0f),
 	m_rasMode(0),
-	m_flag(0)
+	m_flag(0),
+	m_passIndex(0)
 {
 	for (unsigned short i = 0; i < RAS_Texture::MaxUnits; ++i) {
 		m_textures[i] = nullptr;
@@ -151,6 +152,11 @@ bool RAS_IMaterial::CastsShadows() const
 bool RAS_IMaterial::OnlyShadow() const
 {
 	return (m_flag & RAS_ONLYSHADOW) != 0;
+}
+
+short RAS_IMaterial::GetPassIndex() const
+{
+	return m_passIndex;
 }
 
 RAS_Texture *RAS_IMaterial::GetTexture(unsigned int index)

--- a/source/gameengine/Rasterizer/RAS_IMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IMaterial.h
@@ -95,6 +95,7 @@ protected:
 	float m_zoffset;
 	int m_rasMode;
 	unsigned int m_flag;
+	short m_passIndex;
 
 	RAS_Texture *m_textures[RAS_Texture::MaxUnits];
 
@@ -127,6 +128,7 @@ public:
 	bool IsAlphaShadow() const;
 	bool CastsShadows() const;
 	bool OnlyShadow() const;
+	short GetPassIndex() const;
 	RAS_Texture *GetTexture(unsigned int index);
 
 	virtual const std::string GetTextureName() const = 0;

--- a/source/gameengine/Rasterizer/RAS_InstancingBuffer.h
+++ b/source/gameengine/Rasterizer/RAS_InstancingBuffer.h
@@ -46,7 +46,9 @@ public:
 		/// Pack object color.
 		COLOR_ATTRIB = (1 << 0),
 		/// Pack object layer.
-		LAYER_ATTRIB = (1 << 1)
+		LAYER_ATTRIB = (1 << 1),
+		/// Pack object info.
+		INFO_ATTRIB = (1 << 2)
 	};
 
 private:
@@ -56,7 +58,8 @@ private:
 		MATRIX_MEMORY_SIZE = sizeof(float[9]),
 		POSITION_MEMORY_SIZE = sizeof(float[3]),
 		COLOR_MEMORY_SIZE = sizeof(float[4]),
-		LAYER_MEMORY_SIZE = sizeof(int)
+		LAYER_MEMORY_SIZE = sizeof(int),
+		INFO_MEMORY_SIZE = sizeof(float[3])
 	};
 
 	/// The OpenGL VBO.
@@ -69,6 +72,8 @@ private:
 	intptr_t m_colorOffset;
 	/// The layer offset in the VBO.
 	intptr_t m_layerOffset;
+	/// The info offset in the VBO.
+	intptr_t m_infoOffset;
 
 	/// Attributes to update.
 	Attrib m_attribs;
@@ -89,7 +94,7 @@ public:
 	 * \param drawingmode The material drawing mode used to detect a billboard/halo/shadow material.
 	 * \param meshSlots The list of all non-culled and visible mesh slots (= game object).
 	 */
-	void Update(RAS_Rasterizer *rasty, int drawingmode, const RAS_MeshSlotList &meshSlots);
+	void Update(RAS_Rasterizer *rasty, int drawingmode, short matPassIndex, const RAS_MeshSlotList &meshSlots);
 
 	inline intptr_t GetMatrixOffset() const
 	{
@@ -107,6 +112,11 @@ public:
 	inline intptr_t GetLayerOffset() const
 	{
 		return m_layerOffset;
+	}
+
+	inline intptr_t GetInfoOffset() const
+	{
+		return m_infoOffset;
 	}
 };
 

--- a/source/gameengine/Rasterizer/RAS_MeshUser.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.cpp
@@ -32,8 +32,12 @@
 #include "RAS_BatchGroup.h"
 #include "RAS_Deformer.h"
 
+#include "BLI_hash.h"
+
 RAS_MeshUser::RAS_MeshUser(void *clientobj, RAS_BoundingBox *boundingBox, RAS_Deformer *deformer)
 	:m_layer((1 << 20) - 1),
+	m_passIndex(0),
+	m_random(BLI_hash_int_2d((uintptr_t)clientobj, 0) / ((float)0xFFFFFFFF)),
 	m_frontFace(true),
 	m_color(mt::zero4),
 	m_boundingBox(boundingBox),
@@ -65,6 +69,16 @@ void RAS_MeshUser::NewMeshSlot(RAS_DisplayArrayBucket *arrayBucket)
 unsigned int RAS_MeshUser::GetLayer() const
 {
 	return m_layer;
+}
+
+short RAS_MeshUser::GetPassIndex() const
+{
+	return m_passIndex;
+}
+
+float RAS_MeshUser::GetRandom() const
+{
+	return m_random;
 }
 
 bool RAS_MeshUser::GetFrontFace() const
@@ -110,6 +124,11 @@ RAS_Deformer *RAS_MeshUser::GetDeformer()
 void RAS_MeshUser::SetLayer(unsigned int layer)
 {
 	m_layer = layer;
+}
+
+void RAS_MeshUser::SetPassIndex(short index)
+{
+	m_passIndex = index;
 }
 
 void RAS_MeshUser::SetFrontFace(bool frontFace)

--- a/source/gameengine/Rasterizer/RAS_MeshUser.h
+++ b/source/gameengine/Rasterizer/RAS_MeshUser.h
@@ -42,6 +42,10 @@ class RAS_MeshUser : public mt::SimdClassAllocator
 private:
 	/// Lamp layer.
 	unsigned int m_layer;
+	/// Object pass index.
+	short m_passIndex;
+	/// Random value of this user.
+	float m_random;
 	/// OpenGL face wise.
 	bool m_frontFace;
 	/// Object color.
@@ -65,6 +69,8 @@ public:
 
 	void NewMeshSlot(RAS_DisplayArrayBucket *arrayBucket);
 	unsigned int GetLayer() const;
+	short GetPassIndex() const;
+	float GetRandom() const;
 	bool GetFrontFace() const;
 	const mt::vec4& GetColor() const;
 	const mt::mat4& GetMatrix() const;
@@ -75,6 +81,7 @@ public:
 	RAS_Deformer *GetDeformer();
 
 	void SetLayer(unsigned int layer);
+	void SetPassIndex(short index);
 	void SetFrontFace(bool frontFace);
 	void SetColor(const mt::vec4& color);
 	void SetMatrix(const mt::mat4& matrix);


### PR DESCRIPTION
Previously the object info node was doing nothing directly by the fact
that GPU_material_bind_uniforms was using nullptr for the last argument
corresponding to the float array of object info.

The pass indices used by the object info is stored either in the
blender material and the game object under the same variable m_passIndex.
The object is coppying this value to the mesh user and BL_BlenderShader::Update
is called with the material pass index as argument and inside it
get the object pass index from the mesh user. These information are
used to set the object info and the random value is computed from
the hash of the mesh user client object, a per object value.

The pass index is exposed in python too under attributes:
KX_BlenderMaterial.passIndex
KX_GameObject.passIndex

This commit is used as an example documentation : https://github.com/UPBGE/blender/wiki/Implementing-pass-index

Example file: 
[ge_pass_index.zip](https://github.com/UPBGE/blender/files/2284431/ge_pass_index.zip)
