### PR TITLE
UPBGE: Fix Antialiasing setting at game engine start

### DIFF
--- a/source/gameengine/BlenderRoutines/KX_BlenderCanvas.cpp
+++ b/source/gameengine/BlenderRoutines/KX_BlenderCanvas.cpp
@@ -54,8 +54,8 @@ extern "C" {
 }
 
 KX_BlenderCanvas::KX_BlenderCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments,
-		wmWindowManager *wm, wmWindow *win, RAS_Rect &rect)
-	:RAS_ICanvas(attachments),
+		wmWindowManager *wm, wmWindow *win, RAS_Rect &rect, int numSamples)
+	:RAS_ICanvas(attachments, numSamples),
 	m_wm(wm),
 	m_win(win)
 {

--- a/source/gameengine/BlenderRoutines/KX_BlenderCanvas.h
+++ b/source/gameengine/BlenderRoutines/KX_BlenderCanvas.h
@@ -55,7 +55,7 @@ private:
 
 public:
 	KX_BlenderCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments,
-			wmWindowManager *wm, wmWindow *win, RAS_Rect &rect);
+			wmWindowManager *wm, wmWindow *win, RAS_Rect &rect, int numSamples);
 	virtual ~KX_BlenderCanvas();
 
 	virtual void Init();

--- a/source/gameengine/GamePlayer/GPG_Canvas.cpp
+++ b/source/gameengine/GamePlayer/GPG_Canvas.cpp
@@ -44,8 +44,8 @@
 #include "MEM_guardedalloc.h"
 #include "DNA_space_types.h"
 
-GPG_Canvas::GPG_Canvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, GHOST_IWindow *window)
-	:RAS_ICanvas(attachments),
+GPG_Canvas::GPG_Canvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, GHOST_IWindow *window, int numSamples)
+	:RAS_ICanvas(attachments, numSamples),
 	m_window(window)
 {
 	rasty->GetViewport(m_viewport);

--- a/source/gameengine/GamePlayer/GPG_Canvas.h
+++ b/source/gameengine/GamePlayer/GPG_Canvas.h
@@ -50,7 +50,7 @@ protected:
 	GHOST_IWindow *m_window;
 
 public:
-	GPG_Canvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, GHOST_IWindow *window);
+	GPG_Canvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, GHOST_IWindow *window, int numSamples);
 	virtual ~GPG_Canvas();
 
 	/**

--- a/source/gameengine/Launcher/LA_BlenderLauncher.cpp
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.cpp
@@ -74,9 +74,9 @@ LA_BlenderLauncher::~LA_BlenderLauncher()
 {
 }
 
-RAS_ICanvas *LA_BlenderLauncher::CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments)
+RAS_ICanvas *LA_BlenderLauncher::CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, int numSamples)
 {
-	return (new KX_BlenderCanvas(rasty, attachments, m_windowManager, m_window, m_areaRect));
+	return (new KX_BlenderCanvas(rasty, attachments, m_windowManager, m_window, m_areaRect, numSamples));
 }
 
 RAS_Rasterizer::DrawType LA_BlenderLauncher::GetRasterizerDrawMode()

--- a/source/gameengine/Launcher/LA_BlenderLauncher.h
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.h
@@ -57,7 +57,7 @@ protected:
 
 	virtual void RenderEngine();
 
-	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments);
+	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, int numSamples);
 	virtual RAS_Rasterizer::DrawType GetRasterizerDrawMode();
 	virtual void InitCamera();
 

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -203,7 +203,7 @@ void LA_Launcher::InitEngine()
 	}
 
 	// Create the canvas, rasterizer and rendertools.
-	m_canvas = CreateCanvas(m_rasterizer, attachments);
+	m_canvas = CreateCanvas(m_rasterizer, attachments, m_startScene->gm.aasamples);
 
 	static const RAS_ICanvas::SwapControl swapControlTable[] = {
 		RAS_ICanvas::VSYNC_ON, // VSYNC_ON

--- a/source/gameengine/Launcher/LA_Launcher.h
+++ b/source/gameengine/Launcher/LA_Launcher.h
@@ -118,7 +118,7 @@ protected:
 	virtual void RunPythonMainLoop(const std::string& pythonCode);
 #endif  // WITH_PYTHON
 
-	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments) = 0;
+	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, int numSamples) = 0;
 	virtual RAS_Rasterizer::DrawType GetRasterizerDrawMode() = 0;
 	virtual void InitCamera() = 0;
 

--- a/source/gameengine/Launcher/LA_PlayerLauncher.cpp
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.cpp
@@ -151,7 +151,7 @@ KX_ExitInfo LA_PlayerLauncher::EngineNextFrame()
 	return LA_Launcher::EngineNextFrame();
 }
 
-RAS_ICanvas *LA_PlayerLauncher::CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments)
+RAS_ICanvas *LA_PlayerLauncher::CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, int numSamples)
 {
-	return (new GPG_Canvas(rasty, attachments, m_mainWindow));
+	return (new GPG_Canvas(rasty, attachments, m_mainWindow, numSamples));
 }

--- a/source/gameengine/Launcher/LA_PlayerLauncher.h
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.h
@@ -53,7 +53,7 @@ protected:
 	virtual void RunPythonMainLoop(const std::string& pythonCode);
 #endif  // WITH_PYTHON
 
-	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments);
+	virtual RAS_ICanvas *CreateCanvas(RAS_Rasterizer *rasty, const RAS_OffScreen::AttachmentList& attachments, int numSamples);
 	virtual RAS_Rasterizer::DrawType GetRasterizerDrawMode();
 	virtual void InitCamera();
 

--- a/source/gameengine/Rasterizer/RAS_ICanvas.cpp
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.cpp
@@ -71,8 +71,8 @@ const int RAS_ICanvas::swapInterval[RAS_ICanvas::SWAP_CONTROL_MAX] = {
 	-1 // VSYNC_ADAPTIVE
 };
 
-RAS_ICanvas::RAS_ICanvas(const RAS_OffScreen::AttachmentList& attachments)
-	:m_samples(0),
+RAS_ICanvas::RAS_ICanvas(const RAS_OffScreen::AttachmentList& attachments, int numSamples)
+	:m_samples(numSamples),
 	m_attachments(attachments),
 	m_swapControl(VSYNC_OFF),
 	m_frame(1)

--- a/source/gameengine/Rasterizer/RAS_ICanvas.h
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.h
@@ -60,7 +60,7 @@ public:
 		SWAP_CONTROL_MAX
 	};
 
-	RAS_ICanvas(const RAS_OffScreen::AttachmentList& attachments);
+	RAS_ICanvas(const RAS_OffScreen::AttachmentList& attachments, int numSamples);
 	virtual ~RAS_ICanvas();
 
 	virtual void Init() = 0;


### PR DESCRIPTION
Since 23183936242af, in KX_BlenderCanvas constructor, UpdateOffScreens
was called and and a new offscreen was created, but the number of AA
samples was set to 0, the the offscreen was not created correctly.

To fix that, we can set the samples number in canvas constructor. This
way, the number of AA samples is available when we create the offscreen