### PR TITLE
UPBGE: Enable occluder for invisible objects.

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -738,8 +738,8 @@ static void BL_CreateGraphicObjectNew(KX_GameObject *gameobj, KX_Scene *kxscene,
 	gameobj->SetGraphicController(ctrl);
 	ctrl->SetNewClientInfo(&gameobj->GetClientInfo());
 	if (isActive) {
-		// add first, this will create the proxy handle, only if the object is visible
-		if (gameobj->GetVisible()) {
+		// add first, this will create the proxy handle, only if the object is visible or occluder
+		if (gameobj->GetVisible() || gameobj->GetOccluder()) {
 			env->AddCcdGraphicController(ctrl);
 		}
 	}

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -552,7 +552,7 @@ static void setGraphicController_recursive(SG_Node *node)
 void KX_GameObject::ActivateGraphicController(bool recurse)
 {
 	if (m_graphicController) {
-		m_graphicController->Activate(m_bVisible);
+		m_graphicController->Activate(m_bVisible || m_bOccluder);
 	}
 	if (recurse) {
 		setGraphicController_recursive(m_sgNode.get());
@@ -899,7 +899,7 @@ void KX_GameObject::SetVisible(bool v,
 {
 	m_bVisible = v;
 	if (m_graphicController) {
-		m_graphicController->Activate(m_bVisible);
+		m_graphicController->Activate(m_bVisible || m_bOccluder);
 	}
 	if (recursive) {
 		setVisible_recursive(m_sgNode.get(), v);
@@ -926,6 +926,9 @@ void KX_GameObject::SetOccluder(bool v,
                                 bool recursive)
 {
 	m_bOccluder = v;
+	if (m_graphicController) {
+		m_graphicController->Activate(m_bVisible || m_bOccluder);
+	}
 	if (recursive) {
 		setOccluder_recursive(m_sgNode.get(), v);
 	}


### PR DESCRIPTION
Previously objects were considered as occluder if the occluder option
was checked and that the object was visible. The last constraint is
bothering for the user that could define a simplified mesh for occlusion
that naturally will not be visible.

This commit is introducing the condition "visible || occluder" for the
call activating the graphic controller in KX_GameObject::SetVisible/
SetOccluder and the initialization of the graphic controller.

Fix issue #807.