### PR TITLE
UPBGE: UI space logic: Use same bl_category for components than for p…

### DIFF
--- a/release/scripts/startup/bl_ui/space_logic.py
+++ b/release/scripts/startup/bl_ui/space_logic.py
@@ -23,6 +23,7 @@ from bpy.types import Header, Menu, Panel
 class LOGIC_PT_components(bpy.types.Panel):
     bl_space_type = 'LOGIC_EDITOR'
     bl_region_type = 'UI'
+    bl_category = "Logic"
     bl_label = 'Components'
 
     @classmethod


### PR DESCRIPTION
…roperties

In space_logic.py, the bl_category for python components was not
defined.

Then contrarly to upbge 2.7, comonents and game properties were in 2
different "tabs".

I think since 2.8, to avoid this we must define the bl_category each
time.

With this commit we can see that game properties and components belong
to the same UI