### PR TITLE
UPBGE: Rename async parameter from LibLoad as is a reserved word

### DIFF
--- a/doc/python_api/rst/bge.logic.rst
+++ b/doc/python_api/rst/bge.logic.rst
@@ -185,7 +185,7 @@ General functions
 
    Restarts the current game by reloading the .blend file (the last saved version, not what is currently running).
    
-.. function:: LibLoad(blend, type, data, load_actions=False, verbose=False, load_scripts=True, async=False, scene=None)
+.. function:: LibLoad(blend, type, data, load_actions=False, verbose=False, load_scripts=True, asyncronous=False, scene=None)
    
    Converts the all of the datablocks of the given type from the given blend.
    
@@ -201,8 +201,8 @@ General functions
    :type verbose: bool
    :arg load_scripts: Whether or not to load text datablocks as well (can be disabled for some extra security)
    :type load_scripts: bool   
-   :arg async: Whether or not to do the loading asynchronously (in another thread). Only the "Scene" type is currently supported for this feature.
-   :type async: bool
+   :arg asyncronous: Whether or not to do the loading asynchronously (in another thread). Only the "Scene" type is currently supported for this feature.
+   :type asyncronous: bool
    :arg scene: Scene to merge loaded data to, if `None` use the current scene.
    :type scene: :class:`bge.types.KX_Scene` or string
    

--- a/doc/python_api/rst/bge.logic.rst
+++ b/doc/python_api/rst/bge.logic.rst
@@ -185,7 +185,7 @@ General functions
 
    Restarts the current game by reloading the .blend file (the last saved version, not what is currently running).
    
-.. function:: LibLoad(blend, type, data, load_actions=False, verbose=False, load_scripts=True, asyncronous=False, scene=None)
+.. function:: LibLoad(blend, type, data, load_actions=False, verbose=False, load_scripts=True, asynchronous=False, scene=None)
    
    Converts the all of the datablocks of the given type from the given blend.
    
@@ -201,8 +201,8 @@ General functions
    :type verbose: bool
    :arg load_scripts: Whether or not to load text datablocks as well (can be disabled for some extra security)
    :type load_scripts: bool   
-   :arg asyncronous: Whether or not to do the loading asynchronously (in another thread). Only the "Scene" type is currently supported for this feature.
-   :type asyncronous: bool
+   :arg asynchronous: Whether or not to do the loading asynchronously (in another thread). Only the "Scene" type is currently supported for this feature.
+   :type asynchronous: bool
    :arg scene: Scene to merge loaded data to, if `None` use the current scene.
    :type scene: :class:`bge.types.KX_Scene` or string
    

--- a/doc/python_api/rst/bge_types/bge.types.KX_LibLoadStatus.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LibLoadStatus.rst
@@ -15,7 +15,7 @@ base class --- :class:`EXP_PyObjectPlus`
       def finished_cb(status):
           print("Library (%s) loaded in %.2fms." % (status.libraryName, status.timeTaken))
 
-      bge.logic.LibLoad('myblend.blend', 'Scene', asyncronous=True).onFinish = finished_cb
+      bge.logic.LibLoad('myblend.blend', 'Scene', asynchronous=True).onFinish = finished_cb
 
    .. attribute:: onFinish
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_LibLoadStatus.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LibLoadStatus.rst
@@ -15,7 +15,7 @@ base class --- :class:`EXP_PyObjectPlus`
       def finished_cb(status):
           print("Library (%s) loaded in %.2fms." % (status.libraryName, status.timeTaken))
 
-      bge.logic.LibLoad('myblend.blend', 'Scene', async=True).onFinish = finished_cb
+      bge.logic.LibLoad('myblend.blend', 'Scene', asyncronous=True).onFinish = finished_cb
 
    .. attribute:: onFinish
 

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -642,11 +642,11 @@ static PyObject *gLibLoad(PyObject *, PyObject *args, PyObject *kwds)
 	KX_LibLoadStatus *status = nullptr;
 
 	short options = 0;
-	int load_actions = 0, verbose = 0, load_scripts = 1, async = 0;
+	int load_actions = 0, verbose = 0, load_scripts = 1, asyncronous = 0;
 
 	if (!EXP_ParseTupleArgsAndKeywords(args, kwds, "ss|y*iiIiO:LibLoad",
-	                                   {"path", "group", "buffer", "load_actions", "verbose", "load_scripts", "async", "scene", 0},
-	                                   &path, &group, &py_buffer, &load_actions, &verbose, &load_scripts, &async, &pyscene)) {
+	                                   {"path", "group", "buffer", "load_actions", "verbose", "load_scripts", "asyncronous", "scene", 0},
+	                                   &path, &group, &py_buffer, &load_actions, &verbose, &load_scripts, &asyncronous, &pyscene)) {
 		return nullptr;
 	}
 
@@ -667,7 +667,7 @@ static PyObject *gLibLoad(PyObject *, PyObject *args, PyObject *kwds)
 	if (load_scripts != 0) {
 		options |= BL_Converter::LIB_LOAD_LOAD_SCRIPTS;
 	}
-	if (async != 0) {
+	if (asyncronous != 0) {
 		options |= BL_Converter::LIB_LOAD_ASYNC;
 	}
 

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -642,11 +642,11 @@ static PyObject *gLibLoad(PyObject *, PyObject *args, PyObject *kwds)
 	KX_LibLoadStatus *status = nullptr;
 
 	short options = 0;
-	int load_actions = 0, verbose = 0, load_scripts = 1, asyncronous = 0;
+	int load_actions = 0, verbose = 0, load_scripts = 1, asynchronous = 0;
 
 	if (!EXP_ParseTupleArgsAndKeywords(args, kwds, "ss|y*iiIiO:LibLoad",
-	                                   {"path", "group", "buffer", "load_actions", "verbose", "load_scripts", "asyncronous", "scene", 0},
-	                                   &path, &group, &py_buffer, &load_actions, &verbose, &load_scripts, &asyncronous, &pyscene)) {
+	                                   {"path", "group", "buffer", "load_actions", "verbose", "load_scripts", "asynchronous", "scene", 0},
+	                                   &path, &group, &py_buffer, &load_actions, &verbose, &load_scripts, &asynchronous, &pyscene)) {
 		return nullptr;
 	}
 
@@ -667,7 +667,7 @@ static PyObject *gLibLoad(PyObject *, PyObject *args, PyObject *kwds)
 	if (load_scripts != 0) {
 		options |= BL_Converter::LIB_LOAD_LOAD_SCRIPTS;
 	}
-	if (asyncronous != 0) {
+	if (asynchronous != 0) {
 		options |= BL_Converter::LIB_LOAD_ASYNC;
 	}
 


### PR DESCRIPTION
async is a reserved word in Pyhon 3.7
Check: https://docs.python.org/3.7/whatsnew/3.7.html#summary-release-highlights

This Fix #826 .

The python rst modification should be commited here and UPBGE-Docs repository or only here or only there?