### PR TITLE
UPBGE: Add documentation example for mouse center normalization.

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.BL_Texture.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_Texture.rst
@@ -1,5 +1,5 @@
 BL_Texture(EXP_Value)
-==================
+=====================
 
 base class --- :class:`EXP_Value`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilterManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilterManager.rst
@@ -1,5 +1,5 @@
 KX_2DFilterManager(EXP_PyObjectPlus)
-================================
+====================================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilterOffScreen.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilterOffScreen.rst
@@ -1,5 +1,5 @@
 KX_2DFilterOffScreen(EXP_Value)
-============================
+===============================
 
 base class --- :class:`EXP_Value`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_BatchGroup.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BatchGroup.rst
@@ -1,5 +1,5 @@
 KX_BatchGroup(EXP_Value)
-=====================
+========================
 
 base class --- :class:`EXP_Value`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_BoundingBox.rst
@@ -1,5 +1,5 @@
 KX_BoundingBox(EXP_PyObjectPlus)
-=============================
+================================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodLevel.rst
@@ -1,5 +1,5 @@
 KX_LodLevel(EXP_PyObjectPlus)
-=========================
+=============================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_LodManager.rst
@@ -1,5 +1,5 @@
 KX_LodManager(EXP_PyObjectPlus)
-===========================
+===============================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_PythonComponent.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_PythonComponent.rst
@@ -1,5 +1,5 @@
 KX_PythonComponent(EXP_Value)
-==========================
+=============================
 
 base class --- :class:`EXP_Value`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_TextureRenderer.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_TextureRenderer.rst
@@ -1,5 +1,5 @@
 KX_TextureRenderer(EXP_Value)
-==========================
+=============================
 
 base class --- :class:`EXP_Value`
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_WorldInfo.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_WorldInfo.rst
@@ -1,5 +1,5 @@
 KX_WorldInfo(EXP_PyObjectPlus)
-=============================
+==============================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.SCA_InputEvent.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_InputEvent.rst
@@ -1,5 +1,5 @@
 SCA_InputEvent(EXP_PyObjectPlus)
-============================
+================================
 
 base class --- :class:`EXP_PyObjectPlus`
 

--- a/doc/python_api/rst/bge_types/bge.types.SCA_PythonMouse.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_PythonMouse.rst
@@ -7,6 +7,23 @@ base class --- :class:`EXP_PyObjectPlus`
 
    The current mouse.
 
+   .. warning::
+
+      Mouse normalization is using the maximum coordinate in width and height, whether `bge.render.getWindowWidth() - 1` and `bge.render.getWindowHeight() -1`.
+
+      A script setting the mouse at center is similar to the following example:
+
+      .. code-block:: python
+
+         import bge
+
+         w, h = bge.render.getWindowWidth() - 1, bge.render.getWindowHeight() - 1
+         center_x, center_y = (w // 2) / w, (h // 2) / h
+
+         bge.logic.mouse.position = center_x, center_y
+
+      Note the usage of floor division to round an existing coordinate.
+
    .. attribute:: inputs
 
       A dictionary containing the input of each mouse event. (read-only).

--- a/doc/python_api/rst/bge_types/bge.types.SCA_PythonMouse.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_PythonMouse.rst
@@ -9,7 +9,7 @@ base class --- :class:`EXP_PyObjectPlus`
 
    .. warning::
 
-      Mouse normalization is using the maximum coordinate in width and height, whether `bge.render.getWindowWidth() - 1` and `bge.render.getWindowHeight() -1`.
+      Mouse normalization is using the maximum coordinate in width and height, whether `bge.render.getWindowWidth() - 1` or `bge.render.getWindowHeight() - 1`.
 
       A script setting the mouse at center is similar to the following example:
 


### PR DESCRIPTION
The issue #865 reported a recurrent user issue concerning the normalization
of mouse coordinates. The user must be aware to use floor division and normalized
by dividing by width or height minus 1.

Fix issue: #865.