### PR TITLE
UPBGE: Fix object render settings for batching groups.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_BatchGroup.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BatchGroup.rst
@@ -19,11 +19,20 @@ base class --- :class:`EXP_Value`
 
       batchGroup = types.KX_BatchGroup([scene.objects["Cube"], scene.objects["Plane"]])
 
+   .. warning::
+
+      Rendering settings unique to objects such as :data:`KX_GameObject.layer` and :data:`KX_GameObject.color` are shared when using batch groups.
+      These settings are taken from object :attr:`referenceObject`.
+
    .. attribute:: objects
 
       The list of the objects merged. (read only)
 
       :type: :class:`EXP_ListValue` of :class:`KX_GameObject`
+
+   .. attribute:: referenceObject
+
+      The object used for object rendering settings (layer, color...).
 
    .. method:: merge(objects)
 

--- a/source/gameengine/Ketsji/BL_BlenderShader.cpp
+++ b/source/gameengine/Ketsji/BL_BlenderShader.cpp
@@ -162,13 +162,12 @@ void BL_BlenderShader::UpdateLights(RAS_Rasterizer *rasty)
 	GPU_material_update_lamps(m_gpuMat, rasty->GetViewMatrix().Data(), rasty->GetViewInvMatrix().Data());
 }
 
-void BL_BlenderShader::Update(RAS_MeshSlot *ms, RAS_Rasterizer *rasty)
+void BL_BlenderShader::Update(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty)
 {
 	if (!GPU_material_bound(m_gpuMat)) {
 		return;
 	}
 
-	RAS_MeshUser *meshUser = ms->m_meshUser;
 	const float (&obcol)[4] = meshUser->GetColor().Data();
 
 	GPU_material_bind_uniforms(m_gpuMat, meshUser->GetMatrix().Data(), rasty->GetViewMatrix().Data(),

--- a/source/gameengine/Ketsji/BL_BlenderShader.h
+++ b/source/gameengine/Ketsji/BL_BlenderShader.h
@@ -78,7 +78,7 @@ public:
 	RAS_InstancingBuffer::Attrib GetInstancingAttribs() const;
 
 	void UpdateLights(RAS_Rasterizer *rasty);
-	void Update(RAS_MeshSlot *ms, RAS_Rasterizer *rasty);
+	void Update(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty);
 
 	/// Return true if the shader uses a special vertex shader for geometry instancing.
 	bool UseInstancing() const;

--- a/source/gameengine/Ketsji/BL_Shader.cpp
+++ b/source/gameengine/Ketsji/BL_Shader.cpp
@@ -162,17 +162,17 @@ void BL_Shader::BindProg()
 	RAS_Shader::BindProg();
 }
 
-void BL_Shader::Update(RAS_Rasterizer *rasty, RAS_MeshSlot *ms)
+void BL_Shader::Update(RAS_Rasterizer *rasty, RAS_MeshUser *meshUser)
 {
 #ifdef WITH_PYTHON
 	if (PyList_GET_SIZE(m_callbacks[CALLBACKS_OBJECT]) > 0) {
-		KX_GameObject *gameobj = KX_GameObject::GetClientObject((KX_ClientObjectInfo *)ms->m_meshUser->GetClientObject());
+		KX_GameObject *gameobj = KX_GameObject::GetClientObject((KX_ClientObjectInfo *)meshUser->GetClientObject());
 		PyObject *args[] = {gameobj->GetProxy()};
 		EXP_RunPythonCallBackList(m_callbacks[CALLBACKS_OBJECT], args, 0, ARRAY_SIZE(args));
 	}
 #endif  // WITH_PYTHON
 
-	RAS_Shader::Update(rasty, mt::mat4(ms->m_meshUser->GetMatrix()));
+	RAS_Shader::Update(rasty, meshUser->GetMatrix());
 }
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Ketsji/BL_Shader.h
+++ b/source/gameengine/Ketsji/BL_Shader.h
@@ -60,11 +60,11 @@ public:
 
 	void BindProg();
 
-	/** Update the uniform shader for the current rendered mesh slot.
+	/** Update the uniform shader for the current rendered mesh user (= object).
 	 * The python callbacks are executed in this function and at the end
 	 * RAS_Shader::Update(rasty, mat) is called.
 	 */
-	void Update(RAS_Rasterizer *rasty, RAS_MeshSlot *ms);
+	void Update(RAS_Rasterizer *rasty, RAS_MeshUser *meshUser);
 
 	// Python interface
 #ifdef WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_BatchGroup.h
+++ b/source/gameengine/Ketsji/KX_BatchGroup.h
@@ -40,6 +40,8 @@ class KX_BatchGroup : public EXP_Value, public RAS_BatchGroup
 private:
 	/// The objects currently merged in the batch group.
 	EXP_ListValue<KX_GameObject> *m_objects;
+	/// Reference object used to retrieve layer and color.
+	KX_GameObject *m_referenceObject;
 
 public:
 	KX_BatchGroup();
@@ -48,6 +50,10 @@ public:
 	virtual std::string GetName();
 
 	EXP_ListValue<KX_GameObject> *GetObjects() const;
+
+	KX_GameObject *GetReferenceObject() const;
+	/// Set reference object with error checking. Return false on error.
+	bool SetReferenceObject(KX_GameObject *object);
 
 	/** Merge a list of objects using their mesh user and transformation.
 	 * \param objects The list of objects to merge.
@@ -62,6 +68,8 @@ public:
 #ifdef WITH_PYTHON
 
 	static PyObject *pyattr_get_objects(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
+	static PyObject *pyattr_get_referenceObject(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
+	static int pyattr_set_referenceObject(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef, PyObject *value);
 
 	EXP_PYMETHOD_DOC(KX_BatchGroup, merge);
 	EXP_PYMETHOD_DOC(KX_BatchGroup, split);

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -365,16 +365,16 @@ bool KX_BlenderMaterial::UsesLighting() const
 	}
 }
 
-void KX_BlenderMaterial::ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans)
+void KX_BlenderMaterial::ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans)
 {
 	if (m_shader && m_shader->Ok()) {
-		m_shader->Update(rasty, ms);
+		m_shader->Update(rasty, meshUser);
 		m_shader->ApplyShader();
 		// Update OpenGL lighting builtins.
 		rasty->ProcessLighting(UsesLighting(), camtrans);
 	}
 	else if (m_blenderShader) {
-		m_blenderShader->Update(ms, rasty);
+		m_blenderShader->Update(meshUser, rasty);
 
 		/* we do blend modes here, because they can change per object
 		 * with the same material due to obcolor/obalpha */

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.h
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.h
@@ -35,7 +35,7 @@ public:
 	virtual void Activate(RAS_Rasterizer *rasty);
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);
-	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
+	virtual void ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
 	void UpdateTextures();
 	void ApplyTextures();

--- a/source/gameengine/Ketsji/KX_TextMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_TextMaterial.cpp
@@ -59,7 +59,7 @@ void KX_TextMaterial::DesactivateInstancing()
 {
 }
 
-void KX_TextMaterial::ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans)
+void KX_TextMaterial::ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans)
 {
 }
 

--- a/source/gameengine/Ketsji/KX_TextMaterial.h
+++ b/source/gameengine/Ketsji/KX_TextMaterial.h
@@ -41,7 +41,7 @@ public:
 	virtual void Desactivate(RAS_Rasterizer *rasty);
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer);
 	virtual void DesactivateInstancing();
-	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
+	virtual void ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans);
 
 	virtual const std::string GetTextureName() const;
 	virtual Material *GetBlenderMaterial() const;

--- a/source/gameengine/Rasterizer/RAS_BatchGroup.cpp
+++ b/source/gameengine/Rasterizer/RAS_BatchGroup.cpp
@@ -42,7 +42,8 @@ RAS_BatchGroup::Batch::Batch()
 }
 
 RAS_BatchGroup::RAS_BatchGroup()
-	:m_users(0)
+	:m_users(0),
+	m_referenceMeshUser(nullptr)
 {
 }
 
@@ -68,6 +69,16 @@ RAS_BatchGroup *RAS_BatchGroup::RemoveMeshUser()
 		return nullptr;
 	}
 	return this;
+}
+
+RAS_MeshUser *RAS_BatchGroup::GetReferenceMeshUser() const
+{
+	return m_referenceMeshUser;
+}
+
+void RAS_BatchGroup::SetReferenceMeshUser(RAS_MeshUser *meshUser)
+{
+	m_referenceMeshUser = meshUser;
 }
 
 bool RAS_BatchGroup::MergeMeshSlot(RAS_BatchGroup::Batch& batch, RAS_MeshSlot& slot, const mt::mat4& mat)

--- a/source/gameengine/Rasterizer/RAS_BatchGroup.h
+++ b/source/gameengine/Rasterizer/RAS_BatchGroup.h
@@ -37,6 +37,8 @@ class RAS_BatchGroup
 private:
 	/// The reference counter.
 	short m_users;
+	/// Reference object used to retrieve layer and color.
+	RAS_MeshUser *m_referenceMeshUser;
 
 	/// A batch contained the merged display array for all the display array used for a given material.
 	class Batch
@@ -79,6 +81,10 @@ public:
 	RAS_BatchGroup *AddMeshUser();
 	/// Notice the batch group that it is unused by one less mesh user.
 	RAS_BatchGroup *RemoveMeshUser();
+
+	RAS_MeshUser *GetReferenceMeshUser() const;
+	/// Change reference mesh user without error check.
+	void SetReferenceMeshUser(RAS_MeshUser *meshUser);
 
 	/** Merge the display array of the mesh slots contained in the mesh user.
 	 * \param meshUser The mesh user to merge mesh slots from.

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -36,7 +36,9 @@
 #include "RAS_MaterialBucket.h"
 #include "RAS_IMaterial.h"
 #include "RAS_Mesh.h"
+#include "RAS_MeshUser.h"
 #include "RAS_Deformer.h"
+#include "RAS_BatchGroup.h"
 #include "RAS_Rasterizer.h"
 #include "RAS_InstancingBuffer.h"
 #include "RAS_BucketManager.h"
@@ -321,6 +323,7 @@ void RAS_DisplayArrayBucket::RunBatchingNode(const RAS_DisplayArrayNodeTuple& tu
 	RAS_ManagerNodeData *managerData = tuple.m_managerData;
 	RAS_MaterialNodeData *materialData = tuple.m_materialData;
 
+	RAS_IMaterial *material = materialData->m_material;
 	const unsigned int nummeshslots = m_activeMeshSlots.size();
 
 	// We must use a int instead of unsigned size to match GLsizei type.
@@ -367,6 +370,11 @@ void RAS_DisplayArrayBucket::RunBatchingNode(const RAS_DisplayArrayNodeTuple& tu
 	/* It's a major issue of the batching : we can't manage face wise per object.
 	 * To be sure we don't use the old face wise we force it to true. */
 	rasty->SetFrontFace(true);
+
+	// Retrieve batch group from first active mesh slot.
+	RAS_BatchGroup *group = m_activeMeshSlots.front()->m_meshUser->GetBatchGroup();
+	// Use batch group reference mesh user for layer and object color.
+	material->ActivateMeshUser(group->GetReferenceMeshUser(), rasty, managerData->m_trans);
 
 	RAS_AttributeArrayStorage *attribStorage = m_nodeData.m_attribStorage;
 	attribStorage->BindPrimitives();

--- a/source/gameengine/Rasterizer/RAS_IMaterial.h
+++ b/source/gameengine/Rasterizer/RAS_IMaterial.h
@@ -108,7 +108,7 @@ public:
 	virtual void Activate(RAS_Rasterizer *rasty) = 0;
 	virtual void Desactivate(RAS_Rasterizer *rasty) = 0;
 	virtual void ActivateInstancing(RAS_Rasterizer *rasty, RAS_InstancingBuffer *buffer) = 0;
-	virtual void ActivateMeshSlot(RAS_MeshSlot *ms, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans) = 0;
+	virtual void ActivateMeshUser(RAS_MeshUser *meshUser, RAS_Rasterizer *rasty, const mt::mat3x4& camtrans) = 0;
 
 	bool IsAlpha() const;
 	bool IsAlphaDepth() const;

--- a/source/gameengine/Rasterizer/RAS_MeshSlot.cpp
+++ b/source/gameengine/Rasterizer/RAS_MeshSlot.cpp
@@ -90,7 +90,7 @@ void RAS_MeshSlot::RunNode(const RAS_MeshSlotNodeTuple& tuple)
 	RAS_DisplayArrayStorage *storage = displayArrayData->m_arrayStorage;
 
 	if (!managerData->m_shaderOverride) {
-		materialData->m_material->ActivateMeshSlot(this, rasty, managerData->m_trans);
+		materialData->m_material->ActivateMeshUser(m_meshUser, rasty, managerData->m_trans);
 
 		if (materialData->m_zsort && storage) {
 			displayArrayData->m_array->SortPolygons(


### PR DESCRIPTION
Previously object render settings such as light layer or object color
were not managed for batching groups.

For attribute like layers we can choose to make an union of all objects
layers, but in case of color there's no meaning of union.

To solve this issue one object should be used as reference for the group.
The attribute KX_BatchGroup.referenceObject is defined and initialized
to the first merged object when creating a batch group.
Later the user can change it to an other object of the same group.

Internally this object is set in KX_BatchGroup and RAS_BatchGroup,
KX_BatchGroup see a KX_GameObject and RAS_BatchGroup only the RAS_MeshUser
of this object. This mesh user is retrieved in RAS_DisplayArrayBucket::RunBatchingNode
from the first mesh slot mesh user and passed to RAS_IMaerial::ActivateMeshUser
which aims the update of material uniforms from object settings.