### PR TITLE
UPBGE: Add a system to do HUDs without overlay scenes

### DIFF
--- a/release/scripts/startup/bl_ui/properties_object.py
+++ b/release/scripts/startup/bl_ui/properties_object.py
@@ -259,6 +259,7 @@ class OBJECT_PT_display(ObjectButtonsPanel, Panel):
 
         col = flow.column()
         col.prop(obj, "show_in_front", text="In Front")
+        col.prop(obj, "show_in_front_bge", text="In Front bge") #Game engine transition
         # if obj_type == 'MESH' or is_empty_image:
         #    col.prop(obj, "show_transparent", text="Transparency")
 

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -254,6 +254,18 @@ static void eevee_draw_background(void *vedata)
     DRW_stats_group_start("Prepass");
     DRW_draw_pass(psl->depth_pass);
     DRW_draw_pass(psl->depth_pass_cull);
+
+    EEVEE_setup_ghost_framebuffer(fbl, vedata);
+
+    GPU_framebuffer_bind(fbl->ghost_prepass_fb);
+    GPU_framebuffer_clear_depth(fbl->ghost_prepass_fb, 1.0f);
+    DRW_draw_pass(psl->ghost_prepass_pass);
+
+
+    GPU_framebuffer_bind(dfbl->depth_only_fb);
+    DRW_draw_pass(psl->ghost_resolve_pass);
+
+
     DRW_stats_group_end();
 
     /* Create minmax texture */

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -255,16 +255,18 @@ static void eevee_draw_background(void *vedata)
     DRW_draw_pass(psl->depth_pass);
     DRW_draw_pass(psl->depth_pass_cull);
 
-    EEVEE_setup_ghost_framebuffer(fbl, vedata);
+    /* Game engine transition */
+    if (!DRW_pass_is_empty(psl->ghost_prepass_pass)) {
+      EEVEE_setup_ghost_framebuffer(fbl, vedata);
 
-    GPU_framebuffer_bind(fbl->ghost_prepass_fb);
-    GPU_framebuffer_clear_depth(fbl->ghost_prepass_fb, 1.0f);
-    DRW_draw_pass(psl->ghost_prepass_pass);
+      GPU_framebuffer_bind(fbl->ghost_prepass_fb);
+      GPU_framebuffer_clear_depth(fbl->ghost_prepass_fb, 1.0f);
+      DRW_draw_pass(psl->ghost_prepass_pass);
 
-
-    GPU_framebuffer_bind(dfbl->depth_only_fb);
-    DRW_draw_pass(psl->ghost_resolve_pass);
-
+      GPU_framebuffer_bind(dfbl->depth_only_fb);
+      DRW_draw_pass(psl->ghost_resolve_pass);
+    }
+    /* End of Game engine transition */
 
     DRW_stats_group_end();
 

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -1189,6 +1189,10 @@ static void material_opaque(Object *ob,
     return;
   }
 
+  if (ob->dtx & OB_DRAWXRAY) {
+    *shgrp_depth = DRW_shgroup_create(e_data.default_prepass_sh, psl->ghost_prepass_pass);
+  }
+
   if (use_gpumat) {
     static float error_col[3] = {1.0f, 0.0f, 1.0f};
     static float compile_col[3] = {0.5f, 0.5f, 0.5f};
@@ -1196,10 +1200,6 @@ static void material_opaque(Object *ob,
 
     /* Shading */
     *gpumat = EEVEE_material_mesh_get(scene, ma, vedata, false, use_ssrefract);
-
-    if (ob->dtx & OB_DRAWXRAY) {
-      *shgrp_depth = DRW_shgroup_create(e_data.default_prepass_sh, psl->ghost_prepass_pass);
-    }
 
     eGPUMaterialStatus status_mat_surface = GPU_material_status(*gpumat);
 

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -55,11 +55,13 @@ static struct {
 
   struct GPUShader *default_prepass_sh;
   struct GPUShader *default_prepass_clip_sh;
+  struct GPUShader *ghost_resolve_sh;
   struct GPUShader *default_hair_prepass_sh;
   struct GPUShader *default_hair_prepass_clip_sh;
   struct GPUShader *default_lit[VAR_MAT_MAX];
   struct GPUShader *default_background;
   struct GPUShader *update_noise_sh;
+  struct GPUTexture *ghost_depth_tx;
 
   /* 64*64 array texture containing all LUTs and other utilitarian arrays.
    * Packing enables us to same precious textures slots. */
@@ -103,6 +105,8 @@ extern char datatoc_volumetric_frag_glsl[];
 extern char datatoc_volumetric_lib_glsl[];
 
 extern char datatoc_gpu_shader_uniform_color_frag_glsl[];
+
+extern char datatoc_workbench_ghost_resolve_frag_glsl[];
 
 /* *********** FUNCTIONS *********** */
 
@@ -601,6 +605,9 @@ void EEVEE_materials_init(EEVEE_ViewLayerData *sldata,
                                                             "#define HAIR_SHADER\n"
                                                             "#define CLIP_PLANES\n");
 
+    e_data.ghost_resolve_sh = DRW_shader_create_fullscreen(
+        datatoc_workbench_ghost_resolve_frag_glsl, NULL);
+
     MEM_freeN(vert_str);
 
     e_data.update_noise_sh = DRW_shader_create_fullscreen(datatoc_update_noise_frag_glsl, NULL);
@@ -999,6 +1006,14 @@ void EEVEE_materials_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
     DRW_PASS_CREATE(psl->depth_pass_clip_cull, state);
     stl->g_data->depth_shgrp_clip_cull = DRW_shgroup_create(e_data.default_prepass_clip_sh,
                                                             psl->depth_pass_clip_cull);
+
+    state = DRW_STATE_WRITE_COLOR | DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_LESS_EQUAL;
+    DRW_PASS_CREATE(psl->ghost_prepass_pass, state);
+    state = DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_ALWAYS;
+    DRW_PASS_CREATE(psl->ghost_resolve_pass, state);
+    DRWShadingGroup *grp = DRW_shgroup_create(e_data.ghost_resolve_sh, psl->ghost_resolve_pass);
+    DRW_shgroup_uniform_texture_ref(grp, "depthBuffer", &e_data.ghost_depth_tx);
+    DRW_shgroup_call(grp, DRW_cache_fullscreen_quad_get(), NULL);
   }
 
   {
@@ -1113,7 +1128,23 @@ typedef struct EeveeMaterialShadingGroups {
   struct DRWShadingGroup *depth_clip_grp;
 } EeveeMaterialShadingGroups;
 
-static void material_opaque(Material *ma,
+void EEVEE_setup_ghost_framebuffer(EEVEE_FramebufferList *fbl, EEVEE_Data *vedata)
+{
+  const float *viewport_size = DRW_viewport_size_get();
+  const int size[2] = {(int)viewport_size[0], (int)viewport_size[1]};
+
+  e_data.ghost_depth_tx = DRW_texture_pool_query_2d(
+      size[0], size[1], GPU_DEPTH_COMPONENT24, &draw_engine_eevee_type);
+
+  GPU_framebuffer_ensure_config(&fbl->ghost_prepass_fb,
+                                {
+                                    GPU_ATTACHMENT_TEXTURE(e_data.ghost_depth_tx),
+                                    GPU_ATTACHMENT_TEXTURE(vedata->txl->color),
+                                });
+}
+
+static void material_opaque(Object *ob,
+                            Material *ma,
                             GHash *material_hash,
                             EEVEE_ViewLayerData *sldata,
                             EEVEE_Data *vedata,
@@ -1166,6 +1197,10 @@ static void material_opaque(Material *ma,
     /* Shading */
     *gpumat = EEVEE_material_mesh_get(scene, ma, vedata, false, use_ssrefract);
 
+    if (ob->dtx & OB_DRAWXRAY) {
+      *shgrp_depth = DRW_shgroup_create(e_data.default_prepass_sh, psl->ghost_prepass_pass);
+    }
+
     eGPUMaterialStatus status_mat_surface = GPU_material_status(*gpumat);
 
     /* Alpha CLipped : Discard pixel from depth pass, then
@@ -1181,15 +1216,19 @@ static void material_opaque(Material *ma,
         status_mat_surface = status_mat_depth;
       }
       else if (use_ssrefract) {
-        *shgrp_depth = DRW_shgroup_material_create(
-            *gpumat_depth, (do_cull) ? psl->refract_depth_pass_cull : psl->refract_depth_pass);
+        if ((ob->dtx & OB_DRAWXRAY) == 0) {
+          *shgrp_depth = DRW_shgroup_material_create(
+              *gpumat_depth, (do_cull) ? psl->refract_depth_pass_cull : psl->refract_depth_pass);
+        }
         *shgrp_depth_clip = DRW_shgroup_material_create(
             *gpumat_depth,
             (do_cull) ? psl->refract_depth_pass_clip_cull : psl->refract_depth_pass_clip);
       }
       else {
-        *shgrp_depth = DRW_shgroup_material_create(
-            *gpumat_depth, (do_cull) ? psl->depth_pass_cull : psl->depth_pass);
+        if ((ob->dtx & OB_DRAWXRAY) == 0) {
+          *shgrp_depth = DRW_shgroup_material_create(
+              *gpumat_depth, (do_cull) ? psl->depth_pass_cull : psl->depth_pass);
+        }
         *shgrp_depth_clip = DRW_shgroup_material_create(
             *gpumat_depth, (do_cull) ? psl->depth_pass_clip_cull : psl->depth_pass_clip);
       }
@@ -1480,7 +1519,8 @@ void EEVEE_materials_cache_populate(EEVEE_Data *vedata,
       shgrp_depth_clip_array[i] = NULL;
 
       if (holdout) {
-        material_opaque(ma_array[i],
+        material_opaque(ob,
+                        ma_array[i],
                         material_hash,
                         sldata,
                         vedata,
@@ -1497,7 +1537,8 @@ void EEVEE_materials_cache_populate(EEVEE_Data *vedata,
         case MA_BM_SOLID:
         case MA_BM_CLIP:
         case MA_BM_HASHED:
-          material_opaque(ma_array[i],
+          material_opaque(ob,
+                          ma_array[i],
                           material_hash,
                           sldata,
                           vedata,
@@ -1776,6 +1817,7 @@ void EEVEE_materials_free(void)
   DRW_SHADER_FREE_SAFE(e_data.default_hair_prepass_clip_sh);
   DRW_SHADER_FREE_SAFE(e_data.default_prepass_sh);
   DRW_SHADER_FREE_SAFE(e_data.default_prepass_clip_sh);
+  DRW_SHADER_FREE_SAFE(e_data.ghost_resolve_sh);
   DRW_SHADER_FREE_SAFE(e_data.default_background);
   DRW_SHADER_FREE_SAFE(e_data.update_noise_sh);
   DRW_TEXTURE_FREE_SAFE(e_data.util_tex);

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -1194,7 +1194,7 @@ static void material_opaque(Object *ob, /* Game engine transition (arg Object *o
   }
 
   /* Game engine transition */
-  if (ob->dtx & OB_DRAWXRAY) {
+  if (ob->dtx & OB_DRAWXRAY_BGE) {
     *shgrp_depth = DRW_shgroup_create(e_data.default_prepass_sh, psl->ghost_prepass_pass);
   }
   /* End of Game engine transition */
@@ -1222,7 +1222,7 @@ static void material_opaque(Object *ob, /* Game engine transition (arg Object *o
         status_mat_surface = status_mat_depth;
       }
       else if (use_ssrefract) {
-        if ((ob->dtx & OB_DRAWXRAY) == 0) { /* Game engine transition */
+        if ((ob->dtx & OB_DRAWXRAY_BGE) == 0) { /* Game engine transition */
           *shgrp_depth = DRW_shgroup_material_create(
               *gpumat_depth, (do_cull) ? psl->refract_depth_pass_cull : psl->refract_depth_pass);
         }
@@ -1231,7 +1231,7 @@ static void material_opaque(Object *ob, /* Game engine transition (arg Object *o
             (do_cull) ? psl->refract_depth_pass_clip_cull : psl->refract_depth_pass_clip);
       }
       else {
-        if ((ob->dtx & OB_DRAWXRAY) == 0) { /* Game engine transition */
+        if ((ob->dtx & OB_DRAWXRAY_BGE) == 0) { /* Game engine transition */
           *shgrp_depth = DRW_shgroup_material_create(
               *gpumat_depth, (do_cull) ? psl->depth_pass_cull : psl->depth_pass);
         }

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -254,8 +254,8 @@ typedef struct EEVEE_PassList {
   struct DRWPass *maxz_copydepth_ps;
   struct DRWPass *maxz_copydepth_layer_ps;
 
-  struct DRWPass *ghost_prepass_pass;
-  struct DRWPass *ghost_resolve_pass;
+  struct DRWPass *ghost_prepass_pass; /* Game engine transition */
+  struct DRWPass *ghost_resolve_pass; /* Game engine transition */
 
   struct DRWPass *depth_pass;
   struct DRWPass *depth_pass_cull;
@@ -318,7 +318,7 @@ typedef struct EEVEE_FramebufferList {
   struct GPUFrameBuffer *taa_history_fb;
   struct GPUFrameBuffer *taa_history_color_fb;
 
-  struct GPUFrameBuffer *ghost_prepass_fb;
+  struct GPUFrameBuffer *ghost_prepass_fb; /* Game engine transition */
 } EEVEE_FramebufferList;
 
 typedef struct EEVEE_TextureList {
@@ -831,7 +831,7 @@ EEVEE_WorldEngineData *EEVEE_world_data_get(struct World *wo);
 EEVEE_WorldEngineData *EEVEE_world_data_ensure(struct World *wo);
 
 /* eevee_materials.c */
-void EEVEE_setup_ghost_framebuffer(EEVEE_FramebufferList *fbl, EEVEE_Data *vedata);
+void EEVEE_setup_ghost_framebuffer(EEVEE_FramebufferList *fbl, EEVEE_Data *vedata); /* Game engine transition */
 struct GPUTexture *EEVEE_materials_get_util_tex(void); /* XXX */
 void EEVEE_materials_init(EEVEE_ViewLayerData *sldata,
                           EEVEE_StorageList *stl,

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -1155,6 +1155,7 @@ static const float cubefacemat[6][4][4] = {
 };
 
 
+/* Game engine transition */
 EEVEE_Data *EEVEE_engine_data_get(void);
-
+/* End of Game engine transition */
 #endif /* __EEVEE_PRIVATE_H__ */

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -254,6 +254,9 @@ typedef struct EEVEE_PassList {
   struct DRWPass *maxz_copydepth_ps;
   struct DRWPass *maxz_copydepth_layer_ps;
 
+  struct DRWPass *ghost_prepass_pass;
+  struct DRWPass *ghost_resolve_pass;
+
   struct DRWPass *depth_pass;
   struct DRWPass *depth_pass_cull;
   struct DRWPass *depth_pass_clip;
@@ -314,6 +317,8 @@ typedef struct EEVEE_FramebufferList {
   struct GPUFrameBuffer *double_buffer_depth_fb;
   struct GPUFrameBuffer *taa_history_fb;
   struct GPUFrameBuffer *taa_history_color_fb;
+
+  struct GPUFrameBuffer *ghost_prepass_fb;
 } EEVEE_FramebufferList;
 
 typedef struct EEVEE_TextureList {
@@ -826,6 +831,7 @@ EEVEE_WorldEngineData *EEVEE_world_data_get(struct World *wo);
 EEVEE_WorldEngineData *EEVEE_world_data_ensure(struct World *wo);
 
 /* eevee_materials.c */
+void EEVEE_setup_ghost_framebuffer(EEVEE_FramebufferList *fbl, EEVEE_Data *vedata);
 struct GPUTexture *EEVEE_materials_get_util_tex(void); /* XXX */
 void EEVEE_materials_init(EEVEE_ViewLayerData *sldata,
                           EEVEE_StorageList *stl,

--- a/source/blender/editors/space_logic/logic_window.c
+++ b/source/blender/editors/space_logic/logic_window.c
@@ -1632,7 +1632,7 @@ static void draw_actuator_constraint(uiLayout *layout, PointerRNA *ptr, bContext
 
 static void draw_actuator_edit_object(uiLayout *layout, PointerRNA *ptr)
 {
-	Object *ob = (Object *)ptr->owner_id;
+	//Object *ob = (Object *)ptr->owner_id;
 	uiLayout *row, *split, *sub;
 	uiItemR(layout, ptr, "mode", 0, NULL, ICON_NONE);
 
@@ -1668,13 +1668,20 @@ static void draw_actuator_edit_object(uiLayout *layout, PointerRNA *ptr)
 			uiItemR(row, ptr, "track_axis", 0, NULL, ICON_NONE);
 			break;
 		case ACT_EDOB_DYNAMICS:
-			if (ob->type != OB_MESH) {
+			/*if (ob->type != OB_MESH) {
 				uiItemL(layout, IFACE_("Mode only available for mesh objects"), ICON_NONE);
 				break;
-			}
+			}*/
 			uiItemR(layout, ptr, "dynamic_operation", 0, NULL, ICON_NONE);
 			if (RNA_enum_get(ptr, "dynamic_operation") == ACT_EDOB_SET_MASS)
 				uiItemR(layout, ptr, "mass", 0, NULL, ICON_NONE);
+      if (RNA_enum_get(ptr, "dynamic_operation") == ACT_EDOB_RESTORE_PHY) {
+        uiItemR(layout, ptr, "children_recursive_restore", 0, NULL, ICON_NONE);
+      }
+      if (RNA_enum_get(ptr, "dynamic_operation") == ACT_EDOB_SUSPEND_PHY) {
+        uiItemR(layout, ptr, "children_recursive_suspend", 0, NULL, ICON_NONE);
+        uiItemR(layout, ptr, "free_constraints", 0, NULL, ICON_NONE);
+      }
 			break;
 	}
 }

--- a/source/blender/makesdna/DNA_actuator_types.h
+++ b/source/blender/makesdna/DNA_actuator_types.h
@@ -98,7 +98,8 @@ typedef struct bEditObjectActuator {
 	short localflag; /* flag for the lin & ang. vel: apply locally   */
 	short dyn_operation;
 	short upflag, trackflag; /* flag for up axis and track axis */
-	int _pad;
+	short dyn_operation_flag;
+  short _pad;
 } bEditObjectActuator;
 
 typedef struct bSceneActuator {
@@ -461,6 +462,13 @@ typedef struct bActuator {
 #define ACT_EDOB_ENABLE_RB		2
 #define ACT_EDOB_DISABLE_RB		3
 #define ACT_EDOB_SET_MASS		4
+#define ACT_EDOB_RESTORE_PHY 5
+#define ACT_EDOB_SUSPEND_PHY 6
+
+/* editObjectActuator->dyn_operation_flag for dynamic actuator */
+#define ACT_EDOB_RESTORE_PHY_CHILDREN_RECURSIVE 2 /* use for dynamic actuator */
+#define ACT_EDOB_SUSPEND_PHY_CHILDREN_RECURSIVE 4
+#define ACT_EDOB_SUSPEND_PHY_FREE_CONSTRAINTS   8
 
 
 /* SceneActuator->type */

--- a/source/blender/makesdna/DNA_object_types.h
+++ b/source/blender/makesdna/DNA_object_types.h
@@ -618,6 +618,8 @@ enum {
   OB_DRAWTRANSP = 1 << 7,
   OB_DRAW_ALL_EDGES = 1 << 8, /* only for meshes currently */
   OB_DRAW_NO_SHADOW_CAST = 1 << 9,
+  /* for overdraws Game engine transition */
+  OB_DRAWXRAY_BGE = 1 << 10,
 };
 
 /* empty_drawtype: no flags */

--- a/source/blender/makesrna/intern/rna_actuator.c
+++ b/source/blender/makesrna/intern/rna_actuator.c
@@ -1349,6 +1349,8 @@ static void rna_def_edit_object_actuator(BlenderRNA *brna)
 		{ACT_EDOB_ENABLE_RB, "ENABLERIGIDBODY", 0, "Enable Rigid Body", ""},
 		{ACT_EDOB_DISABLE_RB, "DISABLERIGIDBODY", 0, "Disable Rigid Body", ""},
 		{ACT_EDOB_SET_MASS, "SETMASS", 0, "Set Mass", ""},
+    {ACT_EDOB_RESTORE_PHY, "RESTOREPHY", 0, "Restore Physics", ""},
+    {ACT_EDOB_SUSPEND_PHY, "SUSPENDPHY", 0, "Suspend Physics", ""},
 		{0, NULL, 0, NULL, NULL}
 	};
 
@@ -1455,6 +1457,24 @@ static void rna_def_edit_object_actuator(BlenderRNA *brna)
 	RNA_def_property_update(prop, NC_LOGIC, NULL);
 
 	/* booleans */
+  prop = RNA_def_property(srna, "children_recursive_suspend", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "dyn_operation_flag", ACT_EDOB_SUSPEND_PHY_CHILDREN_RECURSIVE);
+  RNA_def_property_ui_text(prop, "Suspend Children Dynamics", "Apply to all children");
+  RNA_def_property_boolean_default(prop, false);
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  prop = RNA_def_property(srna, "free_constraints", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "dyn_operation_flag", ACT_EDOB_SUSPEND_PHY_FREE_CONSTRAINTS);
+  RNA_def_property_ui_text(prop, "Free constraints", "Free constraints");
+  RNA_def_property_boolean_default(prop, false);
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  prop = RNA_def_property(srna, "children_recursive_restore", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "dyn_operation_flag", ACT_EDOB_RESTORE_PHY_CHILDREN_RECURSIVE);
+  RNA_def_property_ui_text(prop, "Restore Children Dynamics", "Apply to all children");
+  RNA_def_property_boolean_default(prop, false);
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
 	prop = RNA_def_property(srna, "use_local_linear_velocity", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "localflag", ACT_EDOB_LOCAL_LINV);
 	RNA_def_property_ui_text(prop, "L", "Apply the transformation locally");

--- a/source/blender/makesrna/intern/rna_object.c
+++ b/source/blender/makesrna/intern/rna_object.c
@@ -3697,6 +3697,13 @@ static void rna_def_object(BlenderRNA *brna)
   RNA_def_property_ui_text(prop, "In Front", "Make the object draw in front of others");
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, NULL);
 
+  /* Game engine transition */
+  prop = RNA_def_property(srna, "show_in_front_bge", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "dtx", OB_DRAWXRAY_BGE);
+  RNA_def_property_ui_text(prop, "In Front bge", "Make the object draw in front of others");
+  RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, NULL);
+  /* End of Game engine transition */
+
   /* pose */
   prop = RNA_def_property(srna, "pose_library", PROP_POINTER, PROP_NONE);
   RNA_def_property_pointer_sdna(prop, NULL, "poselib");

--- a/source/gameengine/Converter/KX_ConvertActuators.cpp
+++ b/source/gameengine/Converter/KX_ConvertActuators.cpp
@@ -491,10 +491,18 @@ void BL_ConvertActuators(const char* maggiename,
 					}
 				case ACT_EDOB_DYNAMICS:
 					{
-						SCA_DynamicActuator* tmpdynact = new SCA_DynamicActuator(
-						            gameobj,
-						            editobact->dyn_operation,
-						            editobact->mass);
+						bool suspend_children_phys = ((editobact->dyn_operation_flag &
+                                           ACT_EDOB_SUSPEND_PHY_CHILDREN_RECURSIVE) != 0);
+						bool restore_children_phys = ((editobact->dyn_operation_flag &
+                                           ACT_EDOB_RESTORE_PHY_CHILDREN_RECURSIVE) != 0);
+						bool suspend_constraints = ((editobact->dyn_operation_flag &
+                                         ACT_EDOB_SUSPEND_PHY_FREE_CONSTRAINTS) != 0);
+						SCA_DynamicActuator *tmpdynact = new SCA_DynamicActuator(gameobj,
+                                                                     editobact->dyn_operation,
+                                                                     editobact->mass,
+                                                                     suspend_children_phys,
+                                                                     restore_children_phys,
+                                                                     suspend_constraints);
 						baseact = tmpdynact;
 					}
 				}

--- a/source/gameengine/GameLogic/SCA_DynamicActuator.cpp
+++ b/source/gameengine/GameLogic/SCA_DynamicActuator.cpp
@@ -85,11 +85,17 @@ PyAttributeDef SCA_DynamicActuator::Attributes[] = {
 
 SCA_DynamicActuator::SCA_DynamicActuator(SCA_IObject *gameobj,
 													   short dyn_operation,
-													   float setmass) :
+													   float setmass,
+	                                                   bool suspend_children_phys,
+	                                                   bool restore_children_phys,
+	                                                   bool suspend_constraint) :
 
 	SCA_IActuator(gameobj, KX_ACT_DYNAMIC),
 	m_dyn_operation(dyn_operation),
-	m_setmass(setmass)
+	m_setmass(setmass),
+    m_suspend_children_phys(suspend_children_phys),
+    m_restore_children_phys(restore_children_phys),
+    m_suspend_constraints(suspend_constraint)
 {
 } /* End of constructor */
 

--- a/source/gameengine/GameLogic/SCA_DynamicActuator.cpp
+++ b/source/gameengine/GameLogic/SCA_DynamicActuator.cpp
@@ -145,12 +145,12 @@ bool SCA_DynamicActuator::Update()
 			break;
 		case KX_DYN_RESTORE_PHYSICS:
 		{
-			controller->RestorePhysics();
+			obj->RestorePhysics(m_restore_children_phys);
 			break;
 		}
 		case KX_DYN_DISABLE_PHYSICS:
 		{
-			controller->SuspendPhysics(false);
+			obj->SuspendPhysics(m_suspend_constraints, m_suspend_children_phys);
 			break;
 		}
 	}

--- a/source/gameengine/GameLogic/SCA_DynamicActuator.h
+++ b/source/gameengine/GameLogic/SCA_DynamicActuator.h
@@ -46,11 +46,19 @@ class SCA_DynamicActuator : public SCA_IActuator
 	// dynamics operation to apply to the game object
 	short m_dyn_operation;
 	float m_setmass;
+
+  bool m_suspend_children_phys;
+  bool m_restore_children_phys;
+  bool m_suspend_constraints;
+
  public:
 	SCA_DynamicActuator(
 	        SCA_IObject* gameobj,
 	        short dyn_operation,
-	        float setmass
+	        float setmass,
+          bool suspend_children_phys,
+          bool restore_children_phys,
+          bool suspend_constraints
 	        );
 
 	~SCA_DynamicActuator(


### PR DESCRIPTION
There are 2 parts:

1. Show in front option is implemented for eevee render to have the possibility to display HUD objects in front of other scene objects.
2. Dynamic actuator logic is completed. It's not only available for mesh objects OB_MESH but for all types of objects AND we can DISABLE/ENABLE PHYSICS for all children of an object.
It takes example on Visible actuator.
Using Visibility actuator + Dynamic actuator, we can hide/suspend physics for all objects of the HUD OR unhide/restore physics for all objects of the HUD (physics can be needed if we want to have the HUD objects clickable).

The HUD design should look like this:
![Capture](https://user-images.githubusercontent.com/10052509/68863974-a34ef580-06f0-11ea-9a7a-674002f2c928.jpg)

Show in front option for HUD objects is here:
![Capture](https://user-images.githubusercontent.com/10052509/68864272-2708e200-06f1-11ea-998f-a5281fff7d7d.jpg)

The root Empty of the HUD (main parent for all HUD objects) can be parented to main Camera to follow main Camera position/orientation.

I think this requires a bit more logic than overlay scenes, and may need python (or deal with property sensor/actuator) if for example we want to suspend logic/physics of non HUD objects while the HUD is displayed, but I think it can do the stuff.

I don't really see how we could restore background/overlay scenes with the current depsgraph.

I think it is more handy to deal with 1 scene at a time (We can still use replace scene if we want) and maybe deal with things based on several collections instead? Logic bricks could handle some options for collections too.

The design is not definitive and can be changed...

PS: If we stop to deal with several scenes at the same time, some parts of BGE code could maybe be changed? (SETLOOPER in BlenderDataConversion, m_scenes in KX_KetsjiEngine...)