### PR TITLE
UPBGE: Expose the number of blur passes for variance shadow maps

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -962,6 +962,7 @@ class DATA_PT_shadow_game(DataButtonsPanel, Panel):
         col.prop(lamp, "shadow_buffer_size", text="Size")
         if lamp.ge_shadow_buffer_type == "VARIANCE":
             col.prop(lamp, "shadow_buffer_sharp", text="Sharpness")
+            col.prop(lamp, "shadow_blur_passes", text="Blur Passes")
         elif lamp.shadow_filter in ("PCF", "PCF_BAIL", "PCF_JITTER"):
             col.prop(lamp, "shadow_buffer_samples", text="Samples")
             col.prop(lamp, "shadow_buffer_soft", text="Soft")

--- a/source/blender/blenkernel/intern/lamp.c
+++ b/source/blender/blenkernel/intern/lamp.c
@@ -70,6 +70,7 @@ void BKE_lamp_init(Lamp *la)
 	la->clipend = 40.0f;
 	la->samp = 3;
 	la->bias = 1.0f;
+	la->blurpass = 1;
 	la->soft = 3.0f;
 	la->compressthresh = 0.05f;
 	la->ray_samp = la->ray_sampy = la->ray_sampz = 1;

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -347,4 +347,12 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
 			}
 		}
 	}
+	
+	if (!MAIN_VERSION_UPBGE_ATLEAST(main, 2, 5)) {
+		if (!DNA_struct_elem_find(fd->filesdna, "Lamp", "short", "blurpass")) {
+			for (Lamp *lamp = main->lamp.first; lamp; lamp = lamp->id.next) {
+				lamp->blurpass = 1;
+			}
+		}
+	}
 }

--- a/source/blender/gpu/GPU_framebuffer.h
+++ b/source/blender/gpu/GPU_framebuffer.h
@@ -73,7 +73,7 @@ bool GPU_framebuffer_bound(GPUFrameBuffer *fb);
 void GPU_framebuffer_restore(void);
 void GPU_framebuffer_blur(
         GPUFrameBuffer *fb, struct GPUTexture *tex,
-        GPUFrameBuffer *blurfb, struct GPUTexture *blurtex, float sharpness);
+        GPUFrameBuffer *blurfb, struct GPUTexture *blurtex, float sharpness, int passes);
 void GPU_framebuffer_blit(GPUFrameBuffer *srcfb, GPUFrameBuffer *dstfb, int width, int height,
 		int numAttachment, bool depth);
 

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -2986,9 +2986,7 @@ void GPU_lamp_shadow_buffer_unbind(GPULamp *lamp)
 {
 	if (lamp->la->shadowmap_type == LA_SHADMAP_VARIANCE) {
 		GPU_shader_unbind();
-		for (int i = 0; i < lamp->la->blurpass; i++) {
-			GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex, lamp->la->bufsharp);
-		}
+		GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex, lamp->la->bufsharp, lamp->la->blurpass);
 	}
 
 	GPU_framebuffer_texture_unbind(lamp->fb, lamp->tex);

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -170,7 +170,7 @@ struct GPULamp {
 	float shadow_color[3];
 
 	float bias, slopebias, d, clipend;
-	int size;
+	int size, blurpass;
 
 	int falloff_type;
 	struct CurveMapping *curfalloff;
@@ -2749,6 +2749,7 @@ static void gpu_lamp_from_blender(Scene *scene, Object *ob, Object *par, Lamp *l
 	lamp->size = la->bufsize;
 	lamp->d = la->clipsta;
 	lamp->clipend = la->clipend;
+	lamp->blurpass = la->blurpass;
 
 	/* arbitrary correction for the fact we do no soft transition */
 	lamp->bias *= 0.25f;
@@ -2985,7 +2986,9 @@ void GPU_lamp_shadow_buffer_unbind(GPULamp *lamp)
 {
 	if (lamp->la->shadowmap_type == LA_SHADMAP_VARIANCE) {
 		GPU_shader_unbind();
-		GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex, lamp->la->bufsharp);
+		for (int i = 0; i < lamp->la->blurpass; i++) {
+			GPU_framebuffer_blur(lamp->fb, lamp->tex, lamp->blurfb, lamp->blurtex, lamp->la->bufsharp);
+		}
 	}
 
 	GPU_framebuffer_texture_unbind(lamp->fb, lamp->tex);

--- a/source/blender/makesdna/DNA_lamp_types.h
+++ b/source/blender/makesdna/DNA_lamp_types.h
@@ -69,8 +69,9 @@ typedef struct Lamp {
 
 	float clipsta, clipend;
 	float bias, slopebias, soft, compressthresh;
-	float bleedbias, pad;
+	float bleedbias;
 	float bufsharp;
+	short blurpass, pad;
 	short bufsize, samp, buffers, filtertype;
 	char bufflag, buftype;
 

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -653,6 +653,12 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 	RNA_def_property_ui_text(prop, "Samples", "Number of shadow buffer samples");
 	RNA_def_property_update(prop, 0, "rna_Lamp_update");
 
+	prop = RNA_def_property(srna, "shadow_blur_passes", PROP_INT, PROP_NONE);
+	RNA_def_property_int_sdna(prop, NULL, "blurpass");
+	RNA_def_property_range(prop, 0, 4);
+	RNA_def_property_ui_text(prop, "Shadow Buffer Size", "Number of shadow buffer blur pass (is expensive)");
+	RNA_def_property_update(prop, 0, "rna_Lamp_update");
+
 	prop = RNA_def_property(srna, "shadow_buffer_type", PROP_ENUM, PROP_NONE);
 	RNA_def_property_enum_sdna(prop, NULL, "buftype");
 	RNA_def_property_enum_items(prop, prop_shadbuftype_items);

--- a/source/blender/makesrna/intern/rna_lamp.c
+++ b/source/blender/makesrna/intern/rna_lamp.c
@@ -655,8 +655,8 @@ static void rna_def_lamp_shadow(StructRNA *srna, int spot, int area)
 
 	prop = RNA_def_property(srna, "shadow_blur_passes", PROP_INT, PROP_NONE);
 	RNA_def_property_int_sdna(prop, NULL, "blurpass");
-	RNA_def_property_range(prop, 0, 4);
-	RNA_def_property_ui_text(prop, "Shadow Buffer Size", "Number of shadow buffer blur pass (is expensive)");
+	RNA_def_property_range(prop, 0, 6);
+	RNA_def_property_ui_text(prop, "Blur Passes", "Number of shadow buffer blur pass (is expensive)");
 	RNA_def_property_update(prop, 0, "rna_Lamp_update");
 
 	prop = RNA_def_property(srna, "shadow_buffer_type", PROP_ENUM, PROP_NONE);

--- a/source/blender/render/intern/include/render_types.h
+++ b/source/blender/render/intern/include/render_types.h
@@ -602,6 +602,8 @@ typedef struct LampRen {
 	float bias;
 	/* Compression threshold for deep shadow maps */
 	float compressthresh;
+	/* Number of blur passes for shadow maps */
+	short blurpass;
 
 	short ray_samp, ray_sampy, ray_sampz, ray_samp_method, ray_samp_type, area_shape, ray_totsamp;
 	short xold[BLENDER_MAX_THREADS], yold[BLENDER_MAX_THREADS];	/* last jitter table for area lights */

--- a/source/blender/render/intern/source/convertblender.c
+++ b/source/blender/render/intern/source/convertblender.c
@@ -3696,6 +3696,7 @@ static GroupObject *add_render_lamp(Render *re, Object *ob)
 	lar->buftype= la->buftype;
 	lar->filtertype= la->filtertype;
 	lar->soft = la->soft;
+	lar->blurpass = la->blurpass;
 	lar->shadhalostep = la->shadhalostep;
 	lar->clipsta = la->clipsta;
 	lar->clipend = la->clipend;

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -874,6 +874,7 @@ static KX_LightObject *BL_GameLightFromBlenderLamp(Lamp *la, unsigned int layerf
 	lightobj->m_shadowclipend = la->clipend;
 	lightobj->m_shadowbias = la->bias;
 	lightobj->m_shadowbleedbias = la->bleedbias;
+	lightobj->m_shadowblurpass = la->blurpass;
 	lightobj->m_shadowmaptype = la->shadowmap_type;
 	lightobj->m_shadowfrustumsize = la->shadow_frustum_size;
 	lightobj->m_shadowcolor = mt::vec3(la->shdwr, la->shdwg, la->shdwb);

--- a/source/gameengine/Rasterizer/RAS_ILightObject.h
+++ b/source/gameengine/Rasterizer/RAS_ILightObject.h
@@ -61,6 +61,7 @@ public:
 	float	m_shadowfrustumsize;
 	float	m_shadowclipend;
 	float	m_shadowbias;
+	short	m_shadowblurpass;
 	float	m_shadowbleedbias;
 	short	m_shadowmaptype;
 	mt::vec3 m_shadowcolor;


### PR DESCRIPTION
The default value is 1 (as current default) but the recommended value for quality/real shadows is 2 or 3.
Max 4 passes. To use with care because it is expensive. 
![lamp_blur_passes](https://user-images.githubusercontent.com/1015605/46899437-92033c00-ce93-11e8-9438-5e80ae57c990.png)