### PR TITLE
UPBGE: Try to fix mipmap for cubemap textures

### DIFF
--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -175,10 +175,9 @@ KX_TextureRenderScheduleList KX_TextureRendererManager::ScheduleRenderer(RAS_Ras
 				viewpoint->SetVisible(visible, false);
 			};
 
-			renderer->EndRender(rasty, layer);
-
 			textures.push_back(textureSchedule);
 		}
+		renderer->EndRender(rasty, layer);
 	}
 
 	return textures;

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -175,6 +175,8 @@ KX_TextureRenderScheduleList KX_TextureRendererManager::ScheduleRenderer(RAS_Ras
 				viewpoint->SetVisible(visible, false);
 			};
 
+			renderer->EndRender(rasty, layer);
+
 			textures.push_back(textureSchedule);
 		}
 	}


### PR DESCRIPTION
In cubemap/planar rendering process, this:
void RAS_TextureRenderer::EndRender(RAS_Rasterizer *rasty, unsigned
short layer)
{
	m_layers[layer].Unbind(m_useMipmap);
}

was not called. To generate mipmap, we have to call it each frame.
This is an attempt to fix https://github.com/UPBGE/blender/issues/998

This would need to be reviewed by panzergame or lordloki