### PR TITLE
UPBGE: Fix geometry instancing ligthing.

### DIFF
--- a/source/blender/gpu/GPU_material.h
+++ b/source/blender/gpu/GPU_material.h
@@ -104,12 +104,14 @@ typedef enum GPUBuiltin {
 	GPU_INSTANCING_MATRIX          = (1 << 15),
 	GPU_INSTANCING_INVERSE_MATRIX  = (1 << 16),
 	GPU_INSTANCING_COLOR           = (1 << 17),
-	GPU_INSTANCING_COLOR_ATTRIB    = (1 << 18),
-	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 19),
-	GPU_INSTANCING_POSITION_ATTRIB = (1 << 20),
-	GPU_TIME                       = (1 << 21),
-	GPU_OBJECT_INFO                = (1 << 22),
-	GPU_OBJECT_LAY                 = (1 << 23)
+	GPU_INSTANCING_LAYER           = (1 << 18),
+	GPU_INSTANCING_COLOR_ATTRIB    = (1 << 19),
+	GPU_INSTANCING_MATRIX_ATTRIB   = (1 << 20),
+	GPU_INSTANCING_POSITION_ATTRIB = (1 << 21),
+	GPU_INSTANCING_LAYER_ATTRIB    = (1 << 22),
+	GPU_TIME                       = (1 << 23),
+	GPU_OBJECT_INFO                = (1 << 24),
+	GPU_OBJECT_LAY                 = (1 << 25)
 } GPUBuiltin;
 
 typedef enum GPUOpenGLBuiltin {
@@ -413,7 +415,7 @@ void GPU_material_update_fvar_offset(GPUMaterial *gpu_material,
 
 /* Instancing material */
 bool GPU_material_use_instancing(GPUMaterial *material);
-void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
+void GPU_material_bind_instancing_attrib(GPUMaterial *material, void *matrixoffset, void *positionoffset, void *coloroffset, void *layeroffset);
 
 #ifdef __cplusplus
 }

--- a/source/blender/gpu/GPU_shader.h
+++ b/source/blender/gpu/GPU_shader.h
@@ -98,7 +98,7 @@ void GPU_shader_geometry_stage_primitive_io(GPUShader *shader, int input, int ou
 int GPU_shader_get_attribute(GPUShader *shader, const char *name);
 void GPU_shader_bind_attribute(GPUShader *shader, int location, const char *name);
 
-void GPU_shader_bind_instancing_attrib(GPUShader *shader, void *matrixoffset, void *positionoffset, unsigned int stride);
+void GPU_shader_bind_instancing_attrib(GPUShader *shader, void *matrixoffset, void *positionoffset);
 
 /* Builtin/Non-generated shaders */
 typedef enum GPUBuiltinShader {

--- a/source/blender/gpu/intern/gpu_codegen.c
+++ b/source/blender/gpu/intern/gpu_codegen.c
@@ -416,12 +416,16 @@ const char *GPU_builtin_name(GPUBuiltin builtin)
 		return "varinstinvmat";
 	else if (builtin == GPU_INSTANCING_COLOR)
 		return "varinstcolor";
+	else if (builtin == GPU_INSTANCING_LAYER)
+		return "varinstlayer";
 	else if (builtin == GPU_INSTANCING_COLOR_ATTRIB)
 		return "ininstcolor";
 	else if (builtin == GPU_INSTANCING_MATRIX_ATTRIB)
 		return "ininstmatrix";
 	else if (builtin == GPU_INSTANCING_POSITION_ATTRIB)
 		return "ininstposition";
+	else if (builtin == GPU_INSTANCING_LAYER_ATTRIB)
+		return "ininstlayer";
 	else if (builtin == GPU_TIME)
 		return "unftime";
 	else if (builtin == GPU_OBJECT_INFO)
@@ -550,9 +554,17 @@ static int codegen_print_uniforms_functions(DynStr *ds, ListBase *nodes)
 							GPU_DATATYPE_STR[input->type], name);
 					}
 					else {
-						BLI_dynstr_appendf(ds, "%s %s %s;\n",
-							GLEW_VERSION_3_0 ? "in" : "varying",
-							GPU_DATATYPE_STR[input->type], name);
+						// GPU_INSTANCING_LAYER is an integer, it must be flat in GLSL.
+						if (input->builtin == GPU_INSTANCING_LAYER) {
+							BLI_dynstr_appendf(ds, "%s %s %s;\n",
+								GLEW_VERSION_3_0 ? "flat in" : "flat varying",
+								GPU_DATATYPE_STR[input->type], name);
+						}
+						else {
+							BLI_dynstr_appendf(ds, "%s %s %s;\n",
+								GLEW_VERSION_3_0 ? "in" : "varying",
+								GPU_DATATYPE_STR[input->type], name);
+						}
 					}
 				}
 			}

--- a/source/blender/gpu/intern/gpu_shader.c
+++ b/source/blender/gpu/intern/gpu_shader.c
@@ -763,20 +763,21 @@ void GPU_shader_bind_attribute(GPUShader *shader, int location, const char *name
 }
 
 // Used only for VSM shader with geometry instancing support.
-void GPU_shader_bind_instancing_attrib(GPUShader *shader, void *matrixoffset, void *positionoffset, unsigned int stride)
+void GPU_shader_bind_instancing_attrib(GPUShader *shader, void *matrixoffset, void *positionoffset)
 {
-	int posloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_POSITION_ATTRIB));
-	int matloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_MATRIX_ATTRIB));
+	const int posloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_POSITION_ATTRIB));
+	const int matloc = GPU_shader_get_attribute(shader, GPU_builtin_name(GPU_INSTANCING_MATRIX_ATTRIB));
 
 	// Matrix
 	if (matloc != -1) {
-		glEnableVertexAttribArrayARB(matloc);
-		glEnableVertexAttribArrayARB(matloc + 1);
-		glEnableVertexAttribArrayARB(matloc + 2);
+		glEnableVertexAttribArray(matloc);
+		glEnableVertexAttribArray(matloc + 1);
+		glEnableVertexAttribArray(matloc + 2);
 
-		glVertexAttribPointerARB(matloc, 3, GL_FLOAT, GL_FALSE, stride, matrixoffset);
-		glVertexAttribPointerARB(matloc + 1, 3, GL_FLOAT, GL_FALSE, stride, ((char *)matrixoffset) + 3 * sizeof(float));
-		glVertexAttribPointerARB(matloc + 2, 3, GL_FLOAT, GL_FALSE, stride, ((char *)matrixoffset) + 6 * sizeof(float));
+		const unsigned short stride = sizeof(float) * 9;
+		glVertexAttribPointer(matloc, 3, GL_FLOAT, GL_FALSE, stride, matrixoffset);
+		glVertexAttribPointer(matloc + 1, 3, GL_FLOAT, GL_FALSE, stride, ((char *)matrixoffset) + 3 * sizeof(float));
+		glVertexAttribPointer(matloc + 2, 3, GL_FLOAT, GL_FALSE, stride, ((char *)matrixoffset) + 6 * sizeof(float));
 
 		glVertexAttribDivisorARB(matloc, 1);
 		glVertexAttribDivisorARB(matloc + 1, 1);
@@ -785,8 +786,8 @@ void GPU_shader_bind_instancing_attrib(GPUShader *shader, void *matrixoffset, vo
 
 	// Position
 	if (posloc != -1) {
-		glEnableVertexAttribArrayARB(posloc);
-		glVertexAttribPointerARB(posloc, 3, GL_FLOAT, GL_FALSE, stride, positionoffset);
+		glEnableVertexAttribArray(posloc);
+		glVertexAttribPointer(posloc, 3, GL_FLOAT, GL_FALSE, 0, positionoffset);
 		glVertexAttribDivisorARB(posloc, 1);
 	}
 }

--- a/source/blender/gpu/shaders/gpu_shader_vertex.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_vertex.glsl
@@ -11,10 +11,12 @@ out block {
 in mat3 ininstmatrix;
 in vec3 ininstposition;
 in vec4 ininstcolor;
+in int ininstlayer;
 
 out vec4 varinstcolor;
 out mat4 varinstmat;
 out mat4 varinstinvmat;
+flat out int varinstlayer;
 
 uniform mat4 unfviewmat;
 #endif
@@ -114,6 +116,7 @@ void main()
 	varinstinvmat = varinstmat;
 #endif
 	varinstcolor = ininstcolor;
+	varinstlayer = ininstlayer;
 
 	position *= instmat;
 	normal *= ininstmatrix;

--- a/source/gameengine/Ketsji/BL_BlenderShader.h
+++ b/source/gameengine/Ketsji/BL_BlenderShader.h
@@ -35,6 +35,7 @@
 #include "RAS_AttributeArray.h"
 #include "RAS_Mesh.h"
 #include "RAS_Texture.h" // for MaxUnits
+#include "RAS_InstancingBuffer.h"
 
 #include "CM_Update.h"
 
@@ -74,13 +75,14 @@ public:
 	 * \return The map of attributes layers.
 	 */
 	const RAS_AttributeArray::AttribList GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const;
+	RAS_InstancingBuffer::Attrib GetInstancingAttribs() const;
 
 	void UpdateLights(RAS_Rasterizer *rasty);
 	void Update(RAS_MeshSlot *ms, RAS_Rasterizer *rasty);
 
 	/// Return true if the shader uses a special vertex shader for geometry instancing.
 	bool UseInstancing() const;
-	void ActivateInstancing(void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
+	void ActivateInstancing(RAS_InstancingBuffer *buffer);
 
 	void ReloadMaterial();
 	int GetAlphaBlend();

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -342,10 +342,10 @@ bool KX_BlenderMaterial::UseInstancing() const
 	return m_material->shade_flag & MA_INSTANCING;
 }
 
-void KX_BlenderMaterial::ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)
+void KX_BlenderMaterial::ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer)
 {
 	if (m_blenderShader) {
-		m_blenderShader->ActivateInstancing(matrixoffset, positionoffset, coloroffset, stride);
+		m_blenderShader->ActivateInstancing(buffer);
 	}
 }
 
@@ -440,6 +440,15 @@ const RAS_AttributeArray::AttribList KX_BlenderMaterial::GetAttribs(const RAS_Me
 	}
 
 	return {};
+}
+
+RAS_InstancingBuffer::Attrib KX_BlenderMaterial::GetInstancingAttribs() const
+{
+	if (m_blenderShader && m_blenderShader->Ok()) {
+		return m_blenderShader->GetInstancingAttribs();
+	}
+
+	return RAS_InstancingBuffer::DEFAULT_ATTRIBS;
 }
 
 std::string KX_BlenderMaterial::GetName()

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -33,7 +33,7 @@ public:
 	virtual void Prepare(RAS_Rasterizer *rasty);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
-	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
+	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
 	void UpdateTextures();
@@ -62,6 +62,7 @@ public:
 						   float emit, float ambient, float alpha, float specalpha);
 
 	virtual const RAS_AttributeArray::AttribList GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const;
+	virtual RAS_InstancingBuffer::Attrib GetInstancingAttribs() const;
 
 	// Stuff for cvalue related things.
 	virtual std::string GetName();

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -51,7 +51,7 @@ void KX_TextMaterial::Desactivate(RAS_Rasterizer *rasty)
 {
 }
 
-void KX_TextMaterial::ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride)
+void KX_TextMaterial::ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer)
 {
 }
 
@@ -100,6 +100,11 @@ void KX_TextMaterial::UpdateIPO(const mt::vec4 &rgba, const mt::vec3 &specrgb, f
 const RAS_AttributeArray::AttribList KX_TextMaterial::GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const
 {
 	return {};
+}
+
+RAS_InstancingBuffer::Attrib KX_TextMaterial::GetInstancingAttribs() const
+{
+	return RAS_InstancingBuffer::DEFAULT_ATTRIBS;
 }
 
 KX_TextMaterial *KX_TextMaterial::GetSingleton()

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -39,7 +39,7 @@ public:
 	virtual void Prepare(RAS_Rasterizer *rasty);
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
-	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride);
+	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);
 	virtual void DesactivateInstancing();
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
@@ -54,6 +54,7 @@ public:
 						   float emit, float ambient, float alpha, float specalpha);
 
 	virtual const RAS_AttributeArray::AttribList GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const;
+	virtual RAS_InstancingBuffer::Attrib GetInstancingAttribs() const;
 
 	static KX_TextMaterial *GetSingleton();
 };

--- a/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
+++ b/source/gameengine/Rasterizer/Node/RAS_RenderNode.h
@@ -74,6 +74,7 @@ struct RAS_DisplayArrayNodeData
 	RAS_AttributeArrayStorage *m_attribStorage;
 	RAS_DisplayArrayStorage *m_arrayStorage;
 	bool m_applyMatrix;
+	RAS_InstancingBuffer *m_instancingBuffer;
 };
 
 struct RAS_MeshSlotNodeData

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.h
@@ -67,8 +67,8 @@ private:
 	/// Attribute array used for each different render categories.
 	RAS_AttributeArray m_attribArray;
 
-	/// The vertex buffer object containing all the data used for the instancing rendering.
-	std::unique_ptr<RAS_InstancingBuffer> m_instancingBuffer;
+	/// The vertex buffer object containing all the data used for the instancing rendering for each drawing category.
+	std::unique_ptr<RAS_InstancingBuffer> m_instancingBuffer[RAS_Rasterizer::RAS_DRAW_MAX];
 
 	CM_UpdateClient<RAS_IMaterial> m_materialUpdateClient;
 	CM_UpdateClient<RAS_DisplayArray> m_arrayUpdateClient;
@@ -100,7 +100,7 @@ public:
 	bool UseBatching() const;
 
 	/// Update render infos.
-	void UpdateActiveMeshSlots(RAS_Rasterizer::DrawType drawingMode);
+	void UpdateActiveMeshSlots(RAS_Rasterizer::DrawType drawingMode, bool instancing);
 
 	void GenerateTree(RAS_MaterialDownwardNode& downwardRoot, RAS_MaterialUpwardNode& upwardRoot,
 			RAS_UpwardTreeLeafs& upwardLeafs, RAS_Rasterizer::DrawType drawingMode, bool sort, bool instancing);

--- a/source/gameengine/Rasterizer/RAS_IMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IMaterial.h
@@ -35,6 +35,7 @@
 #include "RAS_Texture.h"
 #include "RAS_Mesh.h"
 #include "RAS_AttributeArray.h"
+#include "RAS_InstancingBuffer.h"
 
 #include "CM_Update.h"
 
@@ -106,7 +107,7 @@ public:
 	virtual void Prepare(RAS_Rasterizer *rasty) = 0;
 	virtual void Activate(RAS_Rasterizer *rasty) = 0;
 	virtual void Desactivate(RAS_Rasterizer *rasty) = 0;
-	virtual void ActivateInstancing(RAS_Rasterizer *rasty, void *matrixoffset, void *positionoffset, void *coloroffset, unsigned int stride) = 0;
+	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer) = 0;
 	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans) = 0;
 
 	bool IsAlpha() const;
@@ -141,6 +142,8 @@ public:
 						   float emit, float ambient, float alpha, float specalpha) = 0;
 
 	virtual const RAS_AttributeArray::AttribList GetAttribs(const RAS_Mesh::LayersInfo& layersInfo) const = 0;
+	/// Return attributes category used for instancing, this value tell what attributes must be updated.
+	virtual RAS_InstancingBuffer::Attrib GetInstancingAttribs() const = 0;
 
 	/**
 	 * \return the equivalent drawing mode for the material settings (equivalent to old TexFace tface->mode).

--- a/source/gameengine/Rasterizer/RAS_InstancingBuffer.h
+++ b/source/gameengine/Rasterizer/RAS_InstancingBuffer.h
@@ -37,28 +37,45 @@ struct GPUBuffer;
 
 class RAS_InstancingBuffer
 {
+public:
+	/// Item to pack.
+	enum Attrib
+	{
+		/// Pack matrix and positions, needed for all shaders.
+		DEFAULT_ATTRIBS = 0,
+		/// Pack object color.
+		COLOR_ATTRIB = (1 << 0),
+		/// Pack object layer.
+		LAYER_ATTRIB = (1 << 1)
+	};
+
+private:
+	/// Memory size of packed items.
+	enum MemorySize
+	{
+		MATRIX_MEMORY_SIZE = sizeof(float[9]),
+		POSITION_MEMORY_SIZE = sizeof(float[3]),
+		COLOR_MEMORY_SIZE = sizeof(float[4]),
+		LAYER_MEMORY_SIZE = sizeof(int)
+	};
+
 	/// The OpenGL VBO.
 	GPUBuffer *m_vbo;
 	/// The matrix offset in the VBO.
-	void *m_matrixOffset;
+	intptr_t m_matrixOffset;
 	/// The position offset in the VBO.
-	void *m_positionOffset;
+	intptr_t m_positionOffset;
 	/// The color offset in the VBO.
-	void *m_colorOffset;
-	/// The instance structure stride in the VBO.
-	unsigned int m_stride;
+	intptr_t m_colorOffset;
+	/// The layer offset in the VBO.
+	intptr_t m_layerOffset;
 
-	/// Structure used to store object info for geometry instancing objects render.
-	struct InstancingObject
-	{
-		float matrix[9];
-		float position[3];
-		unsigned char color[4];
-	};
+	/// Attributes to update.
+	Attrib m_attribs;
 
 public:
-	RAS_InstancingBuffer();
-	virtual ~RAS_InstancingBuffer();
+	RAS_InstancingBuffer(Attrib attribs);
+	~RAS_InstancingBuffer();
 
 	/// Realloc the VBO.
 	void Realloc(unsigned int size);
@@ -72,23 +89,24 @@ public:
 	 * \param drawingmode The material drawing mode used to detect a billboard/halo/shadow material.
 	 * \param meshSlots The list of all non-culled and visible mesh slots (= game object).
 	 */
-	void Update(RAS_Rasterizer *rasty, int drawingmode, RAS_MeshSlotList &meshSlots);
+	void Update(RAS_Rasterizer *rasty, int drawingmode, const RAS_MeshSlotList &meshSlots);
 
-	inline void *GetMatrixOffset() const
+	inline intptr_t GetMatrixOffset() const
 	{
 		return m_matrixOffset;
 	}
-	inline void *GetPositionOffset() const
+	inline intptr_t GetPositionOffset() const
 	{
 		return m_positionOffset;
 	}
-	inline void *GetColorOffset() const
+	inline intptr_t GetColorOffset() const
 	{
 		return m_colorOffset;
 	}
-	inline unsigned int GetStride() const
+
+	inline intptr_t GetLayerOffset() const
 	{
-		return m_stride;
+		return m_layerOffset;
 	}
 };
 

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
@@ -34,6 +34,7 @@
 #include "RAS_OpenGLDebugDraw.h"
 #include "RAS_IMaterial.h"
 #include "RAS_DisplayArrayBucket.h"
+#include "RAS_InstancingBuffer.h"
 
 #include "RAS_ICanvas.h"
 #include "RAS_OffScreen.h"
@@ -1160,11 +1161,11 @@ RAS_Rasterizer::OverrideShaderType RAS_Rasterizer::GetOverrideShader()
 	return m_overrideShader;
 }
 
-void RAS_Rasterizer::ActivateOverrideShaderInstancing(void *matrixoffset, void *positionoffset, unsigned int stride)
+void RAS_Rasterizer::ActivateOverrideShaderInstancing(RAS_InstancingBuffer *buffer)
 {
 	GPUShader *shader = GetOverrideGPUShader(m_overrideShader);
 	if (shader) {
-		GPU_shader_bind_instancing_attrib(shader, matrixoffset, positionoffset, stride);
+		GPU_shader_bind_instancing_attrib(shader, (void *)buffer->GetMatrixOffset(), (void *)buffer->GetPositionOffset());
 	}
 }
 

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.h
@@ -53,6 +53,7 @@ class RAS_ICanvas;
 class RAS_OffScreen;
 class RAS_MeshSlot;
 class RAS_DebugDraw;
+class RAS_InstancingBuffer;
 class RAS_ILightObject;
 class RAS_ISync;
 struct KX_ClientObjectInfo;
@@ -672,7 +673,7 @@ public:
 
 	void SetOverrideShader(OverrideShaderType type);
 	OverrideShaderType GetOverrideShader();
-	void ActivateOverrideShaderInstancing(void *matrixoffset, void *positionoffset, unsigned int stride);
+	void ActivateOverrideShaderInstancing(RAS_InstancingBuffer *buffer);
 
 	/// \see KX_RayCast
 	bool RayHit(KX_ClientObjectInfo *client, KX_RayCast *result, RayCastTranform *raytransform);


### PR DESCRIPTION
In recent commit material object layer was introduced as an uniform used
to compute light visibility. But the geometry instancing wasn't defaulting
this layer (bad option) or setting it with an instance attribute (best option).

In consideration RAS_InstancingBuffer must prepare a buffer with layer data
packed in.
The instancing attributes could be just extended but this will introduce
performance decrease for all other cases not using layer (shadow/wire) same
as the object color attribute is doing currently.
To avoid this drawback, RAS_InstancingBuffer is configured for a combination
of attributes and uniquelly stored per drawing mode.

The attributes deserve object color (COLOR_ATTRIB) or object layer
(LAYER_ATTRIB). Position and matrix attributes are defaulted (DEFAULT_ATTRIBUTE).
The attributes is determined by RAS_IMaterial::GetInstancingAttrib forwarding
to BL_BlenderShader::GetInstancingAttrib.
Each of these instancing buffers are stored into an array in RAS_DisplayArrayBucket.
UpdateActiveMeshSlots is selecting the instancing buffer according the
current drawing mode and link it in render node data.

In the shader part, the binding of attributes is simplified by passing
RAS_InstancingBuffer directly to RAS_IMaterial or RAS_Rasterizer instead
of each offsets.
GPU_material_instancing_bind_attrib and GPU_shader_bind_instancing_attrib
now receive an offset for layer attribute.
Finally calls to GPU_bultin are replaced by material_builtin which check
if the material is using instancing and if so translate attributes depending
on object transform, color or layer.

Concerning memory packing, RAS_InstancingBuffer is now using a SoA pattern,
the offsets are computing in Update function.

Fix issue #830.