### PR TITLE
UPBGE: Revert OpenColorIO library update for Windows

### DIFF
--- a/build_files/cmake/platform/platform_win32.cmake
+++ b/build_files/cmake/platform/platform_win32.cmake
@@ -454,14 +454,7 @@ if(WITH_OPENCOLORIO)
 	set(OPENCOLORIO ${LIBDIR}/opencolorio)
 	set(OPENCOLORIO_INCLUDE_DIRS ${OPENCOLORIO}/include)
 	set(OPENCOLORIO_LIBPATH ${LIBDIR}/opencolorio/lib)
-	set(OPENCOLORIO_LIBRARIES
-		optimized ${OPENCOLORIO_LIBPATH}/OpenColorIO.lib
-		optimized ${OPENCOLORIO_LIBPATH}/tinyxml.lib
-		optimized ${OPENCOLORIO_LIBPATH}/libyaml-cpp.lib
-		debug ${OPENCOLORIO_LIBPATH}/OpenColorIO_d.lib
-		debug ${OPENCOLORIO_LIBPATH}/tinyxml_d.lib
-		debug ${OPENCOLORIO_LIBPATH}/libyaml-cpp_d.lib
-	)
+	set(OPENCOLORIO_LIBRARIES ${OPENCOLORIO_LIBPATH}/OpenColorIO.lib)
 	set(OPENCOLORIO_DEFINITIONS)
 endif()
 

--- a/intern/opencolorio/CMakeLists.txt
+++ b/intern/opencolorio/CMakeLists.txt
@@ -63,9 +63,6 @@ if(WITH_OPENCOLORIO)
 		list(APPEND INC_SYS
 			${BOOST_INCLUDE_DIR}
 		)
-		add_definitions(
-			-DOpenColorIO_STATIC
-		)
 	endif()
 
 	data_to_c_simple(gpu_shader_display_transform.glsl SRC)

--- a/source/creator/CMakeLists.txt
+++ b/source/creator/CMakeLists.txt
@@ -842,6 +842,15 @@ elseif(WIN32)
 		DESTINATION "."
 	)
 
+	if(WITH_OPENCOLORIO)
+		set(OCIOBIN ${LIBDIR}/opencolorio/bin)
+			install(
+				FILES
+					${OCIOBIN}/OpenColorIO.dll
+				DESTINATION "."
+			)
+	endif()
+
 elseif(APPLE)
 
 	# handy install macro to exclude files, we use \$ escape for the "to"


### PR DESCRIPTION
It fixes #863 and #876, and maybe others undiscovered

It gives a lot crashes in all things related with color management. We
will wait to new library update to see if we can update our library too.

Replace lib/OpenColorIO with old one:
- 32bits: https://mega.nz/#!9xVh3YLb!6blxUar4V6byXn__XgylI-gLix-0ugH7wO0kIQDJ82A
- 64bits: https://mega.nz/#!As00HYSS!itMW9KIEVUZFdxNtyETOFLC3QVUOc1ac3kP2c8ckHyI
