### PR TITLE
UPBGE: Expose parallax component for material texture.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_texture.py
+++ b/release/scripts/startup/bl_ui/properties_texture.py
@@ -1137,6 +1137,7 @@ class TEXTURE_PT_game_parallax(TextureSlotPanel, Panel):
 
         col = split.column()
         col.active = tex.use_map_parallax
+        col.prop(tex, "parallax_component", text="")
         col.prop(tex, "parallax_steps", text="Steps")
         col.prop(tex, "parallax_bump_scale", text="Bump Scale")
 

--- a/source/blender/blenkernel/intern/texture.c
+++ b/source/blender/blenkernel/intern/texture.c
@@ -386,6 +386,7 @@ void BKE_texture_mtex_default(MTex *mtex)
 	mtex->norfac = 1.0;
 	mtex->parallaxbumpsc = 0.03f;
 	mtex->parallaxsteps = 10.0f;
+	mtex->parallaxcomp = 3;
 	mtex->varfac = 1.0;
 	mtex->dispfac = 0.2;
 	mtex->colspecfac = 1.0f;

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -316,4 +316,17 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
 			}
 		}
 	}
+
+	if (!MAIN_VERSION_UPBGE_ATLEAST(main, 2, 5)) {
+		if (!DNA_struct_elem_find(fd->filesdna, "MTex", "short", "parallaxcomp")) {
+			for (Material *ma = main->mat.first; ma; ma = ma->id.next) {
+				for (unsigned short a = 0; a < MAX_MTEX; ++a) {
+					if (ma->mtex[a]) {
+						// Default alpha.
+						ma->mtex[a]->parallaxcomp = 3;
+					}
+				}
+			}
+		}
+	}
 }

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -1395,7 +1395,7 @@ static void do_material_tex(GPUShadeInput *shi)
 			}
 
 			discard = (mtex->parflag & MTEX_DISCARD_AT_EDGES) != 0 ? 1.0f : 0.0f;
-			float comp = 3.0f; // alpha
+			float comp = mtex->parallaxcomp;
 			GPU_link(mat, "mtex_parallax", texco,
 					 GPU_builtin(GPU_VIEW_POSITION), tangent, orn,
 					 GPU_image(tex->ima, &tex->iuser, false),

--- a/source/blender/makesdna/DNA_texture_types.h
+++ b/source/blender/makesdna/DNA_texture_types.h
@@ -99,7 +99,7 @@ typedef struct MTex {
 	float lodbias;
 
 	/* parallax */
-	short parflag, pad3;
+	short parflag, parallaxcomp;
 } MTex;
 
 #ifndef DNA_USHORT_FIX

--- a/source/blender/makesrna/intern/rna_material.c
+++ b/source/blender/makesrna/intern/rna_material.c
@@ -495,6 +495,14 @@ static void rna_def_material_mtex(BlenderRNA *brna)
 		{0, NULL, 0, NULL, NULL}
 	};
 
+	static const EnumPropertyItem node_parallax_items[] = {
+		{0, "RED",  ICON_COLOR_RED, "Red",  ""},
+		{1, "GREEN",  ICON_COLOR_GREEN, "Green",  ""},
+		{2, "BLUE",  ICON_COLOR_BLUE, "Blue",  ""},
+		{3, "ALPHA",  ICON_IMAGE_ALPHA, "Alpha",  ""},
+		{0, NULL, 0, NULL, NULL}
+	};
+
 	srna = RNA_def_struct(brna, "MaterialTextureSlot", "TextureSlot");
 	RNA_def_struct_sdna(srna, "MTex");
 	RNA_def_struct_ui_text(srna, "Material Texture Slot", "Texture slot for textures in a Material data-block");
@@ -679,6 +687,12 @@ static void rna_def_material_mtex(BlenderRNA *brna)
 	prop = RNA_def_property(srna, "parallax_uv_discard", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "parflag", MTEX_DISCARD_AT_EDGES);
 	RNA_def_property_ui_text(prop, "Parallax UV discard", "To discard parallax UV at edges");
+	RNA_def_property_update(prop, 0, "rna_Material_update");
+
+	prop = RNA_def_property(srna, "parallax_component", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_sdna(prop, NULL, "parallaxcomp");
+	RNA_def_property_enum_items(prop, node_parallax_items);
+	RNA_def_property_ui_text(prop, "Parallax Component", "The color component to extract the height information from");
 	RNA_def_property_update(prop, 0, "rna_Material_update");
 
 	prop = RNA_def_property(srna, "lod_bias", PROP_FLOAT, PROP_NONE);


### PR DESCRIPTION
Peviously parallax node was able to select an other texture component
than alpha thanks to a enum option.

This option is ported to material texture and so visible in material
texture parallax panel.

The value is defaulted to alpha for versioning and new textures.