### PR TITLE
UPBGE: Set frame step to elapsed time in case of external clock.

### DIFF
--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -355,13 +355,14 @@ bool KX_KetsjiEngine::NextFrame()
 	double timestep;
 
 	if (m_flags & USE_EXTERNAL_CLOCK) {
+		timestep = m_clockTime - m_frameTime;
 		// Always proceed a frame when the user control time.
 		frames = 1;
 	}
 	else {
-		double current_time = m_clock.GetTimeSecond();
-		double dt = current_time - m_previousRealTime;
-		m_previousRealTime = current_time;
+		const double now = m_clock.GetTimeSecond();
+		const double dt = now - m_previousRealTime;
+		m_previousRealTime = now;
 		m_clockTime += dt * m_timescale;
 
 		const double deltatime = m_clockTime - m_frameTime;


### PR DESCRIPTION
Previously the time step (base of frame step) was set to the
fixed frame step (1 / FPS * scale) when the user was using external
clock (setting the clock manually).

This commit introduces a different behaviour: the timestep is the
elapsed time bewteen two clock set of the user.