### PR TITLE
UPBGE: Fix conversion of realtime maps.

### DIFF
--- a/source/gameengine/Common/CM_Map.h
+++ b/source/gameengine/Common/CM_Map.h
@@ -24,16 +24,16 @@
  *  \ingroup common
  */
 
-#ifndef __CM_LIST_H__
-#define __CM_LIST_H__
+#ifndef __CM_MAP_H__
+#define __CM_MAP_H__
 
 #include <map>
 #include <unordered_map>
 
 template <class Item, class Key, class ... Args>
-inline const Item& CM_MapGetItemNoInsert(const std::map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
+inline const Item CM_MapGetItemNoInsert(const std::map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
 {
-	const typename std::map<Key, Item, Args ...>::iterator it = map.find(key);
+	const typename std::map<Key, Item, Args ...>::const_iterator it = map.find(key);
 	if (it != map.end()) {
 		return it->second;
 	}
@@ -41,9 +41,9 @@ inline const Item& CM_MapGetItemNoInsert(const std::map<Key, Item, Args ...>& ma
 }
 
 template <class Item, class Key, class ... Args>
-inline const Item& CM_MapGetItemNoInsert(const std::unordered_map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
+inline const Item CM_MapGetItemNoInsert(const std::unordered_map<Key, Item, Args ...>& map, const Key& key, const Item defaultItem = nullptr)
 {
-	const typename std::map<Key, Item, Args ...>::iterator it = map.find(key);
+	const typename std::map<Key, Item, Args ...>::const_iterator it = map.find(key);
 	if (it != map.end()) {
 		return it->second;
 	}

--- a/source/gameengine/Converter/BL_SceneConverter.cpp
+++ b/source/gameengine/Converter/BL_SceneConverter.cpp
@@ -37,6 +37,7 @@
 #include "KX_BlenderMaterial.h"
 
 #include "CM_List.h"
+#include "CM_Map.h"
 
 BL_SceneConverter::BL_SceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId)
 	:m_scene(scene),
@@ -90,9 +91,9 @@ void BL_SceneConverter::UnregisterGameObject(KX_GameObject *gameobject)
 	CM_ListRemoveIfFound(m_objects, gameobject);
 }
 
-KX_GameObject *BL_SceneConverter::FindGameObject(Object *for_blenderobject)
+KX_GameObject *BL_SceneConverter::FindGameObject(Object *for_blenderobject) const
 {
-	return m_map_blender_to_gameobject[for_blenderobject];
+	return CM_MapGetItemNoInsert(m_map_blender_to_gameobject, for_blenderobject);
 }
 
 void BL_SceneConverter::RegisterGameMesh(KX_Mesh *gamemesh, Mesh *for_blendermesh)
@@ -105,9 +106,9 @@ void BL_SceneConverter::RegisterGameMesh(KX_Mesh *gamemesh, Mesh *for_blendermes
 	m_meshobjects.push_back(gamemesh);
 }
 
-KX_Mesh *BL_SceneConverter::FindGameMesh(Mesh *for_blendermesh)
+KX_Mesh *BL_SceneConverter::FindGameMesh(Mesh *for_blendermesh) const
 {
-	return m_map_mesh_to_gamemesh[for_blendermesh];
+	return CM_MapGetItemNoInsert(m_map_mesh_to_gamemesh, for_blendermesh);
 }
 
 void BL_SceneConverter::RegisterMaterial(KX_BlenderMaterial *blmat, Material *mat)
@@ -120,9 +121,9 @@ void BL_SceneConverter::RegisterMaterial(KX_BlenderMaterial *blmat, Material *ma
 	m_materials.push_back(blmat);
 }
 
-KX_BlenderMaterial *BL_SceneConverter::FindMaterial(Material *mat)
+KX_BlenderMaterial *BL_SceneConverter::FindMaterial(Material *mat) const
 {
-	return m_map_mesh_to_polyaterial[mat];
+	return CM_MapGetItemNoInsert(m_map_mesh_to_polyaterial, mat);
 }
 
 void BL_SceneConverter::RegisterActionData(BL_ActionData *data)
@@ -136,9 +137,9 @@ void BL_SceneConverter::RegisterGameActuator(SCA_IActuator *act, bActuator *for_
 	m_map_blender_to_gameactuator[for_actuator] = act;
 }
 
-SCA_IActuator *BL_SceneConverter::FindGameActuator(bActuator *for_actuator)
+SCA_IActuator *BL_SceneConverter::FindGameActuator(bActuator *for_actuator) const
 {
-	return m_map_blender_to_gameactuator[for_actuator];
+	return CM_MapGetItemNoInsert(m_map_blender_to_gameactuator, for_actuator);
 }
 
 void BL_SceneConverter::RegisterGameController(SCA_IController *cont, bController *for_controller)
@@ -146,9 +147,9 @@ void BL_SceneConverter::RegisterGameController(SCA_IController *cont, bControlle
 	m_map_blender_to_gamecontroller[for_controller] = cont;
 }
 
-SCA_IController *BL_SceneConverter::FindGameController(bController *for_controller)
+SCA_IController *BL_SceneConverter::FindGameController(bController *for_controller) const
 {
-	return m_map_blender_to_gamecontroller[for_controller];
+	return CM_MapGetItemNoInsert(m_map_blender_to_gamecontroller, for_controller);
 }
 
 BL_ConvertObjectInfo *BL_SceneConverter::GetObjectInfo(Object *blenderobj)
@@ -168,4 +169,9 @@ BL_ConvertObjectInfo *BL_SceneConverter::GetObjectInfo(Object *blenderobj)
 const std::vector<KX_GameObject *> &BL_SceneConverter::GetObjects() const
 {
 	return m_objects;
+}
+
+const std::vector<KX_BlenderMaterial *> &BL_SceneConverter::GetMaterials() const
+{
+	return m_materials;
 }

--- a/source/gameengine/Converter/BL_SceneConverter.h
+++ b/source/gameengine/Converter/BL_SceneConverter.h
@@ -94,25 +94,26 @@ public:
 
 	void RegisterGameObject(KX_GameObject *gameobject, Object *for_blenderobject);
 	void UnregisterGameObject(KX_GameObject *gameobject);
-	KX_GameObject *FindGameObject(Object *for_blenderobject);
+	KX_GameObject *FindGameObject(Object *for_blenderobject) const;
 
 	void RegisterGameMesh(KX_Mesh *gamemesh, Mesh *for_blendermesh);
-	KX_Mesh *FindGameMesh(Mesh *for_blendermesh);
+	KX_Mesh *FindGameMesh(Mesh *for_blendermesh) const;
 
 	void RegisterMaterial(KX_BlenderMaterial *blmat, Material *mat);
-	KX_BlenderMaterial *FindMaterial(Material *mat);
+	KX_BlenderMaterial *FindMaterial(Material *mat) const;
 
 	void RegisterActionData(BL_ActionData *data);
 
 	void RegisterGameActuator(SCA_IActuator *act, bActuator *for_actuator);
-	SCA_IActuator *FindGameActuator(bActuator *for_actuator);
+	SCA_IActuator *FindGameActuator(bActuator *for_actuator) const;
 
 	void RegisterGameController(SCA_IController *cont, bController *for_controller);
-	SCA_IController *FindGameController(bController *for_controller);
+	SCA_IController *FindGameController(bController *for_controller) const;
 
 	BL_ConvertObjectInfo *GetObjectInfo(Object *blenderobj);
 
 	const std::vector<KX_GameObject *>& GetObjects() const;
+	const std::vector<KX_BlenderMaterial *>& GetMaterials() const;
 };
 
 #endif  // __KX_BLENDERSCENECONVERTER_H__

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -198,8 +198,6 @@ void KX_BlenderMaterial::ReloadMaterial()
 		m_blenderShader->ReloadMaterial();
 	}
 	else {
-		// Init textures.
-		InitTextures();
 		// Create shader.
 		m_blenderShader = new BL_BlenderShader(m_scene, m_material, this);
 

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -53,6 +53,8 @@ public:
 	virtual SCA_IScene *GetScene() const;
 	virtual void ReloadMaterial();
 
+	void InitTextures();
+
 	void ReplaceScene(KX_Scene *scene);
 
 	static void EndFrame(RAS_Rasterizer *rasty);
@@ -122,8 +124,6 @@ private:
 		float ambient;
 		float specularalpha;
 	} m_savedData;
-
-	void InitTextures();
 
 	void ActivateGLMaterials(RAS_Rasterizer *rasty) const;
 


### PR DESCRIPTION
The issue #855 reports a bug related to the cube and planar map, this is explained
by the fact that the texture renderers try to convert before the textures are
available.
The texture are converted in reload material step which is proceeded after conversion
and post conversion. In the same time leaving texture renderer conversion the ability
to be mutlithread could be very dangerous as they could create FBO and manipulate
any other OpenGL setting for initialization.

The issue is solved by making KX_BlenderMaterial::InitTextures public and call it
into post conversion step and move after in the same step the conversion of
texture renderers.

As the scene converter is constant in post conversion (it's forbidden to create
data but allowed to modify) the function starting with Find are now constant and
their bodies is adapted to avoid implicit insert in std::map.

Fix issue #855.