### PR TITLE
UPBGE: Improve component UI.

### DIFF
--- a/release/scripts/startup/bl_ui/space_logic.py
+++ b/release/scripts/startup/bl_ui/space_logic.py
@@ -45,15 +45,18 @@ class LOGIC_PT_components(bpy.types.Panel):
         for i, c in enumerate(game.components):
             box = layout.box()
             row = box.row()
-            row.prop(c, "name", text="")
+            row.prop(c, "show_expanded", text="", emboss=False)
+            row.label(c.name)
             row.operator("logic.python_component_reload", text="", icon='RECOVER_LAST').index = i
             row.operator("logic.python_component_remove", text="", icon='X').index = i
 
-            for prop in c.properties:
-                row = box.row()
-                row.label(text=prop.name)
-                col = row.column()
-                col.prop(prop, "value", text="")
+            if c.show_expanded and len(c.properties) > 0:
+                box = box.box()
+                for prop in c.properties:
+                    row = box.row()
+                    row.label(text=prop.name)
+                    col = row.column()
+                    col.prop(prop, "value", text="")
 
 
 class LOGIC_PT_properties(Panel):

--- a/source/blender/makesdna/DNA_python_component_types.h
+++ b/source/blender/makesdna/DNA_python_component_types.h
@@ -43,6 +43,8 @@ typedef struct PythonComponent {
 	ListBase properties;
 	char name[64];
 	char module[64];
+	int flag;
+	int pad;
 } PythonComponent;
 
 
@@ -55,5 +57,9 @@ typedef struct PythonComponent {
 #define CPROP_TYPE_VEC2        5
 #define CPROP_TYPE_VEC3        6
 #define CPROP_TYPE_VEC4        7
+
+enum {
+	COMPONENT_SHOW = (1 << 0)
+};
 
 #endif /* __DNA_COMPONENT_TYPES_H__ */

--- a/source/blender/makesrna/intern/rna_python_component.c
+++ b/source/blender/makesrna/intern/rna_python_component.c
@@ -111,6 +111,19 @@ static void rna_def_py_component(BlenderRNA *brna)
 	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 
+	prop = RNA_def_property(srna, "module", PROP_STRING, PROP_NONE);
+	RNA_def_property_string_sdna(prop, NULL, "module");
+	RNA_def_property_ui_text(prop, "Module", "");
+	RNA_def_struct_name_property(srna, prop);
+	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
+	RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+	prop = RNA_def_property(srna, "show_expanded", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "flag", COMPONENT_SHOW);
+	RNA_def_property_ui_text(prop, "Expanded", "Set sensor expanded in the user interface");
+	RNA_def_property_ui_icon(prop, ICON_TRIA_RIGHT, 1);
+	RNA_def_property_update(prop, NC_LOGIC, NULL);
+
 	prop = RNA_def_property(srna, "properties", PROP_COLLECTION, PROP_NONE);
 	RNA_def_property_collection_sdna(prop, NULL, "properties", NULL);
 	RNA_def_property_struct_type(prop, "PythonComponentProperty");


### PR DESCRIPTION
Previously the components name was exposed by a property non-editable which
was rendered in light gray and the component box was always expanded.
Also the module name was inaccesible from bpy.

The last issue is simply solved by exposing the "module" string to RNA.
The name property is replaced by a label in the UI. To expanse the box
the property "show_expanded" similar to the logic brick is implemented,
when this property is True, an inner box is generated containing all the
properties.

Fix issue #793.

![component_ui_1](https://user-images.githubusercontent.com/8046004/44307046-cf6bb180-a39b-11e8-9166-15969604466f.png)
![component_ui_0](https://user-images.githubusercontent.com/8046004/44307047-cf6bb180-a39b-11e8-9ec8-d1d5d842e70d.png)
