### PR TITLE
UPBGE: Allow asynchronous mesh libload.

### DIFF
--- a/build_files/cmake/macros.cmake
+++ b/build_files/cmake/macros.cmake
@@ -621,11 +621,11 @@ function(SETUP_BLENDER_SORTED_LIBS)
 		ge_device
 		ge_rasterizer
 		ge_oglrasterizer
-		ge_common
 		ge_logic_expressions
 		ge_scenegraph
 		ge_logic_network
 		ge_videotex
+		ge_common
 
 		bf_render
 		bf_python

--- a/source/blenderplayer/CMakeLists.txt
+++ b/source/blenderplayer/CMakeLists.txt
@@ -106,10 +106,10 @@ endif()
 		ge_rasterizer
 		ge_oglrasterizer
 		ge_logic_expressions
-		ge_common
 		ge_scenegraph
 		ge_logic_network
 		ge_videotex
+		ge_common
 
 		bf_editor_datafiles
 

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.cpp
@@ -30,11 +30,11 @@
 
 #include "PIL_time.h"
 
-KX_LibLoadStatus::KX_LibLoadStatus(BL_Converter *converter, KX_KetsjiEngine *engine, KX_Scene *merge_scene, const std::string& path)
-	:m_converter(converter),
-	m_engine(engine),
-	m_mergescene(merge_scene),
+KX_LibLoadStatus::KX_LibLoadStatus(const std::vector<KX_Scene *>& scenes, KX_Scene *mergeScene, const ConvertFunction& function,
+		const BL_Resource::Library& libraryId, const std::string& path)
+	:m_mergeScene(mergeScene),
 	m_libname(path),
+	m_convertFunction(function),
 	m_progress(0.0f),
 	m_finished(false)
 #ifdef WITH_PYTHON
@@ -44,6 +44,11 @@ KX_LibLoadStatus::KX_LibLoadStatus(BL_Converter *converter, KX_KetsjiEngine *eng
 #endif
 {
 	m_endtime = m_starttime = PIL_check_seconds_timer();
+
+	// Create scene converters.
+	for (KX_Scene *scene : scenes) {
+		m_sceneConverters.emplace_back(scene, libraryId);
+	}
 }
 
 void KX_LibLoadStatus::Finish()
@@ -73,29 +78,19 @@ void KX_LibLoadStatus::RunProgressCallback()
 {
 }
 
-BL_Converter *KX_LibLoadStatus::GetConverter() const
-{
-	return m_converter;
-}
-
-KX_KetsjiEngine *KX_LibLoadStatus::GetEngine() const
-{
-	return m_engine;
-}
-
 KX_Scene *KX_LibLoadStatus::GetMergeScene() const
 {
-	return m_mergescene;
+	return m_mergeScene;
 }
 
 std::vector<BL_SceneConverter>& KX_LibLoadStatus::GetSceneConverters()
 {
-	return m_sceneConvertes;
+	return m_sceneConverters;
 }
 
-void KX_LibLoadStatus::AddSceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId)
+const KX_LibLoadStatus::ConvertFunction& KX_LibLoadStatus::GetConvertFunction() const
 {
-	m_sceneConvertes.emplace_back(scene, libraryId);
+	return m_convertFunction;
 }
 
 bool KX_LibLoadStatus::IsFinished() const

--- a/source/gameengine/Ketsji/KX_LibLoadStatus.h
+++ b/source/gameengine/Ketsji/KX_LibLoadStatus.h
@@ -30,6 +30,8 @@
 #include "EXP_PyObjectPlus.h"
 #include "BL_SceneConverter.h"
 
+#include <functional>
+
 class BL_Converter;
 class KX_KetsjiEngine;
 class KX_Scene;
@@ -37,12 +39,14 @@ class KX_Scene;
 class KX_LibLoadStatus : public EXP_PyObjectPlus
 {
 	Py_Header
+public:
+	using ConvertFunction = std::function<void (BL_Converter&, BL_SceneConverter&)>;
+
 private:
-	BL_Converter *m_converter;
-	KX_KetsjiEngine *m_engine;
-	KX_Scene *m_mergescene;
-	std::vector<BL_SceneConverter> m_sceneConvertes;
+	KX_Scene *m_mergeScene;
+	std::vector<BL_SceneConverter> m_sceneConverters;
 	std::string m_libname;
+	ConvertFunction m_convertFunction;
 
 	float m_progress;
 	double m_starttime;
@@ -57,19 +61,17 @@ private:
 #endif
 
 public:
-	KX_LibLoadStatus(BL_Converter *converter, KX_KetsjiEngine *engine, KX_Scene *merge_scene, const std::string& path);
+	KX_LibLoadStatus(const std::vector<KX_Scene *>& scenes, KX_Scene *mergeScene, const ConvertFunction& function,
+			const BL_Resource::Library& libraryId, const std::string& path);
 
 	/// Called when the libload is done.
 	void Finish();
 	void RunFinishCallback();
 	void RunProgressCallback();
 
-	BL_Converter *GetConverter() const;
-	KX_KetsjiEngine *GetEngine() const;
 	KX_Scene *GetMergeScene() const;
-
 	std::vector<BL_SceneConverter>& GetSceneConverters();
-	void AddSceneConverter(KX_Scene *scene, const BL_Resource::Library& libraryId);
+	const ConvertFunction& GetConvertFunction() const;
 
 	bool IsFinished() const;
 


### PR DESCRIPTION
Previously only scene supported asynchronous libloading.
But the loading of meshes and scenes are similar in the point
that they both use a scene converter but with a different
procedure on the data to convert and register to this scene
converter.

This commit introduce a more flexible KX_LibLoadStatus
with the usage of a lambda function which receive as argument
one of the scene converted listed in KX_LibLoadStatus and
process the conversion.

This lambda is created in BL_Converter::LinkBlendFile
in the same time than a list of scenes used to create the
scene converters is built. KX_LibLoadStatus is constructed
passing the function and the scene list.

BL_Converter also replaced the usage of blender task scheduler
by TBB. A tbb::task_group and a std::mutex is now hold.
The function BL_Converter::ConvertLibraryTask is in charge to
call the conversion function and this function can be called
by a task group or manually which help to reuse code.
As before BL_Converter::LinkBlendFile, is reponsible to
do a direct conversion or launch a conversion asynchronous task.

Fix issue: #533.