### PR TITLE
UPBGE: Fix issues on LibFree/LibLoad.

### DIFF
--- a/source/gameengine/Common/CM_Map.h
+++ b/source/gameengine/Common/CM_Map.h
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN GPL LICENSE BLOCK *****
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Contributor(s): Tristan Porteries.
+ *
+ * ***** END GPL LICENSE BLOCK *****
+ */
+
+/** \file CM_List.h
+ *  \ingroup common
+ */
+
+#ifndef __CM_LIST_H__
+#define __CM_LIST_H__
+
+#include <map>
+#include <unordered_map>
+
+template <class Item, class Key, class ... Args>
+inline const Item& CM_MapGetItemNoInsert(const std::map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
+{
+	const typename std::map<Key, Item, Args ...>::iterator it = map.find(key);
+	if (it != map.end()) {
+		return it->second;
+	}
+	return defaultItem;
+}
+
+template <class Item, class Key, class ... Args>
+inline const Item& CM_MapGetItemNoInsert(const std::unordered_map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
+{
+	const typename std::map<Key, Item, Args ...>::iterator it = map.find(key);
+	if (it != map.end()) {
+		return it->second;
+	}
+	return defaultItem;
+}
+
+template <class Map, class Item>
+inline bool CM_MapRemoveIfItemFound(Map& map, const Item& item)
+{
+	bool found = false;
+	for (typename Map::iterator it = map.begin(); it != map.end();) {
+		if (it->second == item) {
+			it = map.erase(it);
+			found = true;
+		}
+		else {
+			++it;
+		}
+	}
+
+	return found;
+}
+
+#endif  // __CM_LIST_H__

--- a/source/gameengine/Common/CMakeLists.txt
+++ b/source/gameengine/Common/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRC
 	CM_Clock.h
 	CM_Format.h
 	CM_List.h
+	CM_Map.h
 	CM_Message.h
 	CM_RefCount.h
 	CM_Template.h

--- a/source/gameengine/Converter/BL_ActionActuator.h
+++ b/source/gameengine/Converter/BL_ActionActuator.h
@@ -45,7 +45,7 @@ public:
 						const std::string& framepropname,
 						float starttime,
 						float endtime,
-						struct bAction *action,
+						const std::string& actionName,
 						short	playtype,
 						short	blend_mode,
 						short	blendin,
@@ -63,9 +63,6 @@ public:
 	void SetLocalTime(float curtime);
 	void ResetStartTime(float curtime);
 	
-	bAction*	GetAction() { return m_action; }
-	void		SetAction(bAction* act) { m_action= act; }
-
 	virtual void DecLink();
 
 	bool Play(KX_GameObject *obj, float start, float end, short mode);
@@ -114,7 +111,7 @@ protected:
 	short	m_priority;
 	short	m_layer;
 	short	m_ipo_flags;
-	struct bAction *m_action;
+	std::string m_actionName;
 	std::string	m_propname;
 	std::string	m_framepropname;
 };

--- a/source/gameengine/Converter/BL_ActionData.cpp
+++ b/source/gameengine/Converter/BL_ActionData.cpp
@@ -1,0 +1,38 @@
+#include "BL_ActionData.h"
+
+extern "C" {
+#  include "DNA_action_types.h"
+#  include "DNA_anim_types.h"
+#  include "BKE_fcurve.h"
+}
+
+BL_ActionData::BL_ActionData(bAction *action)
+	:m_action(action)
+{
+	for (FCurve *fcu = (FCurve *)action->curves.first; fcu; fcu = fcu->next) {
+		if (fcu->rna_path) {
+			m_interpolators.emplace_back(fcu);
+		}
+	}
+}
+
+std::string BL_ActionData::GetName() const
+{
+	return m_action->id.name + 2;
+}
+
+bAction *BL_ActionData::GetAction() const
+{
+	return m_action;
+}
+
+BL_ScalarInterpolator *BL_ActionData::GetScalarInterpolator(const std::string& rna_path, int array_index)
+{
+	for (BL_ScalarInterpolator &interp : m_interpolators) {
+		FCurve *fcu = interp.GetFCurve();
+		if (array_index == fcu->array_index && rna_path == fcu->rna_path) {
+			return &interp;
+		}
+	}
+	return nullptr;
+}

--- a/source/gameengine/Converter/BL_ActionData.h
+++ b/source/gameengine/Converter/BL_ActionData.h
@@ -1,0 +1,31 @@
+#ifndef __BL_ACTION_DATA_H__
+#define __BL_ACTION_DATA_H__
+
+#include "BL_Resource.h"
+#include "BL_ScalarInterpolator.h"
+
+#include <string>
+
+struct bAction;
+
+/** Data related to a blender animation.
+ */
+class BL_ActionData : public BL_Resource
+{
+private:
+	/// The blender action.
+	bAction *m_action;
+	/// The interpolators for each curve (FCurve) of the action.
+	std::vector<BL_ScalarInterpolator> m_interpolators;
+
+public:
+	BL_ActionData(bAction *action);
+	~BL_ActionData() = default;
+
+	std::string GetName() const;
+	bAction *GetAction() const;
+
+	BL_ScalarInterpolator *GetScalarInterpolator(const std::string& rna_path, int array_index);
+};
+
+#endif  // __BL_ACTION_DATA_H__

--- a/source/gameengine/Converter/BL_BlenderDataConversion.h
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.h
@@ -41,10 +41,12 @@ class RAS_ICanvas;
 class KX_KetsjiEngine;
 class KX_Scene;
 class BL_SceneConverter;
+class BL_ActionData;
 struct Mesh;
 struct DerivedMesh;
 struct Object;
 struct Main;
+struct bAction;
 
 struct BL_MeshMaterial {
 	RAS_DisplayArray *array;
@@ -60,6 +62,10 @@ void BL_ConvertDerivedMeshToArray(DerivedMesh *dm, Mesh *me, const std::vector<B
                                   const RAS_Mesh::LayersInfo& layersInfo);
 
 RAS_Deformer *BL_ConvertDeformer(KX_GameObject *object, KX_Mesh *meshobj);
+
+BL_ActionData *BL_ConvertAction(bAction *action, KX_Scene *scene, BL_SceneConverter& converter);
+/// Convert all actions of a library and register them in a converter.
+void BL_ConvertActions(KX_Scene *scene, Main *maggie, BL_SceneConverter& converter);
 
 void BL_ConvertBlenderObjects(Main *maggie, KX_Scene *kxscene, KX_KetsjiEngine *ketsjiEngine,
 							  RAS_Rasterizer *rendertools, RAS_ICanvas *canvas, BL_SceneConverter& sceneconverter,

--- a/source/gameengine/Converter/BL_ConvertActuators.cpp
+++ b/source/gameengine/Converter/BL_ConvertActuators.cpp
@@ -222,13 +222,15 @@ void BL_ConvertActuators(const char *maggiename,
 					ipo_flags |= BL_Action::ACT_IPOFLAG_ADD;
 				}
 
+				const std::string actionName = (actact->act) ? actact->act->id.name + 2 : "";
+
 				BL_ActionActuator *tmpbaseact = new BL_ActionActuator(
 					gameobj,
 					propname,
 					propframe,
 					actact->sta,
 					actact->end,
-					actact->act,
+					actionName,
 					actact->type,         // + 1, because Blender starts to count at zero,
 					actact->blend_mode,
 					actact->blendin,

--- a/source/gameengine/Converter/BL_ConvertObjectInfo.cpp
+++ b/source/gameengine/Converter/BL_ConvertObjectInfo.cpp
@@ -1,0 +1,6 @@
+#include "BL_ConvertObjectInfo.h"
+
+BL_ConvertObjectInfo::BL_ConvertObjectInfo(Object *blendobj)
+	:m_blenderObject(blendobj)
+{
+}

--- a/source/gameengine/Converter/BL_ConvertObjectInfo.h
+++ b/source/gameengine/Converter/BL_ConvertObjectInfo.h
@@ -1,18 +1,22 @@
 #ifndef __BL_CONVERT_OBJECT_INFO__
 #define __BL_CONVERT_OBJECT_INFO__
 
+#include "BL_Resource.h"
+
 #include <vector>
 
 struct bRigidBodyJointConstraint;
 struct Object;
 
-class BL_ConvertObjectInfo
+class BL_ConvertObjectInfo : public BL_Resource
 {
 public:
 	/// Blender object used during conversion.
 	Object *m_blenderObject;
 	/// Object constraints defined by the user.
 	std::vector<bRigidBodyJointConstraint *> m_constraints;
+
+	BL_ConvertObjectInfo(Object *blendobj);
 };
 
 #endif  // __BL_CONVERT_OBJECT_INFO__

--- a/source/gameengine/Converter/BL_IpoConvert.h
+++ b/source/gameengine/Converter/BL_IpoConvert.h
@@ -32,35 +32,34 @@
 #ifndef __KX_IPOCONVERT_H__
 #define __KX_IPOCONVERT_H__
 
-struct Object;
-struct bAction;
 class SG_Controller;
+class BL_ActionData;
 class KX_GameObject;
 class KX_Scene;
 class RAS_IMaterial;
 
-SG_Controller *BL_CreateIPO(bAction *action,
+SG_Controller *BL_CreateIPO(BL_ActionData *action,
 	KX_GameObject* gameobj,
 	KX_Scene *scene);
 
-SG_Controller *BL_CreateObColorIPO(bAction *action,
+SG_Controller *BL_CreateObColorIPO(BL_ActionData *action,
 	KX_GameObject* gameobj,
 	KX_Scene *scene);
 
-SG_Controller *BL_CreateLampIPO(bAction *action,
+SG_Controller *BL_CreateLampIPO(BL_ActionData *action,
 	KX_GameObject* lightobj,
 	KX_Scene *scene);
 
-SG_Controller *BL_CreateWorldIPO(bAction *action,
+SG_Controller *BL_CreateWorldIPO(BL_ActionData *action,
 	struct World *blenderworld,
 	KX_Scene *scene);
 
-SG_Controller *BL_CreateCameraIPO(bAction *action,
+SG_Controller *BL_CreateCameraIPO(BL_ActionData *action,
 	KX_GameObject* cameraobj,
 	KX_Scene *scene);
 
 SG_Controller *BL_CreateMaterialIpo(
-	bAction *action,
+	BL_ActionData *action,
 	RAS_IMaterial *mat,
 	KX_GameObject* gameobj,
 	KX_Scene *scene);

--- a/source/gameengine/Converter/BL_Resource.cpp
+++ b/source/gameengine/Converter/BL_Resource.cpp
@@ -1,0 +1,31 @@
+#include "BL_Resource.h"
+
+#include "BLI_utildefines.h"
+
+BL_Resource::Library::Library()
+	:m_id(0)
+{
+}
+
+BL_Resource::Library::Library(Main *maggie)
+	:m_id((uintptr_t)maggie)
+{
+}
+
+bool BL_Resource::Library::Valid() const
+{
+	return (m_id != 0);
+}
+
+void BL_Resource::SetOwner(const Library& libraryId)
+{
+	// Forbid changing of library, replacing a valid library.
+	BLI_assert(!m_libraryId.Valid());
+
+	m_libraryId = libraryId;
+}
+
+bool BL_Resource::Belong(const Library& libraryId) const
+{
+	return (m_libraryId == libraryId);
+}

--- a/source/gameengine/Converter/BL_Resource.h
+++ b/source/gameengine/Converter/BL_Resource.h
@@ -1,0 +1,47 @@
+#ifndef __BL_RESOURCE_H__
+#define __BL_RESOURCE_H__
+
+#include <cstdint>
+
+class BL_SceneConverter;
+struct Main;
+
+/** Base class of resources. Used to identify the library of the resource.
+ */
+class BL_Resource
+{
+public:
+	/// Opaque library identifier.
+	class Library
+	{
+	private:
+		uintptr_t m_id;
+
+	public:
+		Library();
+		explicit Library(Main *maggie);
+
+		/// Return true if the identifier was constructed along an existing library.
+		bool Valid() const;
+
+		inline bool operator==(const Library& other) const
+		{
+			return (m_id == other.m_id);
+		}
+	};
+
+private:
+	/// The identifier of library owning the resource.
+	Library m_libraryId;
+
+public:
+	/// Initialize the library of this resource, must be called only once.
+	void SetOwner(const Library& libraryId);
+
+	/** Return true if the libraryId match m_libraryId.
+	 * Meaning the resource was converted with date from this library.
+	 */
+	bool Belong(const Library& libraryId) const;
+};
+
+#endif  // __BL_RESOURCE_H__

--- a/source/gameengine/Converter/BL_ScalarInterpolator.cpp
+++ b/source/gameengine/Converter/BL_ScalarInterpolator.cpp
@@ -32,7 +32,6 @@
 #include "BL_ScalarInterpolator.h"
 
 extern "C" {
-#  include "DNA_action_types.h"
 #  include "DNA_anim_types.h"
 #  include "BKE_fcurve.h"
 }
@@ -51,38 +50,3 @@ FCurve *BL_ScalarInterpolator::GetFCurve() const
 {
 	return m_fcu;
 }
-
-BL_InterpolatorList::BL_InterpolatorList(bAction *action)
-	:m_action(action)
-{
-	if (!action) {
-		return;
-	}
-
-	for (FCurve *fcu = (FCurve *)action->curves.first; fcu; fcu = fcu->next) {
-		if (fcu->rna_path) {
-			m_interpolators.emplace_back(fcu);
-		}
-	}
-}
-
-BL_InterpolatorList::~BL_InterpolatorList()
-{
-}
-
-bAction *BL_InterpolatorList::GetAction() const
-{
-	return m_action;
-}
-
-BL_ScalarInterpolator *BL_InterpolatorList::GetScalarInterpolator(const std::string& rna_path, int array_index)
-{
-	for (BL_ScalarInterpolator &interp : m_interpolators) {
-		FCurve *fcu = interp.GetFCurve();
-		if (array_index == fcu->array_index && rna_path == fcu->rna_path) {
-			return &interp;
-		}
-	}
-	return nullptr;
-}
-

--- a/source/gameengine/Converter/BL_ScalarInterpolator.h
+++ b/source/gameengine/Converter/BL_ScalarInterpolator.h
@@ -53,19 +53,4 @@ public:
 	FCurve *GetFCurve() const;
 };
 
-class BL_InterpolatorList
-{
-private:
-	bAction *m_action;
-	std::vector<BL_ScalarInterpolator> m_interpolators;
-
-public:
-	BL_InterpolatorList(bAction *action);
-	~BL_InterpolatorList();
-
-	bAction *GetAction() const;
-
-	BL_ScalarInterpolator *GetScalarInterpolator(const std::string& rna_path, int array_index);
-};
-
 #endif  /* __KX_BLENDERSCALARINTERPOLATOR_H__ */

--- a/source/gameengine/Converter/BL_SceneConverter.h
+++ b/source/gameengine/Converter/BL_SceneConverter.h
@@ -32,7 +32,7 @@
 #ifndef __KX_BLENDERSCENECONVERTER_H__
 #define __KX_BLENDERSCENECONVERTER_H__
 
-#include "CM_Message.h"
+#include "BL_Resource.h"
 
 #include <map>
 #include <vector>
@@ -43,6 +43,7 @@ class KX_Mesh;
 class KX_BlenderMaterial;
 class BL_Converter;
 class BL_ConvertObjectInfo;
+class BL_ActionData;
 class KX_GameObject;
 class KX_Scene;
 class KX_LibLoadStatus;
@@ -52,6 +53,7 @@ struct Object;
 struct Scene;
 struct Mesh;
 struct Material;
+struct bAction;
 struct bActuator;
 struct bController;
 
@@ -61,11 +63,16 @@ class BL_SceneConverter
 
 private:
 	KX_Scene *m_scene;
+	const BL_Resource::Library m_libraryId;
+
+	/// Ressources from the scene.
 
 	std::vector<KX_BlenderMaterial *> m_materials;
 	std::vector<KX_Mesh *> m_meshobjects;
 	std::vector<BL_ConvertObjectInfo *> m_objectInfos;
-	// List of all object converted, active and inactive.
+	std::vector<BL_ActionData *> m_actions;
+
+	/// List of all object converted, active and inactive, not considered as a ressource.
 	std::vector<KX_GameObject *> m_objects;
 
 	std::map<Object *, BL_ConvertObjectInfo *> m_blenderToObjectInfos;
@@ -76,12 +83,11 @@ private:
 	std::map<bController *, SCA_IController *> m_map_blender_to_gamecontroller;
 
 public:
-	BL_SceneConverter(KX_Scene *scene);
+	BL_SceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId);
 	~BL_SceneConverter() = default;
 
 	// Disable dangerous copy.
 	BL_SceneConverter(const BL_SceneConverter& other) = delete;
-
 	BL_SceneConverter(BL_SceneConverter&& other);
 
 	KX_Scene *GetScene() const;
@@ -95,6 +101,8 @@ public:
 
 	void RegisterMaterial(KX_BlenderMaterial *blmat, Material *mat);
 	KX_BlenderMaterial *FindMaterial(Material *mat);
+
+	void RegisterActionData(BL_ActionData *data);
 
 	void RegisterGameActuator(SCA_IActuator *act, bActuator *for_actuator);
 	SCA_IActuator *FindGameActuator(bActuator *for_actuator);

--- a/source/gameengine/Converter/CMakeLists.txt
+++ b/source/gameengine/Converter/CMakeLists.txt
@@ -66,35 +66,40 @@ set(INC_SYS
 
 set(SRC
 	BL_ActionActuator.cpp
+	BL_ActionData.cpp
 	BL_ArmatureActuator.cpp
 	BL_ArmatureChannel.cpp
 	BL_ArmatureConstraint.cpp
 	BL_ArmatureObject.cpp
 	BL_BlenderDataConversion.cpp
+	BL_Converter.cpp
 	BL_MeshDeformer.cpp
 	BL_ModifierDeformer.cpp
+	BL_Resource.cpp
 	BL_ShapeDeformer.cpp
 	BL_SkinDeformer.cpp
-	BL_Converter.cpp
 	BL_ScalarInterpolator.cpp
 	BL_SceneConverter.cpp
 	BL_ConvertActuators.cpp
 	BL_ConvertControllers.cpp
+	BL_ConvertObjectInfo.cpp
 	BL_ConvertProperties.cpp
 	BL_ConvertSensors.cpp
 	BL_IpoConvert.cpp
 
 	BL_ActionActuator.h
+	BL_ActionData.h
 	BL_ArmatureActuator.h
 	BL_ArmatureChannel.h
 	BL_ArmatureConstraint.h
 	BL_ArmatureObject.h
 	BL_BlenderDataConversion.h
+	BL_Converter.h
 	BL_MeshDeformer.h
 	BL_ModifierDeformer.h
+	BL_Resource.h
 	BL_ShapeDeformer.h
 	BL_SkinDeformer.h
-	BL_Converter.h
 	BL_ScalarInterpolator.h
 	BL_SceneConverter.h
 	BL_ConvertActuators.h

--- a/source/gameengine/GameLogic/SCA_LogicManager.cpp
+++ b/source/gameengine/GameLogic/SCA_LogicManager.cpp
@@ -37,8 +37,8 @@
 #include "SCA_IActuator.h"
 #include "SCA_EventManager.h"
 #include "SCA_PythonController.h"
-#include <set>
 
+#include "CM_Map.h"
 
 SCA_LogicManager::SCA_LogicManager()
 {
@@ -220,32 +220,38 @@ void SCA_LogicManager::UpdateFrame(double curtime)
 
 void *SCA_LogicManager::GetActionByName(const std::string& actname)
 {
-	std::string an = actname;
-	return m_mapStringToActions[an];
+	const auto it = m_mapStringToActions.find(actname);
+	if (it != m_mapStringToActions.end()) {
+		return it->second;
+	}
+
+	return nullptr;
 }
-
-
 
 void *SCA_LogicManager::GetMeshByName(const std::string& meshname)
 {
-	std::string mn = meshname;
-	return m_mapStringToMeshes[mn];
+	const auto it = m_mapStringToMeshes.find(meshname);
+	if (it != m_mapStringToMeshes.end()) {
+		return it->second;
+	}
+
+	return nullptr;
 }
-
-
 
 void SCA_LogicManager::RegisterMeshName(const std::string& meshname, void *mesh)
 {
-	std::string mn = meshname;
-	m_mapStringToMeshes[mn] = mesh;
+	m_mapStringToMeshes[meshname] = mesh;
 }
 
 void SCA_LogicManager::UnregisterMeshName(const std::string& meshname, void *mesh)
 {
-	std::string mn = meshname;
-	m_mapStringToMeshes.erase(mn);
+	m_mapStringToMeshes.erase(meshname);
 }
 
+void SCA_LogicManager::UnregisterMesh(void *mesh)
+{
+	CM_MapRemoveIfItemFound(m_mapStringToMeshes, mesh);
+}
 
 void SCA_LogicManager::RegisterActionName(const std::string& actname, void *action)
 {
@@ -253,7 +259,10 @@ void SCA_LogicManager::RegisterActionName(const std::string& actname, void *acti
 	m_mapStringToActions[an] = action;
 }
 
-
+void SCA_LogicManager::UnregisterAction(void *action)
+{
+	CM_MapRemoveIfItemFound(m_mapStringToActions, action);
+}
 
 void SCA_LogicManager::EndFrame()
 {

--- a/source/gameengine/GameLogic/SCA_LogicManager.h
+++ b/source/gameengine/GameLogic/SCA_LogicManager.h
@@ -119,10 +119,10 @@ public:
 	// for the scripting... needs a FactoryManager later (if we would have time... ;)
 	void	RegisterMeshName(const std::string& meshname,void* mesh);
 	void	UnregisterMeshName(const std::string& meshname,void* mesh);
-	std::map<std::string, void *>&	GetMeshMap() { return m_mapStringToMeshes; }
-	std::map<std::string, void *>&	GetActionMap() { return m_mapStringToActions; }
-	
+	void UnregisterMesh(void *mesh);
+
 	void	RegisterActionName(const std::string& actname,void* action);
+	void UnregisterAction(void *action);
 
 	void*	GetActionByName (const std::string& actname);
 	void*	GetMeshByName(const std::string& meshname);

--- a/source/gameengine/Ketsji/BL_Action.h
+++ b/source/gameengine/Ketsji/BL_Action.h
@@ -32,14 +32,14 @@
 
 class KX_GameObject;
 class SG_Controller;
-
+class BL_ActionData;
 struct bAction;
 struct bPose;
 
 class BL_Action
 {
 private:
-	bAction* m_action;
+	BL_ActionData *m_actionData;
 	bAction* m_tmpaction;
 	bPose* m_blendpose;
 	bPose* m_blendinpose;
@@ -126,7 +126,7 @@ public:
 	float GetFrame();
 	const std::string GetName();
 
-	struct bAction *GetAction();
+	BL_ActionData *GetActionData();
 
 	// Mutators
 	void SetFrame(float frame);

--- a/source/gameengine/Ketsji/BL_ActionManager.cpp
+++ b/source/gameengine/Ketsji/BL_ActionManager.cpp
@@ -25,10 +25,8 @@
  */
 
 #include "BL_Action.h"
+#include "BL_ActionData.h"
 #include "BL_ActionManager.h"
-#include "DNA_ID.h"
-
-#define IS_TAGGED(_id) ((_id) && (((ID *)_id)->tag & LIB_TAG_DOIT))
 
 BL_ActionManager::BL_ActionManager(class KX_GameObject *obj) :
 	m_obj(obj),
@@ -47,11 +45,11 @@ BL_ActionManager::~BL_ActionManager()
 	m_layers.clear();
 }
 
-BL_Action *BL_ActionManager::GetAction(short layer)
+BL_Action *BL_ActionManager::GetAction(short layer) const
 {
-	BL_ActionMap::iterator it = m_layers.find(layer);
+	BL_ActionMap::const_iterator it = m_layers.find(layer);
 
-	return (it != m_layers.end()) ? it->second : 0;
+	return (it != m_layers.end()) ? it->second : nullptr;
 }
 
 float BL_ActionManager::GetActionFrame(short layer)
@@ -76,11 +74,11 @@ void BL_ActionManager::SetActionFrame(short layer, float frame)
 	}
 }
 
-struct bAction *BL_ActionManager::GetCurrentAction(short layer)
+std::string BL_ActionManager::GetCurrentActionName(short layer) const
 {
 	BL_Action *action = GetAction(layer);
 
-	return action ? action->GetAction() : 0;
+	return action ? action->GetName() : "";
 }
 
 void BL_ActionManager::SetPlayMode(short layer, short mode)
@@ -129,10 +127,10 @@ void BL_ActionManager::StopAction(short layer)
 	}
 }
 
-void BL_ActionManager::RemoveTaggedActions()
+void BL_ActionManager::RemoveActions(const BL_Resource::Library& libraryId)
 {
 	for (BL_ActionMap::iterator it = m_layers.begin(); it != m_layers.end(); ) {
-		if (IS_TAGGED(it->second->GetAction())) {
+		if (it->second->GetActionData()->Belong(libraryId)) {
 			delete it->second;
 			it = m_layers.erase(it);
 		}

--- a/source/gameengine/Ketsji/BL_ActionManager.h
+++ b/source/gameengine/Ketsji/BL_ActionManager.h
@@ -53,7 +53,7 @@ private:
 	/**
 	 * Check if an action exists
 	 */
-	BL_Action* GetAction(short layer);
+	BL_Action* GetAction(short layer) const;
 
 public:
 	BL_ActionManager(class KX_GameObject* obj);
@@ -88,7 +88,7 @@ public:
 	/**
 	 * Gets the currently running action on the given layer
 	 */
-	struct bAction *GetCurrentAction(short layer);
+	std::string GetCurrentActionName(short layer) const;
 
 	/**
 	 * Sets play mode of the action on the given layer
@@ -100,10 +100,7 @@ public:
 	 */
 	void StopAction(short layer);
 
-	/**
-	 * Remove playing tagged actions.
-	 */
-	void RemoveTaggedActions();
+	void RemoveActions(const BL_Resource::Library& libraryId);
 
 	/**
 	 * Check if an action has finished playing

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -117,8 +117,6 @@ KX_BlenderMaterial::KX_BlenderMaterial(Material *mat, const std::string& name, K
 
 	m_blendFunc[0] = RAS_Rasterizer::RAS_ZERO;
 	m_blendFunc[1] = RAS_Rasterizer::RAS_ZERO;
-
-	InitTextures();
 }
 
 KX_BlenderMaterial::~KX_BlenderMaterial()
@@ -193,8 +191,22 @@ SCA_IScene *KX_BlenderMaterial::GetScene() const
 
 void KX_BlenderMaterial::ReloadMaterial()
 {
+	BLI_assert(m_scene);
+
 	if (m_blenderShader) {
+		// If shader exists reload it.
 		m_blenderShader->ReloadMaterial();
+	}
+	else {
+		// Init textures.
+		InitTextures();
+		// Create shader.
+		m_blenderShader = new BL_BlenderShader(m_scene, m_material, this);
+
+		if (!m_blenderShader->Ok()) {
+			delete m_blenderShader;
+			m_blenderShader = nullptr;
+		}
 	}
 }
 
@@ -213,19 +225,6 @@ void KX_BlenderMaterial::InitTextures()
 			BL_Texture *texture = new BL_Texture(mtex);
 			m_textures[i] = texture;
 		}
-	}
-}
-
-void KX_BlenderMaterial::InitShader()
-{
-	BLI_assert(!m_blenderShader);
-	BLI_assert(m_scene);
-
-	m_blenderShader = new BL_BlenderShader(m_scene, m_material, this);
-
-	if (!m_blenderShader->Ok()) {
-		delete m_blenderShader;
-		m_blenderShader = nullptr;
 	}
 }
 

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -8,6 +8,7 @@
 
 #include "RAS_IMaterial.h"
 #include "BL_Texture.h"
+#include "BL_Resource.h"
 
 #include "EXP_Value.h"
 
@@ -21,7 +22,7 @@ struct Material;
 void KX_BlenderMaterial_Mathutils_Callback_Init(void);
 #endif
 
-class KX_BlenderMaterial : public EXP_Value, public RAS_IMaterial
+class KX_BlenderMaterial : public EXP_Value, public BL_Resource, public RAS_IMaterial
 {
 	Py_Header
 
@@ -53,7 +54,6 @@ public:
 	virtual void ReloadMaterial();
 
 	void ReplaceScene(KX_Scene *scene);
-	void InitShader();
 
 	static void EndFrame(RAS_Rasterizer *rasty);
 

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -51,6 +51,7 @@
 #include "DNA_constraint_types.h" /* for constraint replication */
 #include "DNA_object_types.h"
 #include "SCA_LogicManager.h" /* for ConvertPythonToGameObject to search object names */
+#include "BL_Resource.h" // For BL_Resource::Library.
 
 class KX_RayCast;
 class KX_LodManager;
@@ -291,7 +292,7 @@ public:
 	/**
 	 * Gets the currently running action on the given layer
 	 */
-	bAction *GetCurrentAction(short layer);
+	std::string GetCurrentActionName(short layer);
 
 	/**
 	 * Sets play mode of the action on the given layer
@@ -302,11 +303,6 @@ public:
 	 * Stop playing the action on the given layer
 	 */
 	void StopAction(short layer);
-
-	/**
-	 * Remove playing tagged actions.
-	 */
-	void RemoveTaggedActions();
 
 	/**
 	 * Check if an action has finished playing
@@ -368,6 +364,12 @@ public:
 	 * object belongs with the caller.
 	 */
 	virtual EXP_Value *GetReplica();
+
+	/** Remove object resource coming from the given library.
+	 * These resource could be actions and meshes.
+	 * \param libraryId The identifier of the library used to recognize the resource.
+	 */
+	void RemoveRessources(const BL_Resource::Library& libraryId);
 	
 	/** 
 	 * Return the linear velocity of the game object.

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -417,8 +417,6 @@ bool KX_KetsjiEngine::NextFrame()
 	for (unsigned short i = 0; i < times.frames; ++i) {
 		m_frameTime += times.framestep;
 
-		m_converter->MergeAsyncLoads();
-
 		if (m_inputDevice) {
 			m_inputDevice->ReleaseMoveEvent();
 		}
@@ -489,6 +487,8 @@ bool KX_KetsjiEngine::NextFrame()
 		if (m_inputDevice) {
 			m_inputDevice->ClearInputs();
 		}
+
+		m_converter->ProcessScheduledLibraries();
 
 		UpdateSuspendedScenes(times.framestep);
 		// scene management
@@ -1336,14 +1336,6 @@ KX_Scene *KX_KetsjiEngine::CreateScene(const std::string& scenename)
 	return CreateScene(scene);
 }
 
-void KX_KetsjiEngine::ConvertScene(KX_Scene *scene)
-{
-	BL_SceneConverter sceneConverter(scene);
-	m_converter->ConvertScene(sceneConverter, false);
-	m_converter->PostConvertScene(sceneConverter);
-	m_converter->FinalizeSceneData(sceneConverter);
-}
-
 void KX_KetsjiEngine::AddScheduledScenes()
 {
 	if (!m_addingOverlayScenes.empty()) {
@@ -1351,7 +1343,7 @@ void KX_KetsjiEngine::AddScheduledScenes()
 			KX_Scene *tmpscene = CreateScene(scenename);
 
 			if (tmpscene) {
-				ConvertScene(tmpscene);
+				m_converter->ConvertScene(tmpscene);
 				m_scenes->Add(CM_AddRef(tmpscene));
 				PostProcessScene(tmpscene);
 				tmpscene->Release();
@@ -1368,7 +1360,7 @@ void KX_KetsjiEngine::AddScheduledScenes()
 			KX_Scene *tmpscene = CreateScene(scenename);
 
 			if (tmpscene) {
-				ConvertScene(tmpscene);
+				m_converter->ConvertScene(tmpscene);
 				m_scenes->Insert(0, CM_AddRef(tmpscene));
 				PostProcessScene(tmpscene);
 				tmpscene->Release();
@@ -1422,7 +1414,7 @@ void KX_KetsjiEngine::ReplaceScheduledScenes()
 						DestructScene(scene);
 
 						KX_Scene *tmpscene = CreateScene(blScene);
-						ConvertScene(tmpscene);
+						m_converter->ConvertScene(tmpscene);
 
 						m_scenes->SetValue(sce_idx, CM_AddRef(tmpscene));
 						PostProcessScene(tmpscene);

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -508,9 +508,6 @@ public:
 	KX_Scene *CreateScene(const std::string& scenename);
 	KX_Scene *CreateScene(Scene *scene);
 
-	/// Fully convert a non-libloaded scene.
-	void ConvertScene(KX_Scene *scene);
-
 	GlobalSettings *GetGlobalSettings(void);
 	void SetGlobalSettings(GlobalSettings *gs);
 

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
@@ -88,24 +88,14 @@ KX_Scene *KX_LibLoadStatus::GetMergeScene() const
 	return m_mergescene;
 }
 
-const std::vector<KX_Scene *>& KX_LibLoadStatus::GetScenes() const
-{
-	return m_scenes;
-}
-
-void KX_LibLoadStatus::SetScenes(const std::vector<KX_Scene *>& scenes)
-{
-	m_scenes = scenes;
-}
-
-const std::vector<BL_SceneConverter>& KX_LibLoadStatus::GetSceneConverters() const
+std::vector<BL_SceneConverter>& KX_LibLoadStatus::GetSceneConverters()
 {
 	return m_sceneConvertes;
 }
 
-void KX_LibLoadStatus::AddSceneConverter(BL_SceneConverter&& converter)
+void KX_LibLoadStatus::AddSceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId)
 {
-	m_sceneConvertes.push_back(std::move(converter));
+	m_sceneConvertes.emplace_back(scene, libraryId);
 }
 
 bool KX_LibLoadStatus::IsFinished() const

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.h
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.h
@@ -41,7 +41,6 @@ private:
 	BL_Converter *m_converter;
 	KX_KetsjiEngine *m_engine;
 	KX_Scene *m_mergescene;
-	std::vector<KX_Scene *> m_scenes;
 	std::vector<BL_SceneConverter> m_sceneConvertes;
 	std::string m_libname;
 
@@ -69,10 +68,8 @@ public:
 	KX_KetsjiEngine *GetEngine() const;
 	KX_Scene *GetMergeScene() const;
 
-	const std::vector<KX_Scene *>& GetScenes() const;
-	void SetScenes(const std::vector<KX_Scene *>& scenes);
-	const std::vector<BL_SceneConverter>& GetSceneConverters() const;
-	void AddSceneConverter(BL_SceneConverter&& converter);
+	std::vector<BL_SceneConverter>& GetSceneConverters();
+	void AddSceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId);
 
 	bool IsFinished() const;
 

--- a/source/gameengine/Ketsji/KX_Mesh.h
+++ b/source/gameengine/Ketsji/KX_Mesh.h
@@ -34,6 +34,8 @@
 
 #include "RAS_Mesh.h"
 
+#include "BL_Resource.h"
+
 #include "EXP_Value.h"
 
 class KX_Mesh;
@@ -46,7 +48,7 @@ bool ConvertPythonToMesh(SCA_LogicManager *logicmgr, PyObject *value, KX_Mesh **
 
 #endif  // WITH_PYTHON
 
-class KX_Mesh : public EXP_Value, public RAS_Mesh
+class KX_Mesh : public EXP_Value, public BL_Resource, public RAS_Mesh
 {
 	Py_Header
 

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -716,7 +716,7 @@ static PyObject *gLibNew(PyObject *, PyObject *args)
 
 	BL_Converter *converter = KX_GetActiveEngine()->GetConverter();
 
-	if (converter->GetMainDynamicPath(path)) {
+	if (converter->ExistLibrary(path)) {
 		PyErr_SetString(PyExc_KeyError, "the name of the path given exists");
 		return nullptr;
 	}
@@ -727,7 +727,7 @@ static PyObject *gLibNew(PyObject *, PyObject *args)
 		return nullptr;
 	}
 
-	Main *maggie = converter->CreateMainDynamic(path);
+	Main *maggie = converter->CreateLibrary(path);
 
 	/* Copy the object into main */
 	if (idcode == ID_ME) {
@@ -773,11 +773,11 @@ static PyObject *gLibFree(PyObject *, PyObject *args)
 
 static PyObject *gLibList(PyObject *, PyObject *args)
 {
-	const std::vector<Main *> &dynMaggie = KX_GetActiveEngine()->GetConverter()->GetMainDynamic();
-	PyObject *list = PyList_New(dynMaggie.size());
+	const std::vector<std::string> names = KX_GetActiveEngine()->GetConverter()->GetLibraryNames();
+	PyObject *list = PyList_New(names.size());
 
-	for (unsigned short i = 0, size = dynMaggie.size(); i < size; ++i) {
-		PyList_SET_ITEM(list, i, PyUnicode_FromString(dynMaggie[i]->name));
+	for (unsigned short i = 0, size = names.size(); i < size; ++i) {
+		PyList_SET_ITEM(list, i, PyUnicode_FromStdString(names[i]));
 	}
 
 	return list;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -259,6 +259,11 @@ private:
 	bool m_isActivedHysteresis;
 	int m_lodHysteresisValue;
 
+	void RemoveNodeDestructObject(KX_GameObject *gameobj);
+	void RemoveObject(KX_GameObject *gameobj);
+	void RemoveDupliGroup(KX_GameObject *gameobj);
+	bool NewRemoveObject(KX_GameObject *gameobj);
+
 public:
 	KX_Scene(SCA_IInputDevice *inputDevice,
 	         const std::string& scenename,
@@ -287,11 +292,10 @@ public:
 	KX_GameObject *AddReplicaObject(KX_GameObject *gameobj, KX_GameObject *locationobj, float lifespan = 0.0f);
 	KX_GameObject *AddNodeReplicaObject(SG_Node *node, KX_GameObject *gameobj);
 
-	void RemoveNodeDestructObject(KX_GameObject *gameobj);
-	void RemoveObject(KX_GameObject *gameobj);
-	void RemoveDupliGroup(KX_GameObject *gameobj);
+	/// Add an object to remove.
 	void DelayedRemoveObject(KX_GameObject *gameobj);
-	bool NewRemoveObject(KX_GameObject *gameobj);
+	/// Effectivly remove object added with DelayedRemoveObject
+	void RemoveEuthanasyObjects();
 
 	void AddAnimatedObject(KX_GameObject *gameobj);
 

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -296,7 +296,7 @@ void LA_Launcher::InitEngine()
 #endif  // WITH_AUDASPACE
 
 	// Convert scene data.
-	m_ketsjiEngine->ConvertScene(m_kxStartScene);
+	m_converter->ConvertScene(m_kxStartScene);
 
 	m_ketsjiEngine->AddScene(m_kxStartScene);
 	m_kxStartScene->Release();

--- a/source/gameengine/Rasterizer/CMakeLists.txt
+++ b/source/gameengine/Rasterizer/CMakeLists.txt
@@ -28,6 +28,7 @@ set(INC
 	Node
 	RAS_OpenGLRasterizer
 	../Common
+	../Converter
 	../Expressions
 	../Ketsji
 	../Physics/Common

--- a/source/gameengine/Rasterizer/RAS_BucketManager.cpp
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.cpp
@@ -378,22 +378,23 @@ void RAS_BucketManager::ReloadMaterials(RAS_IMaterial *mat)
 	}
 }
 
-/* frees the bucket, only used when freeing scenes */
 void RAS_BucketManager::RemoveMaterial(RAS_IMaterial *mat)
 {
-	for (unsigned short i = 0; i < NUM_BUCKET_TYPE; ++i) {
-		BucketList& buckets = m_buckets[i];
-		for (BucketList::iterator it = buckets.begin(); it != buckets.end(); ) {
-			RAS_MaterialBucket *bucket = *it;
-			if (mat == bucket->GetMaterial()) {
-				it = buckets.erase(it);
-				if (i == ALL_BUCKET) {
-					delete bucket;
-				}
+	BucketList& allBuckets = m_buckets[ALL_BUCKET];
+	for (BucketList::iterator it = allBuckets.begin(); it != allBuckets.end();) {
+		RAS_MaterialBucket *bucket = *it;
+		// Find the bucket in ALL_BUCKET list.
+		if (mat == bucket->GetMaterial()) {
+			// Iterate over all bucket list excepted ALL_BUCKET and remove the bucket.
+			for (unsigned short i = 0; i < ALL_BUCKET; ++i) {
+				CM_ListRemoveIfFound(m_buckets[i], bucket);
 			}
-			else {
-				++it;
-			}
+			// Remove the bucket from ALL_BUCKET and destruct it.
+			it = allBuckets.erase(it);
+			delete bucket;
+		}
+		else {
+			++it;
 		}
 	}
 }

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/CMakeLists.txt
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/CMakeLists.txt
@@ -29,6 +29,7 @@ set(INC
 	# XXX Remove these <<<
 	../../BlenderRoutines
 	../../Common
+	../../Converter
 	../../Expressions
 	../../GameLogic
 	../../Ketsji

--- a/source/gameengine/Rasterizer/RAS_Texture.cpp
+++ b/source/gameengine/Rasterizer/RAS_Texture.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "RAS_Texture.h"
+#include "RAS_TextureRenderer.h"
 
 #include "GPU_glew.h"
 
@@ -35,6 +36,10 @@ RAS_Texture::RAS_Texture()
 
 RAS_Texture::~RAS_Texture()
 {
+	// If the texture is free before the renderer (e.g lib free) then unregsiter ourself.
+	if (m_renderer) {
+		m_renderer->RemoveTextureUser(this);
+	}
 }
 
 std::string& RAS_Texture::GetName()

--- a/source/gameengine/Rasterizer/RAS_TextureRenderer.cpp
+++ b/source/gameengine/Rasterizer/RAS_TextureRenderer.cpp
@@ -32,6 +32,8 @@
 #include "GPU_framebuffer.h"
 #include "GPU_draw.h"
 
+#include "CM_List.h"
+
 #include "BKE_image.h"
 
 #include "BLI_utildefines.h"
@@ -175,6 +177,12 @@ void RAS_TextureRenderer::AddTextureUser(RAS_Texture *texture)
 {
 	m_textureUsers.push_back(texture);
 	texture->SetRenderer(this);
+}
+
+void RAS_TextureRenderer::RemoveTextureUser(RAS_Texture *texture)
+{
+	CM_ListRemoveIfFound(m_textureUsers, texture);
+	texture->SetRenderer(nullptr);
 }
 
 void RAS_TextureRenderer::BeginRender(RAS_Rasterizer *rasty)

--- a/source/gameengine/Rasterizer/RAS_TextureRenderer.h
+++ b/source/gameengine/Rasterizer/RAS_TextureRenderer.h
@@ -87,6 +87,7 @@ public:
 	/// Return true if the material texture use the same data than one of the texture user.
 	bool EqualTextureUser(RAS_Texture *texture) const;
 	void AddTextureUser(RAS_Texture *texture);
+	void RemoveTextureUser(RAS_Texture *texture);
 
 	virtual void BeginRender(RAS_Rasterizer *rasty);
 	virtual void EndRender(RAS_Rasterizer *rasty);

--- a/source/gameengine/VideoTexture/CMakeLists.txt
+++ b/source/gameengine/VideoTexture/CMakeLists.txt
@@ -27,6 +27,7 @@ set(INC
 	.
 	../BlenderRoutines
 	../Common
+	../Converter
 	../Device
 	../Expressions
 	../GameLogic


### PR DESCRIPTION
The issue #805 reported a bug relative to LibLoad and LibFree. This bug is
reproduced by using two scenes which both use meshes without material (so using
defmaterial) and the first scene LibLoad and merge the second. What is happening
is that the new created scene will contain a RAS_MaterialBucket of defmaterial
which is also used by the host scene, but defmaterial is not owned by any file
as it's a global default material.
The technique used by LibFree was to tag all ID structs (data, e.g Mesh,
Material, Object) of a Main (the file loaded) and remove them from scenes and
users. In the situation of defmaterial, this struct is never tagged and so never
removed during LibFree. This resulted in a material always existing but all the
light objects used were removed and the function GPU_material_update_lamps
called in material preparation before rendering raise an illegal memory access
as it was iterating on freed lamps.

To solve this issue we have to find a way to remove all game engine data that
were created during the scene conversion of a libloaded scene. And the minor
task is avoiding end up with only a part of scene materials using all the lights
present.

The first point is solved by the introduction of a ressource base class:
BL_Ressource. The goal of this class is to store an identifier of the library
source of converted data. This identifier is an opaque intptr_t and the function
BL_Ressource::Belong(intptr_t) return true when the passed library identifier
match the one of the ressource.
The classes inheriting from BL_Ressource are:
- BL_ConvertObjectInfo
- KX_Mesh
- KX_BlenderMaterial
- BL_ActionData

This last class is used to wrap bAction and link the BL_ScalarInterpolator of
the action. All the actions are converted and registered during scene conversion
as the cost is negligeable.
All these ressource types are registered in BL_SceneConverter where all
registering function set the library identifier from the one passed to
BL_SceneConverter constructor. From LinkBlendFile, ConvertMeshSpecial and
ConvertScene(KX_Scene *scene) (the functions creating a scene converter)
BL_SceneConverter is created using as library identifier the Main pointer of the
current file or the loaded file, this way we also ensure that all linked data of
a file will be owned by the same library. Other than that the loading changed by
the call of the function ReloadShaders to reload all shaders of a merged scene:
the new and old shaders, to benefit of all existing lights.

Concerning LibFree, the first modification is to delay the free to the end of
the frame instead doing it instantly. To achieve it, FreeBlendFile(const
std::string& path) stores the library path to free in m_freeQueue if the library
exists and the function ProcessScheduledLibraries process the merging of the
libloads and the free of libraries, this final function is called in
KX_KetsjiEngine::NextFrame at the end of each logic frame.
The actual library free takes place in FreeBlendFileData. It iterates over all
scenes and objects, if the object convert object info belongs to the free
library the object is removed else KX_GameObject::RemoveRessources is called.
Finally the materials, meshes and actions of the library are removed from scene
data slots (m_sceneSlots). KX_GameObject::RemoveRessources is removing all the
meshes that belong to the library or using materials from the library, and do
the same for actions currently played.
Previously BL_ActionManager was also impacted by LibFree as it was using
bAction, now the actuator is using a action name to remove this complexity when
freeing an action.

Shader are now recompiled when merging and freeing a library to ensure that the
lights are properly used, the function BL_Covnerter::ReloadShaders is dedicated
for and call KX_BlenderMaterial::ReloadMaterial that can reload the shader or
create a new one if it wasn't initialized.

Fix issue: #805