### PR TITLE
UPBGE: Allow changing anti aliasing in game.

### DIFF
--- a/doc/python_api/rst/bge.render.rst
+++ b/doc/python_api/rst/bge.render.rst
@@ -307,6 +307,21 @@ Functions
 
    :rtype: integer (one of 1, 2, 4, 8, 16)
 
+.. function:: setAntiAliasing(level)
+
+   Set the anti aliasing level.
+
+   :arg level: The new anisotropic filtering level to use
+   :type level: integer (must be one of 1, 2, 4, 8, 16)
+
+   .. note:: Changing this value cause all off screens to be recreated, which can be slow.
+
+.. function:: getAntiAliasing()
+
+   Get the anti aliasing level setting.
+
+   :rtype: integer (one of 1, 2, 4, 8, 16)
+
 .. function:: setMipmapping(value)
 
    Change how to use mipmapping.

--- a/source/gameengine/GamePlayer/GPG_Canvas.cpp
+++ b/source/gameengine/GamePlayer/GPG_Canvas.cpp
@@ -55,6 +55,8 @@ GPG_Canvas::GPG_Canvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentLis
 		m_window->getClientBounds(bnds);
 		this->Resize(bnds.getWidth(), bnds.getHeight());
 	}
+
+	UpdateOffScreens();
 }
 
 GPG_Canvas::~GPG_Canvas()
@@ -84,8 +86,6 @@ void GPG_Canvas::Resize(int width, int height)
 	m_area.SetBottom(0);
 	m_area.SetRight(width - 1);
 	m_area.SetTop(height - 1);
-
-	UpdateOffScreens();
 }
 
 void GPG_Canvas::SetViewPort(int x, int y, int width, int height)

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -1199,6 +1199,33 @@ static PyObject *gPyGetAnisotropicFiltering(PyObject *, PyObject *args)
 	return PyLong_FromLong(KX_GetActiveEngine()->GetRasterizer()->GetAnisotropicFiltering());
 }
 
+static PyObject *gPySetAntiAliasing(PyObject *, PyObject *args)
+{
+	short level;
+
+	if (!PyArg_ParseTuple(args, "h:setAntiAliasing", &level)) {
+		return nullptr;
+	}
+
+	if (!ELEM(level, 1, 2, 4, 8, 16)) {
+		PyErr_SetString(PyExc_ValueError, "Rasterizer.setAntiAliasing(level): Expected value of 1, 2, 4, 8, or 16 for value");
+		return nullptr;
+	}
+
+	RAS_ICanvas *canvas = KX_GetActiveEngine()->GetCanvas();
+	canvas->SetSamples(level);
+
+	// Recreate off screens.
+	canvas->UpdateOffScreens();
+
+	Py_RETURN_NONE;
+}
+
+static PyObject *gPyGetAntiAliasing(PyObject *, PyObject *args)
+{
+	return PyLong_FromLong(KX_GetActiveEngine()->GetCanvas()->GetSamples());
+}
+
 static PyObject *gPyDrawLine(PyObject *, PyObject *args)
 {
 	PyObject *ob_from;
@@ -1424,6 +1451,10 @@ static struct PyMethodDef rasterizer_methods[] = {
 	{"setAnisotropicFiltering", (PyCFunction)gPySetAnisotropicFiltering,
 	 METH_VARARGS, "set the anisotropic filtering level (must be one of 1, 2, 4, 8, 16)"},
 	{"getAnisotropicFiltering", (PyCFunction)gPyGetAnisotropicFiltering,
+	 METH_VARARGS, "get the anti aliasing level"},
+	{"setAntiAliasing", (PyCFunction)gPySetAntiAliasing,
+	 METH_VARARGS, "set the anti aliasing level (must be one of 1, 2, 4, 8, 16)"},
+	{"getAntiAliasing", (PyCFunction)gPyGetAntiAliasing,
 	 METH_VARARGS, "get the anisotropic filtering level"},
 	{"drawLine", (PyCFunction)gPyDrawLine,
 	 METH_VARARGS, "draw a line on the screen"},

--- a/source/gameengine/Launcher/LA_PlayerLauncher.cpp
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.cpp
@@ -144,6 +144,7 @@ KX_ExitInfo LA_PlayerLauncher::EngineNextFrame()
 		GHOST_Rect bnds;
 		m_mainWindow->getClientBounds(bnds);
 		m_canvas->Resize(bnds.getWidth(), bnds.getHeight());
+		m_canvas->UpdateOffScreens();
 		m_ketsjiEngine->Resize();
 		m_inputDevice->ConvertEvent(SCA_IInputDevice::WINRESIZE, 0, 0);
 	}

--- a/source/gameengine/Rasterizer/RAS_ICanvas.h
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.h
@@ -156,6 +156,9 @@ public:
 	 */
 	RAS_OffScreen *GetOffScreen(RAS_OffScreen::Type type);
 
+	/// Update dimensions of all off screens.
+	void UpdateOffScreens();
+
 protected:
 	/// Swap interval value of each swap control mode.
 	static const int swapInterval[SWAP_CONTROL_MAX];
@@ -198,9 +201,6 @@ protected:
 	 * a separate thread.
 	 */
 	void SaveScreeshot(const Screenshot& screenshot, RAS_Rasterizer *rasty);
-
-	/// Update dimensions of all off screens.
-	void UpdateOffScreens();
 };
 
 #endif  // __RAS_ICANVAS_H__


### PR DESCRIPTION
The new python functions getAntiAliasing and setAntiAliasing are
implemented they both permit to read and set the anti aliasing level.
Setting the level implies recreating the off screen which can be slow.

Fix issue: #964.

Example file: 
[ge_anti_aliasing.zip](https://github.com/UPBGE/blender/files/2695012/ge_anti_aliasing.zip)
