### PR TITLE
UPBGE: Fix default auto exec option for new created user prefs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ mark_as_advanced(WITH_BLENDER)
 option(WITH_INTERNATIONAL "Enable I18N (International fonts and text)" ON)
 
 option(WITH_PYTHON        "Enable Embedded Python API  (only disable for development)" ON)
-option(WITH_PYTHON_SECURITY "Disables execution of scripts within blend files by default" ON)
+option(WITH_PYTHON_SECURITY "Disables execution of scripts within blend files by default" OFF)
 mark_as_advanced(WITH_PYTHON)  # dont want people disabling this unless they really know what they are doing.
 mark_as_advanced(WITH_PYTHON_SECURITY)  # some distributions see this as a security issue, rather than have them patch it, make a build option.
 

--- a/source/blender/windowmanager/intern/wm_files.c
+++ b/source/blender/windowmanager/intern/wm_files.c
@@ -325,6 +325,11 @@ static void wm_init_userdef(Main *bmain, const bool read_userdef_from_memory)
 	/* versioning is here */
 	UI_init_userdef(bmain);
 
+	/* avoid re-saving for every small change to our prefs, allow overrides */
+	if (read_userdef_from_memory) {
+		BLO_update_defaults_userpref_blend();
+	}
+
 	MEM_CacheLimiter_set_maximum(((size_t)U.memcachelimit) * 1024 * 1024);
 	BKE_sound_init(bmain);
 
@@ -335,11 +340,6 @@ static void wm_init_userdef(Main *bmain, const bool read_userdef_from_memory)
 	/* enabled by default, unless explicitly enabled in the command line which overrides */
 	if ((G.f & G_SCRIPT_OVERRIDE_PREF) == 0) {
 		SET_FLAG_FROM_TEST(G.f, (U.flag & USER_SCRIPT_AUTOEXEC_DISABLE) == 0, G_SCRIPT_AUTOEXEC);
-	}
-
-	/* avoid re-saving for every small change to our prefs, allow overrides */
-	if (read_userdef_from_memory) {
-		BLO_update_defaults_userpref_blend();
 	}
 
 	/* update tempdir from user preferences */


### PR DESCRIPTION
When the user pref config isn't saved, blender load one from memory and
call the function BLO_update_defaults_userpref_blend to initialize properly
the preferences such as the auto exec script option defaulted to true.

Unfortunatly this function is called after the check of the option
and so for blender auto exec is always false until the user saves the
preferences and reload.