### PR TITLE
UPBGE: Allow constructing mesh BVH with a transform.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Mesh.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Mesh.rst
@@ -155,9 +155,13 @@ base class --- :class:`EXP_Value`
       :return: a duplicated mesh of the current used.
       :rtype: :class:`KX_Mesh`.
 
-   .. method:: constructBvh()
+   .. method:: constructBvh(transform=mathutils.Matrix.Identity(4), epsilon=0)
 
       Return a BVH tree based on mesh geometry. Indices of tree elements match polygons indices.
 
+      :arg transform: The transform 4x4 matrix applied to vertices.
+      :type transform: :class:`mathutils.Matrix`
+      :arg epsilon: The tree distance epsilon.
+      :type epsilon: float
       :return: A BVH tree based on mesh geometry.
       :rtype: :class:`mathutils.bvhtree.BVHTree`


### PR DESCRIPTION
The function KX_Mesh.constructBvh can now use as first argument
a transform 4x4 matrix used over all the vertices. This allow
the user to create a BVH in world space by passing the object
world transform.

Fix issue #786.