### PR TITLE
UPBGE: Fix color space of ImageRender textures.

### DIFF
--- a/release/scripts/startup/bl_ui/properties_data_empty.py
+++ b/release/scripts/startup/bl_ui/properties_data_empty.py
@@ -43,7 +43,7 @@ class DATA_PT_empty(DataButtonsPanel, Panel):
 
         if ob.empty_draw_type == 'IMAGE':
             layout.template_ID(ob, "data", open="image.open", unlink="object.unlink_data")
-            layout.template_image(ob, "data", ob.image_user, compact=True)
+            layout.template_image(ob, "data", ob.image_user, compact=True, color_space=True)
 
             row = layout.row(align=True)
             row = layout.row(align=True)

--- a/release/scripts/startup/bl_ui/properties_texture.py
+++ b/release/scripts/startup/bl_ui/properties_texture.py
@@ -1102,6 +1102,34 @@ class TEXTURE_PT_mapping(TextureSlotPanel, Panel):
             row.column().prop(tex, "offset")
             row.column().prop(tex, "scale")
 
+class TEXTURE_PT_color_management(TextureSlotPanel, Panel):
+    bl_label = "Color Management"
+    COMPAT_ENGINES = {'BLENDER_GAME'}
+
+    @classmethod
+    def poll(cls, context):
+        idblock = context_tex_datablock(context)
+        if isinstance(idblock, Brush):
+            return False
+
+        if not getattr(context, "texture_slot", None):
+            return False
+
+        engine = context.scene.render.engine
+
+        tex = context.texture
+        if hasattr(tex, "environment_map"):
+            if tex.environment_map.source == 'REALTIME':
+                return False
+
+        return (engine in cls.COMPAT_ENGINES)
+
+    def draw(self, context):
+        layout = self.layout
+        tex = context.texture_slot
+
+        layout.prop(tex, "color_management")
+
 class TEXTURE_PT_game_parallax(TextureSlotPanel, Panel):
     bl_label = "Parallax"
     COMPAT_ENGINES = {'BLENDER_GAME'}
@@ -1537,6 +1565,7 @@ classes = (
     TEXTURE_PT_ocean,
     TEXTURE_PT_game_mapping,
     TEXTURE_PT_mapping,
+    TEXTURE_PT_color_management,
     TEXTURE_PT_game_parallax,
     TEXTURE_PT_game_influence,
     TEXTURE_PT_influence,

--- a/release/scripts/startup/bl_ui/space_image.py
+++ b/release/scripts/startup/bl_ui/space_image.py
@@ -616,7 +616,7 @@ class IMAGE_PT_image_properties(Panel):
         sima = context.space_data
         iuser = sima.image_user
 
-        layout.template_image(sima, "image", iuser, multiview=True)
+        layout.template_image(sima, "image", iuser, multiview=True, color_space=True)
 
 
 class IMAGE_PT_game_properties(Panel):

--- a/source/blender/blenkernel/intern/texture.c
+++ b/source/blender/blenkernel/intern/texture.c
@@ -428,6 +428,7 @@ void BKE_texture_mtex_default(MTex *mtex)
 	mtex->brush_angle_mode = 0;
 	mtex->ior = 1.0f;
 	mtex->refrratio = 0.0f;
+	mtex->colorManagement = GAME_COLOR_MANAGEMENT_SRGB;
 }
 
 

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -315,5 +315,15 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
 				scene->gm.colorManagement = GAME_COLOR_MANAGEMENT_SRGB;
 			}
 		}
+
+		if (!DNA_struct_elem_find(fd->filesdna, "MTex", "short", "colorManagement")) {
+			for (Material *ma = main->mat.first; ma; ma = ma->id.next) {
+				for (unsigned short a = 0; a < MAX_MTEX; ++a) {
+					if (ma->mtex[a]) {
+						ma->mtex[a]->colorManagement = GAME_COLOR_MANAGEMENT_SRGB;
+					}
+				}
+			}
+		}
 	}
 }

--- a/source/blender/editors/include/UI_interface.h
+++ b/source/blender/editors/include/UI_interface.h
@@ -980,7 +980,7 @@ void uiTemplateLayers(
 void uiTemplateGameStates(
         uiLayout *layout, struct PointerRNA *ptr, const char *propname,
         PointerRNA *used_ptr, const char *used_propname, int active_state);
-void uiTemplateImage(uiLayout *layout, struct bContext *C, struct PointerRNA *ptr, const char *propname, struct PointerRNA *userptr, bool compact, bool multiview, bool cubemap);
+void uiTemplateImage(uiLayout *layout, struct bContext *C, struct PointerRNA *ptr, const char *propname, struct PointerRNA *userptr, bool compact, bool multiview, bool cubemap, bool color_space);
 void uiTemplateImageSettings(uiLayout *layout, struct PointerRNA *imfptr, bool color_management);
 void uiTemplateImageStereo3d(uiLayout *layout, struct PointerRNA *stereo3d_format_ptr);
 void uiTemplateImageViews(uiLayout *layout, struct PointerRNA *imaptr);

--- a/source/blender/editors/space_image/CMakeLists.txt
+++ b/source/blender/editors/space_image/CMakeLists.txt
@@ -49,6 +49,10 @@ set(SRC
 	image_intern.h
 )
 
+if(WITH_GAMEENGINE)
+	add_definitions(-DWITH_GAMEENGINE)
+endif()
+
 if(WITH_INTERNATIONAL)
 	add_definitions(-DWITH_INTERNATIONAL)
 endif()

--- a/source/blender/editors/space_image/image_buttons.c
+++ b/source/blender/editors/space_image/image_buttons.c
@@ -826,7 +826,7 @@ static void rna_update_cb(bContext *C, void *arg_cb, void *UNUSED(arg))
 	RNA_property_update(C, &cb->ptr, cb->prop);
 }
 
-void uiTemplateImage(uiLayout *layout, bContext *C, PointerRNA *ptr, const char *propname, PointerRNA *userptr, bool compact, bool multiview, bool cubemap)
+void uiTemplateImage(uiLayout *layout, bContext *C, PointerRNA *ptr, const char *propname, PointerRNA *userptr, bool compact, bool multiview, bool cubemap, bool color_space)
 {
 	PropertyRNA *prop;
 	PointerRNA imaptr;
@@ -960,7 +960,12 @@ void uiTemplateImage(uiLayout *layout, bContext *C, PointerRNA *ptr, const char 
 			}
 
 			col = uiLayoutColumn(layout, false);
-			uiTemplateColorspaceSettings(col, &imaptr, "colorspace_settings");
+#ifdef WITH_GAMEENGINE
+			if (color_space || !STREQ(scene->r.engine, RE_engine_id_BLENDER_GAME))
+#endif
+			{
+				uiTemplateColorspaceSettings(col, &imaptr, "colorspace_settings");
+			}
 			uiItemR(col, &imaptr, "use_view_as_render", 0, NULL, ICON_NONE);
 
 			if (ima->source != IMA_SRC_GENERATED) {

--- a/source/blender/editors/space_node/drawnode.c
+++ b/source/blender/editors/space_node/drawnode.c
@@ -857,7 +857,7 @@ static void node_shader_buts_tex_image(uiLayout *layout, bContext *C, PointerRNA
 static void node_shader_buts_tex_image_ex(uiLayout *layout, bContext *C, PointerRNA *ptr)
 {
 	PointerRNA iuserptr = RNA_pointer_get(ptr, "image_user");
-	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 0, 0);
+	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 0, 0, 1);
 }
 
 static void node_shader_buts_tex_environment(uiLayout *layout, bContext *C, PointerRNA *ptr)
@@ -1390,7 +1390,7 @@ static void node_composit_buts_image_ex(uiLayout *layout, bContext *C, PointerRN
 
 	RNA_pointer_create((ID *)ptr->id.data, &RNA_ImageUser, node->storage, &iuserptr);
 	uiLayoutSetContextPointer(layout, "image_user", &iuserptr);
-	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 1, 0);
+	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 1, 0, 1);
 }
 
 static void node_composit_buts_renderlayers(uiLayout *layout, bContext *C, PointerRNA *ptr)
@@ -2928,7 +2928,7 @@ static void node_texture_buts_image_ex(uiLayout *layout, bContext *C, PointerRNA
 	PointerRNA iuserptr;
 
 	RNA_pointer_create((ID *)ptr->id.data, &RNA_ImageUser, node->storage, &iuserptr);
-	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 0, 0);
+	uiTemplateImage(layout, C, ptr, "image", &iuserptr, 0, 0, 0, 1);
 }
 
 static void node_texture_buts_output(uiLayout *layout, bContext *UNUSED(C), PointerRNA *ptr)

--- a/source/blender/gpu/intern/gpu_material.c
+++ b/source/blender/gpu/intern/gpu_material.c
@@ -195,10 +195,12 @@ static void texture_rgb_blend(
 
 /* Functions */
 
-static bool tex_do_color_management(GPUMaterial *mat, Tex *tex)
+static bool tex_do_color_management(GPUMaterial *mat, MTex *mtex, Tex *tex)
 {
+	const bool mtexDoColorManagement = (mtex->colorManagement == GAME_COLOR_MANAGEMENT_SRGB) && GPU_material_do_color_management(mat);
+
 	if (tex->type == TEX_IMAGE) {
-		return GPU_material_do_color_management(mat);
+		return mtexDoColorManagement;
 	}
 	else if (tex->type == TEX_ENVMAP) {
 		// Realtime textures are rendered from game engine without sRGB conversion.
@@ -206,7 +208,7 @@ static bool tex_do_color_management(GPUMaterial *mat, Tex *tex)
 			return !(mat->flags & GPU_MATERIAL_NO_COLOR_MANAGEMENT);
 		}
 		else {
-			return GPU_material_do_color_management(mat);
+			return mtexDoColorManagement;
 		}
 	}
 
@@ -1590,7 +1592,7 @@ static void do_material_tex(GPUShadeInput *shi)
 						GPU_link(mat, "set_value_one", &tin);
 				}
 
-				if (tex_do_color_management(mat, tex)) {
+				if (tex_do_color_management(mat, mtex, tex)) {
 					GPU_link(mat, "srgb_to_linearrgb", tcol, &tcol);
 				}
 
@@ -2304,7 +2306,7 @@ static void do_world_tex(GPUShadeInput *shi, struct World *wo, GPUNodeLink **hor
 					GPU_link(mat, "mtex_image", texco, GPU_image(tex->ima, &tex->iuser, false), GPU_uniform(&mtex->lodbias), &tin, &trgb);
 			}
 			rgbnor = TEX_RGB;
-			if (tex_do_color_management(mat, tex)) {
+			if (tex_do_color_management(mat, mtex, tex)) {
 				GPU_link(mat, "srgb_to_linearrgb", trgb, &trgb);
 			}
 			/* texture output */

--- a/source/blender/makesdna/DNA_texture_types.h
+++ b/source/blender/makesdna/DNA_texture_types.h
@@ -99,7 +99,9 @@ typedef struct MTex {
 	float lodbias;
 
 	/* parallax */
-	short parflag, pad3;
+	short parflag;
+
+	short colorManagement;
 } MTex;
 
 #ifndef DNA_USHORT_FIX

--- a/source/blender/makesrna/intern/rna_material.c
+++ b/source/blender/makesrna/intern/rna_material.c
@@ -29,6 +29,7 @@
 
 #include "DNA_material_types.h"
 #include "DNA_texture_types.h"
+#include "DNA_scene_types.h"
 
 #include "RNA_define.h"
 #include "RNA_enum_types.h"
@@ -495,6 +496,12 @@ static void rna_def_material_mtex(BlenderRNA *brna)
 		{0, NULL, 0, NULL, NULL}
 	};
 
+	static EnumPropertyItem color_management_items[] = {
+		{GAME_COLOR_MANAGEMENT_LINEAR, "COLOR_MANAGEMENT_LINEAR", 0, "Linear", "Linear color space"},
+		{GAME_COLOR_MANAGEMENT_SRGB, "COLOR_MANAGEMENT_SRGB", 0, "sRGB", "sRGB color space"},
+		{0, NULL, 0, NULL, NULL}
+	};
+
 	srna = RNA_def_struct(brna, "MaterialTextureSlot", "TextureSlot");
 	RNA_def_struct_sdna(srna, "MTex");
 	RNA_def_struct_ui_text(srna, "Material Texture Slot", "Texture slot for textures in a Material data-block");
@@ -679,6 +686,12 @@ static void rna_def_material_mtex(BlenderRNA *brna)
 	prop = RNA_def_property(srna, "parallax_uv_discard", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "parflag", MTEX_DISCARD_AT_EDGES);
 	RNA_def_property_ui_text(prop, "Parallax UV discard", "To discard parallax UV at edges");
+	RNA_def_property_update(prop, 0, "rna_Material_update");
+
+	prop = RNA_def_property(srna, "color_management", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_sdna(prop, NULL, "colorManagement");
+	RNA_def_property_enum_items(prop, color_management_items);
+	RNA_def_property_ui_text(prop, "Color Space", "The color space of the image");
 	RNA_def_property_update(prop, 0, "rna_Material_update");
 
 	prop = RNA_def_property(srna, "lod_bias", PROP_FLOAT, PROP_NONE);

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -4593,7 +4593,7 @@ static void rna_def_scene_game_data(BlenderRNA *brna)
 	prop = RNA_def_property(srna, "color_management", PROP_ENUM, PROP_NONE);
 	RNA_def_property_enum_sdna(prop, NULL, "colorManagement");
 	RNA_def_property_enum_items(prop, color_management_items);
-	RNA_def_property_ui_text(prop, "Color Management", "The color managment of the display");
+	RNA_def_property_ui_text(prop, "Color Space", "The color space of the display");
 	RNA_def_property_update(prop, NC_SCENE | NA_EDITED, "rna_Scene_glsl_update");
 
 	prop = RNA_def_property(srna, "exit_key", PROP_ENUM, PROP_NONE);

--- a/source/blender/makesrna/intern/rna_ui_api.c
+++ b/source/blender/makesrna/intern/rna_ui_api.c
@@ -831,6 +831,7 @@ void RNA_api_ui_layout(StructRNA *srna)
 	RNA_def_boolean(func, "compact", false, "", "Use more compact layout");
 	RNA_def_boolean(func, "multiview", false, "", "Expose Multi-View options");
 	RNA_def_boolean(func, "cubemap", false, "", "Warn for invalid cube map size");
+	RNA_def_boolean(func, "color_space", false, "", "Display color space option");
 
 	func = RNA_def_function(srna, "template_image_settings", "uiTemplateImageSettings");
 	RNA_def_function_ui_description(func, "User interface for setting image format options");

--- a/source/blenderplayer/bad_level_call_stubs/stubs.c
+++ b/source/blenderplayer/bad_level_call_stubs/stubs.c
@@ -622,7 +622,7 @@ void uiTemplateRunningJobs(struct uiLayout *layout, struct bContext *C) RET_NONE
 void uiTemplateOperatorSearch(struct uiLayout *layout) RET_NONE
 void uiTemplateHeader3D(struct uiLayout *layout, struct bContext *C) RET_NONE
 void uiTemplateEditModeSelection(struct uiLayout *layout, struct bContext *C) RET_NONE
-void uiTemplateImage(uiLayout *layout, struct bContext *C, struct PointerRNA *ptr, const char *propname, struct PointerRNA *userptr, bool compact, bool multiview, bool cubemap) RET_NONE
+void uiTemplateImage(uiLayout *layout, struct bContext *C, struct PointerRNA *ptr, const char *propname, struct PointerRNA *userptr, bool compact, bool multiview, bool cubemap, bool color_space) RET_NONE
 void uiTemplateColorPicker(uiLayout *layout, struct PointerRNA *ptr, const char *propname, bool value_slider, bool lock, bool lock_luminosity, bool cubic) RET_NONE
 void uiTemplateHistogram(uiLayout *layout, struct PointerRNA *ptr, const char *propname) RET_NONE
 void uiTemplateReportsBanner(uiLayout *layout, struct bContext *C) RET_NONE


### PR DESCRIPTION
With the introduction of color management, every scene render is
in linear color space and the final draw to the screen (potentially
after filters) might be in sRGB space.

This behvaiour has the side effect of leaving ImageRender/ImageViewport
images in linear spaces as they result from a scene render. But all
blender textures were before supposed to be sRGB space and converted
back into linear in material shaders. Now it is partially the case.

The way of fixing this issue is to leave an option in material texture
panel to select color space of the image. The default is sRGB and
texture sapped with ImageRender in game must select Linear space.

Realtime envmap always ignore this setting as they are in linear
space in any cases.