### PR TITLE
UPBGE: Python controllers module loading fix

### DIFF
--- a/source/gameengine/GameLogic/SCA_PythonController.cpp
+++ b/source/gameengine/GameLogic/SCA_PythonController.cpp
@@ -281,21 +281,27 @@ bool SCA_PythonController::Import()
 		return false;
 	}
 
-	// Import the module and print an error if it's not found
-	PyObject *mod = PyImport_ImportModule(mod_path.c_str());
+	// Try to get the module by name
+	PyObject *mod = PyImport_GetModule(mod_path.c_str());
 
 	if (mod == nullptr) {
-		ErrorPrint("Python module can't be imported");
-		return false;
-	}
 
-	if (m_debug) {
+		// Module not already imported, trying to import it now
+		mod = PyImport_ImportModule(mod_path.c_str());
+		if (mod == nullptr) {
+			ErrorPrint("Python module can't be imported");
+			return false;
+		}
+
+	} else {
+
+		// Module was already imported, let's reload it
 		mod = PyImport_ReloadModule(mod);
-	}
+		if (mod == nullptr) {
+			ErrorPrint("Python module can't be reloaded");
+			return false;
+		}
 
-	if (mod == nullptr) {
-		ErrorPrint("Python module can't be reloaded");
-		return false;
 	}
 
 	// Get the function object


### PR DESCRIPTION
When doing `pyctrl->Import()` we should reload a module if it was already
loaded in the Python runtime. The call to `Import()` should only be done
to update the used script/module anyway, and shouldn't be called
repeatedly, unless you want to refresh the Python program continuously.
This is already managed by `SCA_PythonController::Trigger()` by watching
the `m_bModified` boolean.

Fix #918.

Signed-off-by: marechal-p <marechap.info@gmail.com>