### PR TITLE
UPBGE: Fix uniform caching of arrays.

### DIFF
--- a/source/blender/gpu/GPU_shader.h
+++ b/source/blender/gpu/GPU_shader.h
@@ -75,7 +75,6 @@ int GPU_shader_program(GPUShader *shader);
 
 typedef struct GPUUniformInfo
 {
-	unsigned int location;
 	unsigned int size;
 	unsigned int type;
 	char name[255];

--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -636,7 +636,6 @@ int GPU_shader_get_uniform_infos(GPUShader *shader, GPUUniformInfo **infos)
 	for (unsigned int i = 0; i < count; ++i) {
 		GPUUniformInfo *info = &((*infos)[i]);
 		glGetActiveUniform(shader->program, i, 255, NULL, (int *)&info->size, &info->type, info->name);
-		info->location = GPU_shader_get_uniform(shader, info->name);
 	}
 
 	return count;

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -110,13 +110,25 @@ public:
 protected:
 	struct UniformInfo
 	{
-		unsigned int location;
-		unsigned short size;
-		unsigned int type;
+		/// Hashed uniform name.
+		size_t nameHash;
+		/// Uniform location.
+		int location;
+
+		/** Construct uniform info
+		 * \param name The uniform name.
+		 * \param shader The shader used to retrieve uniform location.
+		 */
+		UniformInfo(const std::string& name, GPUShader *shader);
+
+		inline bool operator< (const UniformInfo& other)
+		{
+			return (nameHash < other.nameHash);
+		}
 	};
 
-	/// Information (location, type, size) on existing uniforms.
-	std::unordered_map<std::string, UniformInfo> m_uniformInfos;
+	// Uniform information sorted by hashed name value.
+	std::vector<UniformInfo> m_uniformInfos;
 
 	typedef std::vector<RAS_Uniform *> RAS_UniformVec;
 	typedef std::vector<RAS_DefUniform *> RAS_UniformVecDef;


### PR DESCRIPTION
Since uniform caching the user was unable to precise the name of
an uniform array item such as colors[42].

This is caused by an ambiguity in the OpenGL function glGetActiveUniform
regarding arrays. If the arrays is of struct type then all the items are
returned by glGetActiveUniform. Else for simple array in main program
of in struct but of primitive type, then only the first element is
returned e.g colors[0].

Two choices were proposed:
- Detecting the array name format and discard caching mechanism while
asking for a location.
- Simulating all item names and store all theirs locations.

The second option is selected in this commit for multiple advantages
over the first:
- Detecting the format of an array name could be complicated as the
program have to manage the case the user is provinding syntaxically
erronous name.
- The current cache is currently getting the location manually for
active uniforms, doing it for arrays is in average not a big amount
of extra work.
- GLSL is limiting big native arrays (rarely up to 100) which limit
the number of locations to retrieve.
- GLSL allow getting the location for "colors" which is an ignored
alias for "colors[0]" by glGetActiveUniform, so this case needed
to be taken in account to ignore caching.

In consideration the caching look up it optimized by using a sorted
vector and a binary search. std::unordered_map is doing an similar
work but do more like caching the uniform name where for searching
only the name hash matter.

This is applied in RAS_Shader::ExtractUniformInfos. If an active
uniform is suppoed array from OpenGL information, the base name is
generated (e.g "colors") and then all the names from indices
(e.g "colors[1]", "colors[2]"). Non-array uniforms are proceeded
as before.
UniformInfo is constructed using the name and shader, the constructor
hash the name and obtain the uniform location.
Then the uniforms are sorted using the name hash value in UniformInfo.

RAS_Shader::GetUniformLocation now uses std::lower_bound to process
a binary search.

Fix issue: #822.