### PR TITLE
UPBGE: Fix and simplify frame time management.

### DIFF
--- a/source/gameengine/Common/CM_Clock.cpp
+++ b/source/gameengine/Common/CM_Clock.cpp
@@ -1,5 +1,15 @@
 #include "CM_Clock.h"
 
+CM_Clock::CM_Clock()
+{
+	Reset();
+}
+
+void CM_Clock::Reset()
+{
+	m_start = m_clock.now();
+}
+
 double CM_Clock::GetTimeSecond() const
 {
 	return GetTimeNano() * 1e-9;
@@ -8,5 +18,5 @@ double CM_Clock::GetTimeSecond() const
 CM_Clock::Rep CM_Clock::GetTimeNano() const
 {
 	const std::chrono::high_resolution_clock::time_point now = m_clock.now();
-	return std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(now - m_start).count();
 }

--- a/source/gameengine/Common/CM_Clock.h
+++ b/source/gameengine/Common/CM_Clock.h
@@ -9,9 +9,14 @@ public:
 	using Rep = std::chrono::nanoseconds::rep;
 
 private:
+	std::chrono::high_resolution_clock::time_point m_start;
 	std::chrono::high_resolution_clock m_clock;
 
 public:
+	CM_Clock();
+
+	void Reset();
+
 	double GetTimeSecond() const;
 	Rep GetTimeNano() const;
 };

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -160,6 +160,16 @@ private:
 		std::vector<FrameRenderData> m_frameDataList;
 	};
 
+	struct FrameTimes
+	{
+		// Number of frames to proceed.
+		int frames;
+		// Real duration of a frame.
+		double timestep;
+		// Scaled duration of a frame.
+		double framestep;
+	};
+
 	CM_Clock m_clock;
 	/// 2D Canvas (2D Rendering Device Context)
 	RAS_ICanvas *m_canvas;
@@ -313,6 +323,8 @@ private:
 
 	void BeginFrame();
 	void EndFrame();
+
+	FrameTimes GetFrameTimes();
 
 public:
 	KX_KetsjiEngine();


### PR DESCRIPTION
Previously a commit introduce for external clock the targeting of one frame
at every call to NextFrame, not more.
The original behaviour is if the user enabled fixed framerate then compute
as many as frame possible respecting the FPS value (m_ticrate).
This behaviour is restored in the refactor.

The refactor is simplyfing the time calculation and isolating it.
The function KX_KetsjiEngine::GetFrameTimes is returning a struct FrameTimes
with the number of frames to proceed and the time/frame step.
Inside this function we first update the clock time if the user isn't (case
of external clock) then the elapsed time is computed. Next the timestep and
frame number are computed using fixed value or elapsed time. The number of frame
is clamped by max logic/physics frame using the simple method: If the
number of frame is higher than the maximum for logic or physics, then clamp
it and set timestep to the elasped time (which is always greater than fixed
time step 1/FPS) divided by the maximum number of frames.
Finally if the user is not using fixed framerate update the previous clock
else if the number of frames to proceed is zero sleep.
Issue were noticed using a sleep, they were caused by the resolution of the
sleep which is about some ~10us, to fix this a part of the sleep is consumed
with std::this_thread::sleep_for and the rest is busy wait.

CM_Clock has now a function Reset to ensure it starts from 0, this is useful
for external clock starting at 0.