### PR TITLE
UPBGE: Allow KX_LibLoadStatus.onFinish to call python method.

### DIFF
--- a/source/gameengine/Expressions/EXP_PythonCallBack.h
+++ b/source/gameengine/Expressions/EXP_PythonCallBack.h
@@ -29,6 +29,14 @@
 
 #include "EXP_Python.h"
 
+/** Check and call a python callable object.
+ * \param value Callable object candidate.
+ * \param arglist The first item in the tuple to execute callbacks (can be nullptr for no arguments).
+ * \param minargcount The minimum of arguments possible.
+ * \param maxargcount The maximum of arguments possible.
+ */
+void EXP_RunPythonCallback(PyObject *value, PyObject **arglist, unsigned int minargcount, unsigned int maxargcount);
+
 /** Execute each functions with at least one argument
  * \param functionlist The python list which contains callbacks.
  * \param arglist The first item in the tuple to execute callbacks (can be nullptr for no arguments).

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
@@ -25,6 +25,9 @@
  */
 
 #include "KX_LibLoadStatus.h"
+
+#include "EXP_PythonCallBack.h"
+
 #include "PIL_time.h"
 
 KX_LibLoadStatus::KX_LibLoadStatus(BL_Converter *converter, KX_KetsjiEngine *engine, KX_Scene *merge_scene, const std::string& path)
@@ -57,14 +60,11 @@ void KX_LibLoadStatus::RunFinishCallback()
 {
 #ifdef WITH_PYTHON
 	if (m_finish_cb) {
-		PyObject *args = Py_BuildValue("(O)", GetProxy());
+		PyObject *args[] = {GetProxy()};
 
-		if (!PyObject_Call(m_finish_cb, args, nullptr)) {
-			PyErr_Print();
-			PyErr_Clear();
-		}
+		EXP_RunPythonCallback(m_finish_cb, args, 0, 1);
 
-		Py_DECREF(args);
+		Py_DECREF(args[0]);
 	}
 #endif
 }


### PR DESCRIPTION
Previously KX_LibLoadStatus finish callback was only permitted to be
python function not method.

To allow calling a method, work from EXP_RunPythonCallBackList is reused
and the calling of a python function is moved into new function
EXP_RunPythonCallback. This function is in charge of checking that the
python object is callable and construct a tuple of the arguments.

EXP_RunPythonCallback is now called into KX_LibLoadStatus::RunFinishCallback.