### PR TITLE
UPBGE: Fix bge.render.[get/set]Vsync.

### DIFF
--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -900,9 +900,11 @@ typedef struct GameData {
 #define OBSTSIMULATION_TOI_cells	2
 
 /* GameData.vsync */
-#define VSYNC_ON	0
-#define VSYNC_OFF	1
-#define VSYNC_ADAPTIVE	2
+enum {
+	VSYNC_ON = 0,
+	VSYNC_OFF,
+	VSYNC_ADAPTIVE
+};
 
 /* GameData.flag */
 #define GAME_RESTRICT_ANIM_UPDATES			(1 << 0)

--- a/source/gameengine/BlenderRoutines/KX_BlenderCanvas.cpp
+++ b/source/gameengine/BlenderRoutines/KX_BlenderCanvas.cpp
@@ -75,14 +75,10 @@ void KX_BlenderCanvas::SwapBuffers()
 	wm_window_swap_buffers(m_win);
 }
 
-void KX_BlenderCanvas::SetSwapInterval(int interval)
+void KX_BlenderCanvas::SetSwapControl(SwapControl control)
 {
-	wm_window_set_swap_interval(m_win, interval);
-}
-
-bool KX_BlenderCanvas::GetSwapInterval(int &intervalOut)
-{
-	return wm_window_get_swap_interval(m_win, &intervalOut);
+	wm_window_set_swap_interval(m_win, swapInterval[control]);
+	RAS_ICanvas::SetSwapControl(control);
 }
 
 void KX_BlenderCanvas::GetDisplayDimensions(int &width, int &height)

--- a/source/gameengine/BlenderRoutines/KX_BlenderCanvas.h
+++ b/source/gameengine/BlenderRoutines/KX_BlenderCanvas.h
@@ -63,8 +63,7 @@ public:
 	virtual void Init();
 
 	virtual void SwapBuffers();
-	virtual void SetSwapInterval(int interval);
-	virtual bool GetSwapInterval(int &intervalOut);
+	virtual void SetSwapControl(SwapControl control);
 
 	virtual void GetDisplayDimensions(int &width, int &height);
 	virtual void ResizeWindow(int width, int height);

--- a/source/gameengine/GamePlayer/GPG_Canvas.cpp
+++ b/source/gameengine/GamePlayer/GPG_Canvas.cpp
@@ -211,20 +211,12 @@ void GPG_Canvas::SwapBuffers()
 	}
 }
 
-void GPG_Canvas::SetSwapInterval(int interval)
+void GPG_Canvas::SetSwapControl(SwapControl control)
 {
 	if (m_window) {
-		m_window->setSwapInterval(interval);
+		m_window->setSwapInterval(swapInterval[control]);
 	}
-}
-
-bool GPG_Canvas::GetSwapInterval(int& intervalOut)
-{
-	if (m_window) {
-		return (bool)m_window->getSwapInterval(intervalOut);
-	}
-
-	return false;
+	RAS_ICanvas::SetSwapControl(control);
 }
 
 void GPG_Canvas::GetDisplayDimensions(int &width, int &height)

--- a/source/gameengine/GamePlayer/GPG_Canvas.h
+++ b/source/gameengine/GamePlayer/GPG_Canvas.h
@@ -87,8 +87,7 @@ public:
 	virtual void SetMousePosition(int x, int y);
 	virtual void SetMouseState(RAS_MouseState mousestate);
 	virtual void SwapBuffers();
-	virtual void SetSwapInterval(int interval);
-	virtual bool GetSwapInterval(int& intervalOut);
+	virtual void SetSwapControl(SwapControl control);
 
 	virtual void ConvertMousePosition(int x, int y, int &r_x, int &r_y, bool screen);
 	virtual float GetMouseNormalizedX(int x);

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -1298,29 +1298,24 @@ static PyObject *gPyGetMipmapping(PyObject *)
 
 static PyObject *gPySetVsync(PyObject *, PyObject *args)
 {
-	int interval;
+	int control;
 
-	if (!PyArg_ParseTuple(args, "i:setVsync", &interval)) {
+	if (!PyArg_ParseTuple(args, "i:setVsync", &control)) {
 		return nullptr;
 	}
 
-	if (interval < 0 || interval > VSYNC_ADAPTIVE) {
+	if (control < 0 || control >= RAS_ICanvas::SWAP_CONTROL_MAX) {
 		PyErr_SetString(PyExc_ValueError, "Rasterizer.setVsync(value): value must be VSYNC_OFF, VSYNC_ON, or VSYNC_ADAPTIVE");
 		return nullptr;
 	}
 
-	if (interval == VSYNC_ADAPTIVE) {
-		interval = -1;
-	}
-	KX_GetActiveEngine()->GetCanvas()->SetSwapInterval((interval == VSYNC_ON) ? 1 : 0);
+	KX_GetActiveEngine()->GetCanvas()->SetSwapControl((RAS_ICanvas::SwapControl)control);
 	Py_RETURN_NONE;
 }
 
 static PyObject *gPyGetVsync(PyObject *)
 {
-	int interval = 0;
-	KX_GetActiveEngine()->GetCanvas()->GetSwapInterval(interval);
-	return PyLong_FromLong(interval);
+	return PyLong_FromLong(KX_GetActiveEngine()->GetCanvas()->GetSwapControl());
 }
 
 static PyObject *gPyShowFramerate(PyObject *, PyObject *args)
@@ -2200,9 +2195,9 @@ PyMODINIT_FUNC initRasterizerPythonBinding()
 	KX_MACRO_addTypesToDict(d, RAS_MIPMAP_LINEAR, RAS_Rasterizer::RAS_MIPMAP_LINEAR);
 
 	/* for get/setVsync */
-	KX_MACRO_addTypesToDict(d, VSYNC_OFF, VSYNC_OFF);
-	KX_MACRO_addTypesToDict(d, VSYNC_ON, VSYNC_ON);
-	KX_MACRO_addTypesToDict(d, VSYNC_ADAPTIVE, VSYNC_ADAPTIVE);
+	KX_MACRO_addTypesToDict(d, VSYNC_OFF, RAS_ICanvas::VSYNC_OFF);
+	KX_MACRO_addTypesToDict(d, VSYNC_ON, RAS_ICanvas::VSYNC_ON);
+	KX_MACRO_addTypesToDict(d, VSYNC_ADAPTIVE, RAS_ICanvas::VSYNC_ADAPTIVE);
 
 	/* stereoscopy */
 	KX_MACRO_addTypesToDict(d, LEFT_EYE, RAS_Rasterizer::RAS_STEREO_LEFTEYE);

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -190,15 +190,13 @@ void LA_Launcher::InitEngine()
 	// Create the canvas, rasterizer and rendertools.
 	m_canvas = CreateCanvas(m_rasterizer);
 
-	// Copy current vsync mode to restore at the game end.
-	m_canvas->GetSwapInterval(m_savedData.vsync);
+	static const RAS_ICanvas::SwapControl swapControlTable[] = {
+		RAS_ICanvas::VSYNC_ON, // VSYNC_ON
+		RAS_ICanvas::VSYNC_OFF, // VSYNC_OFF
+		RAS_ICanvas::VSYNC_ADAPTIVE // VSYNC_ADAPTIVE
+	};
 
-	if (gm.vsync == VSYNC_ADAPTIVE) {
-		m_canvas->SetSwapInterval(-1);
-	}
-	else {
-		m_canvas->SetSwapInterval((gm.vsync == VSYNC_ON) ? 1 : 0);
-	}
+	m_canvas->SetSwapControl(swapControlTable[gm.vsync]);
 
 	// Set canvas multisamples.
 	m_canvas->SetSamples(m_samples);
@@ -326,12 +324,8 @@ void LA_Launcher::ExitEngine()
 
 	// Set anisotropic settign back to its original value.
 	m_rasterizer->SetAnisotropicFiltering(m_savedData.anisotropic);
-
 	// Set mipmap setting back to its original value.
 	m_rasterizer->SetMipmapping(m_savedData.mipmap);
-
-	// Set vsync mode back to original value.
-	m_canvas->SetSwapInterval(m_savedData.vsync);
 
 	if (m_converter) {
 		delete m_converter;

--- a/source/gameengine/Launcher/LA_Launcher.h
+++ b/source/gameengine/Launcher/LA_Launcher.h
@@ -92,7 +92,6 @@ protected:
 
 	/// Saved data to restore at the game end.
 	struct SavedData {
-		int vsync;
 		RAS_Rasterizer::MipmapOption mipmap;
 		int anisotropic;
 	} m_savedData;

--- a/source/gameengine/Rasterizer/RAS_ICanvas.cpp
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.cpp
@@ -62,10 +62,16 @@ struct ScreenshotTaskData {
  */
 void save_screenshot_thread_func(TaskPool *__restrict pool, void *taskdata, int threadid);
 
+const int RAS_ICanvas::swapInterval[RAS_ICanvas::SWAP_CONTROL_MAX] = {
+	0, // VSYNC_OFF
+	1, // VSYNC_ON
+	-1 // VSYNC_ADAPTIVE
+};
 
 RAS_ICanvas::RAS_ICanvas(RAS_Rasterizer *rasty)
 	:m_samples(0),
 	m_hdrType(RAS_Rasterizer::RAS_HDR_NONE),
+	m_swapControl(VSYNC_OFF),
 	m_frame(1)
 {
 	m_taskscheduler = BLI_task_scheduler_create(TASK_SCHEDULER_AUTO_THREADS);
@@ -85,6 +91,16 @@ RAS_ICanvas::~RAS_ICanvas()
 		BLI_task_scheduler_free(m_taskscheduler);
 		m_taskscheduler = nullptr;
 	}
+}
+
+void RAS_ICanvas::SetSwapControl(SwapControl control)
+{
+	m_swapControl = control;
+}
+
+RAS_ICanvas::SwapControl RAS_ICanvas::GetSwapControl() const
+{
+	return m_swapControl;
 }
 
 void RAS_ICanvas::SetSamples(int samples)

--- a/source/gameengine/Rasterizer/RAS_ICanvas.h
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.h
@@ -52,6 +52,14 @@ public:
 		MOUSE_NORMAL
 	};
 
+	enum SwapControl
+	{
+		VSYNC_OFF = 0,
+		VSYNC_ON,
+		VSYNC_ADAPTIVE,
+		SWAP_CONTROL_MAX
+	};
+
 	RAS_ICanvas(RAS_Rasterizer *rasty);
 	virtual ~RAS_ICanvas();
 
@@ -77,8 +85,8 @@ public:
 
 	/// probably needs some arguments for PS2 in future
 	virtual void SwapBuffers() = 0;
-	virtual void SetSwapInterval(int interval) = 0;
-	virtual bool GetSwapInterval(int& intervalOut) = 0;
+	virtual void SetSwapControl(SwapControl control);
+	SwapControl GetSwapControl() const;
 
 	void SetSamples(int samples);
 	int GetSamples() const;
@@ -152,6 +160,9 @@ public:
 	}
 
 protected:
+	/// Swap interval value of each swap control mode.
+	static const int swapInterval[SWAP_CONTROL_MAX];
+
 	struct Screenshot
 	{
 		std::string path;
@@ -167,6 +178,7 @@ protected:
 	int m_samples;
 	RAS_Rasterizer::HdrType m_hdrType;
 
+	SwapControl m_swapControl;
 	RAS_MouseState m_mousestate;
 	/// frame number for screenshots.
 	int m_frame;


### PR DESCRIPTION
Previously bge.render.getVsync wasn't returning the value set by setVsync when
VSYNC_ADAPTIVE was used. It can be justified by the fact that adaptive is set
by using a negative swap interval value but the GLX get function still returns
a positive swap interval value and the flag GLX_LATE_SWAPS_TEAR_EXT meaning
adaptive is enabled.

In any case GLX could refuse a swap interval and the user should be able to do
setVsync(getVsync()) with no change on the swap control. To achieve this behaviour
RAS_ICanvas store the current swap control in a enum variable m_controlSwap,
this variable is used in getter GetSwapControl used by bge.render.getVsync().
The setter is virtual and overloaded in each canvas implementation, they use
a common table to find the swap interval associated to the swap control mode:
RAS_ICanvas::swapInterval.

Finally KX_PythonInit is using swap control enum value from RAS_ICanvas instead
of the one from DNA to avoid conversions.

Fix issue #820.